### PR TITLE
Allow explicitly proxying only ld requests

### DIFF
--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -43,7 +43,8 @@ class Config(object):
                  offline=False,
                  user_keys_capacity=1000,
                  user_keys_flush_interval=300,
-                 inline_users_in_events=False):
+                 inline_users_in_events=False,
+                 http_proxy=None):
         """
         :param string sdk_key: The SDK key for your LaunchDarkly account.
         :param string base_uri: The base URL for the LaunchDarkly server. Most users should use the default
@@ -95,6 +96,8 @@ class Config(object):
         :type event_processor_class: (ldclient.config.Config) -> EventProcessor
         :param update_processor_class: A factory for an UpdateProcessor implementation taking the sdk key,
           config, and FeatureStore implementation
+        :param http_proxy: Use a proxy when connecting to LaunchDarkly. This is the full URI of the
+          proxy; for example: http://my-proxy.com:1234.
         """
         self.__sdk_key = sdk_key
 
@@ -126,6 +129,7 @@ class Config(object):
         self.__user_keys_capacity = user_keys_capacity
         self.__user_keys_flush_interval = user_keys_flush_interval
         self.__inline_users_in_events = inline_users_in_events
+        self.__http_proxy = http_proxy
 
     @classmethod
     def default(cls):
@@ -277,6 +281,10 @@ class Config(object):
     @property
     def inline_users_in_events(self):
         return self.__inline_users_in_events
+
+    @property
+    def http_proxy(self):
+        return self.__http_proxy
 
     def _validate(self):
         if self.offline is False and self.sdk_key is None or self.sdk_key is '':

--- a/ldclient/event_processor.py
+++ b/ldclient/event_processor.py
@@ -211,7 +211,7 @@ class EventDispatcher(object):
     def __init__(self, inbox, config, http_client):
         self._inbox = inbox
         self._config = config
-        self._http = create_http_pool_manager(num_pools=1, verify_ssl=config.verify_ssl) if http_client is None else http_client
+        self._http = create_http_pool_manager(num_pools=1, verify_ssl=config.verify_ssl, proxy_url=config.http_proxy) if http_client is None else http_client
         self._close_http = (http_client is None)  # so we know whether to close it later
         self._disabled = False
         self._outbox = EventBuffer(config.events_max_pending)

--- a/ldclient/feature_requester.py
+++ b/ldclient/feature_requester.py
@@ -25,7 +25,7 @@ CacheEntry = namedtuple('CacheEntry', ['data', 'etag'])
 class FeatureRequesterImpl(FeatureRequester):
     def __init__(self, config):
         self._cache = dict()
-        self._http = create_http_pool_manager(num_pools=1, verify_ssl=config.verify_ssl)
+        self._http = create_http_pool_manager(num_pools=1, verify_ssl=config.verify_ssl, proxy_url=config.http_proxy)
         self._config = config
 
     def get_all_data(self):

--- a/ldclient/sse_client.py
+++ b/ldclient/sse_client.py
@@ -23,7 +23,7 @@ end_of_field = re.compile(r'\r\n\r\n|\r\r|\n\n')
 
 class SSEClient(object):
     def __init__(self, url, last_id=None, retry=3000, connect_timeout=10, read_timeout=300, chunk_size=10000,
-                 verify_ssl=False, http=None, **kwargs):
+                 verify_ssl=False, http=None, http_proxy=None, **kwargs):
         self.url = url
         self.last_id = last_id
         self.retry = retry
@@ -32,7 +32,8 @@ class SSEClient(object):
         self._chunk_size = chunk_size
 
         # Optional support for passing in an HTTP client
-        self.http = create_http_pool_manager(num_pools=1, verify_ssl=verify_ssl)
+        self.http = create_http_pool_manager(num_pools=1, verify_ssl=verify_ssl,
+                                             proxy_url=http_proxy)
 
         # Any extra kwargs will be fed into the request call later.
         self.requests_kwargs = kwargs

--- a/ldclient/streaming.py
+++ b/ldclient/streaming.py
@@ -89,7 +89,8 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
             headers=_stream_headers(self._config.sdk_key),
             connect_timeout=self._config.connect_timeout,
             read_timeout=stream_read_timeout,
-            verify_ssl=self._config.verify_ssl)
+            verify_ssl=self._config.verify_ssl,
+            http_proxy=self._config.http_proxy)
 
     def stop(self):
         log.info("Stopping StreamingUpdateProcessor")


### PR DESCRIPTION
This commit adds a configuration parameter allowing the configuration of
a proxy that should be used when connecting to LaunchDarkly's API. This
allows only this service to be proxied, without having to specify the
global `http_proxy` environment variable.

Our use-case for this was calling LaunchDarkly from within an AWS VPC without external internet access, where we need a proxy to talk to any service not in our VPC but don't want to have the proxy the traffic within the VPC. Explicitly setting a proxy configuration for just LaunchDarkly seemed to me the cleanest solution to this.