### PR TITLE
Addresses https://bugs.python.org/issue34850

### DIFF
--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -290,5 +290,5 @@ class Config(object):
         return self.__http_proxy
 
     def _validate(self):
-        if self.offline is False and self.sdk_key is None or self.sdk_key is '':
+        if self.offline is False and self.sdk_key is None or self.sdk_key == '':
             log.warning("Missing or blank sdk_key.")

--- a/ldclient/fixed_thread_pool.py
+++ b/ldclient/fixed_thread_pool.py
@@ -63,7 +63,7 @@ class FixedThreadPool(object):
     def _run_worker(self):
         while True:
             item = self._job_queue.get(block = True)
-            if item is 'stop':
+            if item == 'stop':
                 return
             try:
                 item()

--- a/ldclient/flag.py
+++ b/ldclient/flag.py
@@ -184,7 +184,7 @@ def _get_value_for_variation_or_rollout(flag, vr, user, reason):
 
 
 def _get_user_attribute(user, attr):
-    if attr is 'secondary':
+    if attr == 'secondary':
         return None, True
     if attr in __BUILTINS__:
         return user.get(attr), False

--- a/ldclient/impl/integrations/redis/redis_feature_store.py
+++ b/ldclient/impl/integrations/redis/redis_feature_store.py
@@ -15,7 +15,7 @@ from ldclient.versioned_data_kind import FEATURES
 class _RedisFeatureStoreCore(FeatureStoreCore):
     def __init__(self, url, prefix, max_connections):
         if not have_redis:
-            raise NotImplementedError("Cannot use Redis feature store because redis package is not installed")        
+            raise NotImplementedError("Cannot use Redis feature store because redis package is not installed")
         self._prefix = prefix or 'launchdarkly'
         self._pool = redis.ConnectionPool.from_url(url=url, max_connections=max_connections)
         self.test_update_hook = None  # exposed for testing
@@ -43,7 +43,7 @@ class _RedisFeatureStoreCore(FeatureStoreCore):
         r = redis.Redis(connection_pool=self._pool)
         all_items = r.hgetall(self._items_key(kind))
 
-        if all_items is None or all_items is "":
+        if all_items is None or all_items == "":
             all_items = {}
 
         results = {}
@@ -56,7 +56,7 @@ class _RedisFeatureStoreCore(FeatureStoreCore):
         r = redis.Redis(connection_pool=self._pool)
         item_json = r.hget(self._items_key(kind), key)
 
-        if item_json is None or item_json is "":
+        if item_json is None or item_json == "":
             log.debug("RedisFeatureStore: key %s not found in '%s'. Returning None.", key, kind.namespace)
             return None
 

--- a/testing/test_config.py
+++ b/testing/test_config.py
@@ -16,8 +16,8 @@ def test_copy_config():
 
 def test_can_set_valid_poll_interval():
 	config = Config(sdk_key = "SDK_KEY", poll_interval = 31)
-	assert config.poll_interval is 31
+	assert config.poll_interval == 31
 
 def test_minimum_poll_interval_is_enforced():
 	config = Config(sdk_key = "SDK_KEY", poll_interval = 29)
-	assert config.poll_interval is 30
+	assert config.poll_interval == 30

--- a/testing/test_event_processor.py
+++ b/testing/test_event_processor.py
@@ -422,7 +422,7 @@ def test_sdk_key_is_sent():
         ep.flush()
         ep._wait_until_inactive()
 
-        assert mock_http.request_headers.get('Authorization') is 'SDK_KEY'
+        assert mock_http.request_headers.get('Authorization') == 'SDK_KEY'
 
 def test_no_more_payloads_are_sent_after_401_error():
     verify_unrecoverable_http_error(401)

--- a/testing/test_feature_store.py
+++ b/testing/test_feature_store.py
@@ -164,7 +164,7 @@ class DynamoDBTester(object):
         for resp in client.get_paginator('scan').paginate(**req):
             for item in resp['Items']:
                 delete_requests.append({ 'DeleteRequest': { 'Key': item } })
-        _DynamoDBHelpers.batch_write_requests(client, self.table_name, delete_requests)        
+        _DynamoDBHelpers.batch_write_requests(client, self.table_name, delete_requests)
 
 
 class TestFeatureStore:
@@ -243,7 +243,7 @@ class TestFeatureStore:
     def test_get_all_versions(self, store):
         store = self.base_initialized_store(store)
         result = store.all(FEATURES, lambda x: x)
-        assert len(result) is 2
+        assert len(result) == 2
         assert result.get('foo') == self.make_feature('foo', 10)
         assert result.get('bar') == self.make_feature('bar', 10)
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**
Python 3.8 made it so that comparisons done via `is` to a literal (str, int, etc.) now throw a SyntaxWarning: https://bugs.python.org/issue34850 In our test suite we convert warnings to errors so this is causing a fairly major issue for us and upgrading to py3.8.

**Describe the solution you've provided**

Nothing has changed about the code itself I've just changed all the places where `is` was used to do a comparison to a literal to use `==` instead.

**Describe alternatives you've considered**

No alternatives were considered, this is the only way to fix this particular issue.

**Additional context**

Add any other context about the pull request here.
