### PR TITLE
Allow authenticating with proxy

### DIFF
--- a/ldclient/impl/http.py
+++ b/ldclient/impl/http.py
@@ -54,11 +54,18 @@ class HTTPFactory(object):
                 ca_certs=ca_certs
                 )
         else:
+            # Get proxy authentication, if provided
+            url = urllib3.util.parse_url(proxy_url)
+            proxy_headers = None
+            if url.auth != None:
+                proxy_headers = urllib3.util.make_headers(proxy_basic_auth=url.auth)
+            # Create a proxied connection
             return urllib3.ProxyManager(
                 proxy_url,
                 num_pools=num_pools,
                 cert_reqs=cert_reqs,
-                ca_certs = ca_certs
+                ca_certs = ca_certs,
+                proxy_headers=proxy_headers
             )
 
 def _get_proxy_url(target_base_uri):


### PR DESCRIPTION
This commit allows for authenticating with a proxy configured with the
`http_proxy` environment variable. Authentication requires passing a
header, and is not parsed by urllib3 from the proxy_url.

This has been tested and is working in our own environment, but no additional tests have been run.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Square uses a proxy with authentication for its internal services, and this is unable to connect through that proxy.

**Describe the solution you've provided**

The URL for the proxy is parsed to explicitly parse out authentication and pass it in as a header.

**Describe alternatives you've considered**

N/A

**Additional context**

N/A
