### PR TITLE
Fix “last_past” timestamp creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,6 @@ workflows:
           docker-image: circleci/python:2.7-jessie
           test-with-codeclimate: true  # we only need to run CodeClimate in one job
       - test-linux:
-          name: Python 3.3
-          docker-image: circleci/python:3.3-jessie
-          consul-supported: false  # Consul isn't supported in 3.3
-          filesource-supported: false  # FileDataSource isn't supported in 3.3
-          test-packaging: false  # packaging test requires virtualenv, which isn't supported in 3.3
-      - test-linux:
-          name: Python 3.4
-          docker-image: circleci/python:3.4-jessie
-          consul-supported: false  # Consul isn't supported in 3.4
-      - test-linux:
           name: Python 3.5
           docker-image: circleci/python:3.5-jessie
       - test-linux:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Supported Python versions
 
-This version of the LaunchDarkly SDK is compatible with Python 2.7 and 3.3 through 3.7. It is tested with the most recent patch releases of those versions. Python 2.6 is no longer supported.
+This version of the LaunchDarkly SDK is compatible with Python 2.7 and 3.5 through 3.7. It is tested with the most recent patch releases of those versions. Python 2.6, 3.3 and 3.4 are no longer supported.
 
 ## Getting started
 

--- a/ldclient/event_processor.py
+++ b/ldclient/event_processor.py
@@ -4,7 +4,7 @@ Implementation details of the analytics event delivery component.
 # currently excluded from documentation - see docs/README.md
 
 from collections import namedtuple
-from email.utils import parsedate
+from email.utils import parsedate_tz, mktime_tz
 import errno
 import json
 from threading import Event, Lock, Thread
@@ -366,9 +366,9 @@ class EventDispatcher(object):
     def _handle_response(self, r):
         server_date_str = r.getheader('Date')
         if server_date_str is not None:
-            server_date = parsedate(server_date_str)
+            server_date = parsedate_tz(server_date_str)
             if server_date is not None:
-                timestamp = int(time.mktime(server_date) * 1000)
+                timestamp = int(mktime_tz(server_date) * 1000)
                 self._last_known_past_time = timestamp
         if r.status > 299 and not is_http_error_recoverable(r.status):
             self._disabled = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ certifi>=2018.4.16
 expiringdict>=1.1.4,<1.2.0
 six>=1.10.0
 pyRFC3339>=1.0
-semver>=2.7.9
+semver>=2.11.0,<3.0.0
 urllib3>=1.22.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,5 @@ redis>=2.10.5
 boto3>=1.9.71
 coverage>=4.4
 jsonpickle==0.9.3
-pytest-capturelog>=0.7
 pytest-cov>=2.4.0
 codeclimate-test-reporter>=0.2.1

--- a/testing/test_event_processor.py
+++ b/testing/test_event_processor.py
@@ -247,6 +247,14 @@ def test_new_index_event_is_added_if_user_cache_has_been_cleared():
 
 def test_event_kind_is_debug_if_flag_is_temporarily_in_debug_mode():
     with DefaultTestProcessor() as ep:
+        # Pick a server time that is somewhat behind the client time
+        server_time = now() - 20000
+
+        # Send and flush an event we don't care about, just to set the last server time
+        mock_http.set_server_time(server_time)
+        ep.send_event({ 'kind': 'identify', 'user': { 'key': 'otherUser' }})
+        flush_and_get_events(ep)
+
         future_time = now() + 100000
         e = {
             'kind': 'feature', 'key': 'flagkey', 'version': 11, 'user': user,
@@ -263,6 +271,14 @@ def test_event_kind_is_debug_if_flag_is_temporarily_in_debug_mode():
 
 def test_event_can_be_both_tracked_and_debugged():
     with DefaultTestProcessor() as ep:
+        # Pick a server time that is somewhat behind the client time
+        server_time = now() - 20000
+
+        # Send and flush an event we don't care about, just to set the last server time
+        mock_http.set_server_time(server_time)
+        ep.send_event({ 'kind': 'identify', 'user': { 'key': 'otherUser' }})
+        flush_and_get_events(ep)
+
         future_time = now() + 100000
         e = {
             'kind': 'feature', 'key': 'flagkey', 'version': 11, 'user': user,


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

After the “Sending events payload” event, the SDK gets the server Date, parse it and set the “last_past” timestamp, but time zones are not accounted for properly which may cause the “last_past” timestamp to be in the future, when that happens it blocks debug events.

**Describe the solution you've provided**

Properly handle timezone when creating timestamp from server Date header.

**Describe alternatives you've considered**

N/A.

**Additional context**

More details in https://support.launchdarkly.com/hc/en-us/requests/13685
