### PR TITLE
bugfix: Use notify_all

### DIFF
--- a/ldclient/rwlock.py
+++ b/ldclient/rwlock.py
@@ -29,7 +29,7 @@ class ReadWriteLock:
         try:
             self._readers -= 1
             if not self._readers:
-                self._read_ready.notifyAll()
+                self._read_ready.notify_all()
         finally:
             self._read_ready.release()
 


### PR DESCRIPTION
The standard library threading.Condition class had `notifyAll` implemented as an alias to `notify_all` for backwards compatibility with older versions of python which still used the camel case methods. Python3.10 deprecated the `notifyAll` alias.

This change removes the call to `notifyAll`, in favor of `notify_all` which should exist as far back as python 3.5.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
  - Because the coverage report showed that the only line missing coverage in rwlock.py is line 41, and the only change is on line 32 it didn't seem like another test is needed.
  - Going to wait for one of the maintainers to let me know this okay.
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions
  - Ran the changes against python 3.6 thru 3.10. 3.5 wouldn't install. Hoping the travis CI run picks up 3.5.
  - CI picked up 3.5, and the tests ran successfully. 

**Related issues**

None.

**Describe the solution you've provided**

Python 3.10 deprecated the backwards compatibility alias `threading.Condition.notifyAll` to `notify_all`. I've removed the call to `notifyAll` in favor of `notify_all`.

**Describe alternatives you've considered**

Considered doing something like this:

```python
if hasattr(self._read_ready, 'notifyAll'):
    self._read_ready.notifyAll()
else:
    self._read_ready.notify_all()
```

However as `notifyAll` was only an alias for `notify_all` it didn't seem necessary given the support matrix for python beginning with 3.5. Additionally the [docs for 3.5](https://docs.python.org/3.5/library/threading.html#threading.Condition.notify_all) have `notify_all` in them. So this conditional doesn't seem necessary.

**Additional context**

Changes are documented in the [3.10 release notes](https://docs.python.org/3/whatsnew/3.10.html#deprecated), and in an update to the documentation [here](https://docs.python.org/3/library/threading.html#threading.Condition.notify_all).
