### PR TITLE
Add support for extra Redis connection params

### DIFF
--- a/ldclient/impl/integrations/redis/redis_big_segment_store.py
+++ b/ldclient/impl/integrations/redis/redis_big_segment_store.py
@@ -1,7 +1,7 @@
 from ldclient import log
 from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 
-from typing import Optional, Set, cast
+from typing import Any, Optional, Set, cast
 
 have_redis = False
 try:
@@ -16,11 +16,11 @@ class _RedisBigSegmentStore(BigSegmentStore):
     KEY_USER_INCLUDE = ':big_segment_include:'
     KEY_USER_EXCLUDE = ':big_segment_exclude:'
 
-    def __init__(self, url: str, prefix: Optional[str], max_connections: int):
+    def __init__(self, url: str, prefix: Optional[str], **conn_options: Any):
         if not have_redis:
             raise NotImplementedError("Cannot use Redis Big Segment store because redis package is not installed")
         self._prefix = prefix or 'launchdarkly'
-        self._pool = redis.ConnectionPool.from_url(url=url, max_connections=max_connections)
+        self._pool = redis.ConnectionPool.from_url(url=url, **conn_options)
         log.info("Started RedisBigSegmentStore connected to URL: " + url + " using prefix: " + self._prefix)
 
     def get_metadata(self) -> BigSegmentStoreMetadata:

--- a/ldclient/impl/integrations/redis/redis_feature_store.py
+++ b/ldclient/impl/integrations/redis/redis_feature_store.py
@@ -13,11 +13,11 @@ from ldclient.versioned_data_kind import FEATURES
 
 
 class _RedisFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
-    def __init__(self, url, prefix, max_connections):
+    def __init__(self, url, prefix, **conn_options):
         if not have_redis:
             raise NotImplementedError("Cannot use Redis feature store because redis package is not installed")
         self._prefix = prefix or 'launchdarkly'
-        self._pool = redis.ConnectionPool.from_url(url=url, max_connections=max_connections)
+        self._pool = redis.ConnectionPool.from_url(url=url, **conn_options)
         self.test_update_hook = None  # exposed for testing
         log.info("Started RedisFeatureStore connected to URL: " + url + " using prefix: " + self._prefix)
 

--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -144,7 +144,8 @@ class Redis:
     def new_feature_store(url: str='redis://localhost:6379/0',
                           prefix: str='launchdarkly',
                           max_connections: int=16,
-                          caching: CacheConfig=CacheConfig.default()) -> CachingStoreWrapper:
+                          caching: CacheConfig=CacheConfig.default(),
+                          **conn_options: Any) -> CachingStoreWrapper:
         """
         Creates a Redis-backed implementation of :class:`~ldclient.interfaces.FeatureStore`.
         For more details about how and why you can use a persistent feature store, see the
@@ -167,8 +168,10 @@ class Redis:
           connection pool; defaults to ``DEFAULT_MAX_CONNECTIONS``
         :param caching: specifies whether local caching should be enabled and if so,
           sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`
+        :param conn_options: extra options for initializing Redis connection from the url,
+          see `redis.connection.ConnectionPool.from_url` for more details.
         """
-        core = _RedisFeatureStoreCore(url, prefix, max_connections)
+        core = _RedisFeatureStoreCore(url, prefix, max_connections=max_connections, **conn_options)
         wrapper = CachingStoreWrapper(core, caching)
         wrapper._core = core  # exposed for testing
         return wrapper
@@ -176,7 +179,8 @@ class Redis:
     @staticmethod
     def new_big_segment_store(url: str='redis://localhost:6379/0',
                               prefix: str='launchdarkly',
-                              max_connections: int=16) -> BigSegmentStore:
+                              max_connections: int=16,
+                              **conn_options: Any) -> BigSegmentStore:
         """
         Creates a Redis-backed Big Segment store.
 
@@ -198,8 +202,10 @@ class Redis:
           ``DEFAULT_PREFIX``
         :param max_connections: the maximum number of Redis connections to keep in the
           connection pool; defaults to ``DEFAULT_MAX_CONNECTIONS``
+        :param conn_options: extra options for initializing Redis connection from the url,
+          see `redis.connection.ConnectionPool.from_url` for more details.
         """
-        return _RedisBigSegmentStore(url, prefix, max_connections)
+        return _RedisBigSegmentStore(url, prefix, max_connections=max_connections, **conn_options)
 
 class Files:
     """Provides factory methods for integrations with filesystem data.


### PR DESCRIPTION
Replaces #169 

----

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

\-

**Describe the solution you've provided**

The `redis.ConnectionPool.from_url()` can accept various number of kwargs.  
Among them, very imporatnt one is the `decode_components=True` which must be enabled in case redis password contains special characters.  
After [rfc1738](https://www.ietf.org/rfc/rfc1738.txt): 

> In addition, octets may be encoded by a character triplet consisting of the character "%" followed by the two hexadecimal digits (from "0123456789ABCDEF") which forming the hexadecimal value of the octet.
>
> ...
> Unsafe:
> Characters can be unsafe for a number of reasons. (...) All unsafe characters must always be encoded within a URL.

In redis-py version < 4, if the flag `decode_components` is set to `False`, then the escaped characters stays escaped and connection to the Redis server cannot be established:

https://github.com/redis/redis-py/blob/2c9f41f46991f94f0626598600d1023d4e12f0bc/redis/connection.py#L947-L950

**Describe alternatives you've considered**

There is none.

**Additional context**

\-
