### PR TITLE
Fix missing py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include test-requirements.txt
 include consul-requirements.txt
 include dynamodb-requirements.txt
 include redis-requirements.txt
+include ldclient/py.typed


### PR DESCRIPTION
alternatively add to `package_data` in `setup.py` https://stackoverflow.com/a/63172998/202168

Fixes #171 