### PR TITLE
Update requirements.txt to limit urllib to version 1.x.x and not inst…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ certifi>=2018.4.16
 expiringdict>=1.1.4
 pyRFC3339>=1.0
 semver>=2.10.2,<3.0.0
-urllib3>=1.22.0
+urllib3>=1.22.0,<1.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ certifi>=2018.4.16
 expiringdict>=1.1.4
 pyRFC3339>=1.0
 semver>=2.10.2,<3.0.0
-urllib3>=1.22.0,<1.27
+urllib3>=1.22.0,<2.0.0


### PR DESCRIPTION
…all version 2

urllib3 v2.0 breaks package

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

https://github.com/launchdarkly/python-server-sdk/issues/201

**Describe the solution you've provided**

Updated requirements file to lock urllib version to 1.x.x

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
