### PR TITLE
Prevent HTTPResponse.getheader() is deprecated warning

### DIFF
--- a/ldclient/impl/datasource/feature_requester.py
+++ b/ldclient/impl/datasource/feature_requester.py
@@ -42,7 +42,7 @@ class FeatureRequesterImpl(FeatureRequester):
             from_cache = True
         else:
             data = json.loads(r.data.decode('UTF-8'))
-            etag = r.getheader('ETag')
+            etag = r.headers.get('ETag')
             from_cache = False
             if etag is not None:
                 self._cache[uri] = CacheEntry(data=data, etag=etag)

--- a/ldclient/impl/events/event_processor.py
+++ b/ldclient/impl/events/event_processor.py
@@ -373,7 +373,7 @@ class EventDispatcher:
                 pass
 
     def _handle_response(self, r):
-        server_date_str = r.getheader('Date')
+        server_date_str = r.headers.get('Date')
         if server_date_str is not None:
             server_date = parsedate(server_date_str)
             if server_date is not None:

--- a/testing/stub_util.py
+++ b/testing/stub_util.py
@@ -72,17 +72,28 @@ class MockFeatureRequester(FeatureRequester):
             raise self.exception
         return self.all_data
 
+
+class _MockHTTPHeaderDict(dict):
+    def __init__(self, d):
+        super().__init__({k.lower(): v for k, v in d.items()})
+
+    def get(self, key, default=None):
+        return super().get(key.lower(), default)
+
+
 class MockResponse:
     def __init__(self, status, headers):
         self._status = status
-        self._headers = headers
+        self._headers = _MockHTTPHeaderDict(headers)
 
     @property
     def status(self):
         return self._status
 
-    def getheader(self, name):
-        return self._headers.get(name.lower())
+    @property
+    def headers(self):
+        return self._headers
+
 
 class MockHttp:
     def __init__(self):


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality (already covered adequately by tests)
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Prevents "DeprecationWarning: HTTPResponse.getheader() is deprecated and will be removed in urllib3 v2.1.0. Instead use HTTPResponse.headers.get(name, default)" from happening by updating relevant code to the supported way (`HTTPResponse.headers.get`)

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Refer to https://github.com/urllib3/urllib3/pull/2814