### PR TITLE
Stream and polling processor logging updates to warn on recoverable errors

### DIFF
--- a/ldclient/impl/datasource/polling.py
+++ b/ldclient/impl/datasource/polling.py
@@ -38,8 +38,11 @@ class PollingUpdateProcessor(UpdateProcessor):
                 log.info("PollingUpdateProcessor initialized ok")
                 self._ready.set()
         except UnsuccessfulResponseException as e:
-            log.error(http_error_message(e.status, "polling request"))
-            if not is_http_error_recoverable(e.status):
+            http_error_message_result = http_error_message(e.status, "polling request")
+            if is_http_error_recoverable(e.status):
+                log.warning(http_error_message_result)
+            else:
+                log.error(http_error_message_result)
                 self._ready.set() # if client is initializing, make it stop waiting; has no effect if already inited
                 self.stop()
         except Exception as e:

--- a/ldclient/impl/datasource/streaming.py
+++ b/ldclient/impl/datasource/streaming.py
@@ -83,10 +83,14 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                         log.info("StreamingUpdateProcessor initialized ok.")
                         self._ready.set()
             except UnsuccessfulResponseException as e:
-                log.error(http_error_message(e.status, "stream connection"))
                 self._record_stream_init(True)
                 self._es_started = None
-                if not is_http_error_recoverable(e.status):
+
+                http_error_message_result = http_error_message(e.status, "stream connection")
+                if is_http_error_recoverable(e.status):
+                    log.warning(http_error_message_result)
+                else:
+                    log.error(http_error_message_result)
                     self._ready.set()  # if client is initializing, make it stop waiting; has no effect if already inited
                     self.stop()
                     break


### PR DESCRIPTION
We are using a logging integration for internal alerting and we want to be able to filter out certain error logs where the LD client is running into a "recoverable" error if possible. Today we noticed there were HTTP responses with a 500 status being returned when StreamingUpdateProcessor was running -- this looked to be a minor blip. Could we log these at the warning level instead of the error level if these are 'expected' blips?