### PR TITLE
build: bumping slsa-github-generator version to resolve issue with retrieving Rekor public keys

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -46,7 +46,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: "${{ needs.build-publish.outputs.package-hashes }}"
       upload-assets: ${{ !inputs.dry_run }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.7.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: "${{ needs.release-package.outputs.package-hashes }}"
       upload-assets: true


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions


**Describe the solution you've provided**

Provenance generation fails due to Rekor public key errors were identified as a known issue and fixed in version 1.10.0 per: https://github.com/slsa-framework/slsa-github-generator/issues/3350