### PR TITLE
ci: Ensure poetry version uses correct python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install poetry
-        run: pipx install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: ./.github/actions/build
       - uses: ./.github/actions/build-docs
@@ -113,10 +113,11 @@ jobs:
           Start-Sleep -s 5
           ./redis-cli ping
 
+      - name: Install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
+
       - name: Install requirements
-        run: |
-          pipx install poetry
-          poetry install --all-extras
+        run: poetry install --all-extras
 
       - name: Run tests
         run: make test

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.8
 
       - name: Install poetry
-        run: pipx install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
         name: 'Get PyPI token'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install poetry
         if: ${{ steps.release.outputs.releases_created }}
-        run: pipx install poetry
+        uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.0.0
         if: ${{ steps.release.outputs.releases_created }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test-filesource = ["pyyaml", "watchdog"]
 [tool.poetry.group.dev.dependencies]
 mock = ">=2.0.0"
 pytest = ">=2.8"
-redis = ">=2.10.5,<3.0.0"
+redis = ">=2.10.5,<5.0.0"
 boto3 = ">=1.9.71,<2.0.0"
 coverage = ">=4.4"
 jsonpickle = ">1.4.1"


### PR DESCRIPTION
`pipx install poetry` does not necessarily use the configured python
version specified in `actions/setup-python`. This separate GH action
helps ensure we are using the correct version consistently.
