### PR TITLE
fix: Skip empty hosts when processing NO_PROXY variable

### DIFF
--- a/ldclient/impl/http.py
+++ b/ldclient/impl/http.py
@@ -120,12 +120,15 @@ def _get_proxy_url(target_base_uri):
         return proxy_url
 
     for no_proxy_entry in no_proxy.split(','):
+        if no_proxy_entry == '':
+            continue
         parts = no_proxy_entry.strip().split(':')
         if len(parts) == 1:
             if target_host.endswith(no_proxy_entry):
                 return None
             continue
-
+        if parts[0] == '':
+            continue
         if target_host.endswith(parts[0]) and target_port == int(parts[1]):
             return None
 

--- a/ldclient/testing/impl/test_http.py
+++ b/ldclient/testing/impl/test_http.py
@@ -16,6 +16,9 @@ from ldclient.impl.http import _get_proxy_url
         ('https://secure.example.com', 'wrong.example.com', 'https://secure.proxy:1234'),
         ('https://secure.example.com:8080', 'secure.example.com', None),
         ('https://secure.example.com:8080', 'secure.example.com:443', 'https://secure.proxy:1234'),
+        ('https://secure.example.com:8080', 'secure.example.com:443,', 'https://secure.proxy:1234'),
+        ('https://secure.example.com:8080', 'secure.example.com:443,,', 'https://secure.proxy:1234'),
+        ('https://secure.example.com:8080', ':8080', 'https://secure.proxy:1234'),
 
         ('https://secure.example.com', 'example.com', None),
         ('https://secure.example.com', 'example.com:443', None),


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**
https://github.com/launchdarkly/python-server-sdk/issues/308

**Describe the solution you've provided**

Add more checks for empty string while parsing `NO_PROXY`

**Describe alternatives you've considered**

N/A

**Additional context**

Comparison of HTTP_PROXY/NO_PROXY implementations: https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/