### PR TITLE
style: Fix and enforce formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ test: install
 lint: #! Run type analysis and linting checks
 lint: install
 	@poetry run mypy ldclient
+	@poetry run isort --check --atomic ldclient contract-tests
+	@poetry run pycodestyle ldclient contract-tests
 
 #
 # Documentation generation

--- a/contract-tests/big_segment_store_fixture.py
+++ b/contract-tests/big_segment_store_fixture.py
@@ -4,8 +4,6 @@ import sys
 from typing import Optional
 import urllib3
 
-# Import ldclient from parent directory
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
 from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 
 

--- a/contract-tests/big_segment_store_fixture.py
+++ b/contract-tests/big_segment_store_fixture.py
@@ -15,7 +15,7 @@ http = urllib3.PoolManager()
 class BigSegmentStoreFixture(BigSegmentStore):
     def __init__(self, callback_uri: str):
         self._callback_uri = callback_uri
-    
+
     def get_metadata(self) -> BigSegmentStoreMetadata:
         resp_data = self._post_callback('/getMetadata', None)
         return BigSegmentStoreMetadata(resp_data.get("lastUpToDate"))
@@ -26,9 +26,7 @@ class BigSegmentStoreFixture(BigSegmentStore):
 
     def _post_callback(self, path: str, params: Optional[dict]) -> dict:
         url = self._callback_uri + path
-        resp = http.request('POST', url,
-            body=None if params is None else json.dumps(params),
-            headers=None if params is None else {'Content-Type': 'application/json'})
+        resp = http.request('POST', url, body=None if params is None else json.dumps(params), headers=None if params is None else {'Content-Type': 'application/json'})
         if resp.status != 200:
             raise Exception("HTTP error %d from callback to %s" % (resp.status, url))
         return json.loads(resp.data.decode('utf-8'))

--- a/contract-tests/big_segment_store_fixture.py
+++ b/contract-tests/big_segment_store_fixture.py
@@ -2,10 +2,10 @@ import json
 import os
 import sys
 from typing import Optional
+
 import urllib3
 
 from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
-
 
 http = urllib3.PoolManager()
 

--- a/contract-tests/client_entity.py
+++ b/contract-tests/client_entity.py
@@ -1,14 +1,14 @@
 import json
 import logging
+
 import requests
+from big_segment_store_fixture import BigSegmentStoreFixture
 from hook import PostingHook
 
-from big_segment_store_fixture import BigSegmentStoreFixture
-
-from ldclient.config import BigSegmentsConfig
-
-from ldclient import Context, MigratorBuilder, ExecutionOrder, MigratorFn, Operation, Stage
 from ldclient import *
+from ldclient import (Context, ExecutionOrder, MigratorBuilder, MigratorFn,
+                      Operation, Stage)
+from ldclient.config import BigSegmentsConfig
 
 
 class ClientEntity:

--- a/contract-tests/client_entity.py
+++ b/contract-tests/client_entity.py
@@ -59,9 +59,7 @@ class ClientEntity:
 
         if config.get("bigSegments") is not None:
             big_params = config["bigSegments"]
-            big_config = {
-                "store": BigSegmentStoreFixture(big_params["callbackUri"])
-            }
+            big_config = {"store": BigSegmentStoreFixture(big_params["callbackUri"])}
             if big_params.get("userCacheSize") is not None:
                 big_config["context_cache_size"] = big_params["userCacheSize"]
             _set_optional_time_prop(big_params, "userCacheTimeMs", big_config, "context_cache_time")
@@ -151,10 +149,7 @@ class ClientEntity:
 
     def get_big_segment_store_status(self) -> dict:
         status = self.client.big_segment_store_status_provider.status
-        return {
-            "available": status.available,
-            "stale": status.stale
-        }
+        return {"available": status.available, "stale": status.stale}
 
     def migration_variation(self, params: dict) -> dict:
         stage, _ = self.client.migration_variation(params["key"], Context.from_dict(params["context"]), Stage.from_str(params["defaultStage"]))

--- a/contract-tests/client_entity.py
+++ b/contract-tests/client_entity.py
@@ -1,7 +1,5 @@
 import json
 import logging
-import os
-import sys
 import requests
 from hook import PostingHook
 
@@ -9,8 +7,6 @@ from big_segment_store_fixture import BigSegmentStoreFixture
 
 from ldclient.config import BigSegmentsConfig
 
-# Import ldclient from parent directory
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
 from ldclient import Context, MigratorBuilder, ExecutionOrder, MigratorFn, Operation, Stage
 from ldclient import *
 

--- a/contract-tests/hook.py
+++ b/contract-tests/hook.py
@@ -1,8 +1,9 @@
-from ldclient.hook import Hook, EvaluationSeriesContext
-from ldclient.evaluation import EvaluationDetail
-
 from typing import Optional
+
 import requests
+
+from ldclient.evaluation import EvaluationDetail
+from ldclient.hook import EvaluationSeriesContext, Hook
 
 
 class PostingHook(Hook):

--- a/contract-tests/service.py
+++ b/contract-tests/service.py
@@ -14,30 +14,24 @@ default_port = 8000
 
 
 # logging configuration
-dictConfig({
-    'version': 1,
-    'formatters': {
-        'default': {
-            'format': '[%(asctime)s] [%(name)s] %(levelname)s: %(message)s',
-        }
-    },
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'formatter': 'default'
-        }
-    },
-    'root': {
-        'level': 'INFO',
-        'handlers': ['console']
-    },
-    'loggers': {
-        'ldclient': {
-            'level': 'INFO', # change to 'DEBUG' to enable SDK debug logging
+dictConfig(
+    {
+        'version': 1,
+        'formatters': {
+            'default': {
+                'format': '[%(asctime)s] [%(name)s] %(levelname)s: %(message)s',
+            }
         },
-        'werkzeug': { 'level': 'ERROR' } # disable irrelevant Flask app logging
+        'handlers': {'console': {'class': 'logging.StreamHandler', 'formatter': 'default'}},
+        'root': {'level': 'INFO', 'handlers': ['console']},
+        'loggers': {
+            'ldclient': {
+                'level': 'INFO',  # change to 'DEBUG' to enable SDK debug logging
+            },
+            'werkzeug': {'level': 'ERROR'},  # disable irrelevant Flask app logging
+        },
     }
-})
+)
 
 app = Flask(__name__)
 app.logger.removeHandler(default_handler)
@@ -79,7 +73,7 @@ def status():
             'anonymous-redaction',
             'evaluation-hooks',
             'omit-anonymous-contexts',
-            'client-prereq-events'
+            'client-prereq-events',
         ]
     }
     return json.dumps(body), 200, {'Content-type': 'application/json'}
@@ -166,6 +160,7 @@ def delete_client(id):
 
     client.close()
     return '', 202
+
 
 if __name__ == "__main__":
     port = default_port

--- a/contract-tests/service.py
+++ b/contract-tests/service.py
@@ -56,6 +56,7 @@ def handle_exception(e):
     app.logger.exception(e)
     return str(e), 500
 
+
 @app.route('/', methods=['GET'])
 def status():
     body = {
@@ -83,10 +84,12 @@ def status():
     }
     return json.dumps(body), 200, {'Content-type': 'application/json'}
 
+
 @app.route('/', methods=['DELETE'])
 def delete_stop_service():
     global_log.info("Test service has told us to exit")
     os._exit(0)
+
 
 @app.route('/', methods=['POST'])
 def post_create_client():
@@ -151,6 +154,7 @@ def post_client_command(id):
     if response is None:
         return '', 201
     return json.dumps(response), 200
+
 
 @app.route('/clients/<id>', methods=['DELETE'])
 def delete_client(id):

--- a/contract-tests/service.py
+++ b/contract-tests/service.py
@@ -1,12 +1,12 @@
-from client_entity import ClientEntity
-
 import json
 import logging
 import os
 import sys
+from logging.config import dictConfig
+
+from client_entity import ClientEntity
 from flask import Flask, request
 from flask.logging import default_handler
-from logging.config import dictConfig
 from werkzeug.exceptions import HTTPException
 
 # Import ldclient from parent directory

--- a/contract-tests/service.py
+++ b/contract-tests/service.py
@@ -9,6 +9,9 @@ from flask.logging import default_handler
 from logging.config import dictConfig
 from werkzeug.exceptions import HTTPException
 
+# Import ldclient from parent directory
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
 
 default_port = 8000
 

--- a/contract-tests/service.py
+++ b/contract-tests/service.py
@@ -81,7 +81,7 @@ def status():
             'client-prereq-events'
         ]
     }
-    return (json.dumps(body), 200, {'Content-type': 'application/json'})
+    return json.dumps(body), 200, {'Content-type': 'application/json'}
 
 @app.route('/', methods=['DELETE'])
 def delete_stop_service():
@@ -102,10 +102,10 @@ def post_create_client():
 
     if client.is_initializing() is False and options['configuration'].get('initCanFail', False) is False:
         client.close()
-        return ("Failed to initialize", 500)
+        return "Failed to initialize", 500
 
     clients[client_id] = client
-    return ('', 201, {'Location': resource_url})
+    return '', 201, {'Location': resource_url}
 
 
 @app.route('/clients/<id>', methods=['POST'])
@@ -116,7 +116,7 @@ def post_client_command(id):
 
     client = clients[id]
     if client is None:
-        return ('', 404)
+        return '', 404
 
     command = params.get('command')
     sub_params = params.get(command)
@@ -146,11 +146,11 @@ def post_client_command(id):
     elif command == "migrationOperation":
         response = client.migration_operation(sub_params)
     else:
-        return ('', 400)
+        return '', 400
 
     if response is None:
-        return ('', 201)
-    return (json.dumps(response), 200)
+        return '', 201
+    return json.dumps(response), 200
 
 @app.route('/clients/<id>', methods=['DELETE'])
 def delete_client(id):
@@ -158,10 +158,10 @@ def delete_client(id):
 
     client = clients[id]
     if client is None:
-        return ('', 404)
+        return '', 404
 
     client.close()
-    return ('', 202)
+    return '', 202
 
 if __name__ == "__main__":
     port = default_port

--- a/contract-tests/setup.cfg
+++ b/contract-tests/setup.cfg
@@ -1,2 +1,2 @@
 [pycodestyle]
-ignore = E501
+ignore = E501,W503

--- a/ldclient/__init__.py
+++ b/ldclient/__init__.py
@@ -13,8 +13,7 @@ __version__ = VERSION
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
-__BUILTINS__ = ["key", "ip", "country", "email",
-                "firstName", "lastName", "avatar", "name", "anonymous"]
+__BUILTINS__ = ["key", "ip", "country", "email", "firstName", "lastName", "avatar", "name", "anonymous"]
 
 """Settings."""
 start_wait = 5
@@ -99,17 +98,4 @@ def _reset_client():
 __BASE_TYPES__ = (str, float, int, bool)
 
 
-__all__ = [
-    'Config',
-    'Context',
-    'ContextBuilder',
-    'ContextMultiBuilder',
-    'LDClient',
-    'Result',
-    'client',
-    'context',
-    'evaluation',
-    'integrations',
-    'interfaces',
-    'migrations'
-]
+__all__ = ['Config', 'Context', 'ContextBuilder', 'ContextMultiBuilder', 'LDClient', 'Result', 'client', 'context', 'evaluation', 'integrations', 'interfaces', 'migrations']

--- a/ldclient/__init__.py
+++ b/ldclient/__init__.py
@@ -3,8 +3,9 @@ The ldclient module contains the most common top-level entry points for the SDK.
 """
 
 from ldclient.impl.rwlock import ReadWriteLock as _ReadWriteLock
-from ldclient.impl.util import log, Result
+from ldclient.impl.util import Result, log
 from ldclient.version import VERSION
+
 from .client import *
 from .context import *
 from .migrations import *

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -2,40 +2,46 @@
 This submodule contains the client class that provides most of the SDK functionality.
 """
 
-from typing import Optional, Any, Dict, Mapping, Tuple, Callable, List
-
-from .impl import AnyNum
-
 import hashlib
 import hmac
 import threading
 import traceback
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from ldclient.config import Config
 from ldclient.context import Context
-from ldclient.feature_store import _FeatureStoreDataSetSorter
-from ldclient.hook import Hook, EvaluationSeriesContext, _EvaluationWithHookResult
 from ldclient.evaluation import EvaluationDetail, FeatureFlagsState
+from ldclient.feature_store import _FeatureStoreDataSetSorter
+from ldclient.hook import (EvaluationSeriesContext, Hook,
+                           _EvaluationWithHookResult)
 from ldclient.impl.big_segments import BigSegmentStoreManager
 from ldclient.impl.datasource.feature_requester import FeatureRequesterImpl
 from ldclient.impl.datasource.polling import PollingUpdateProcessor
+from ldclient.impl.datasource.status import (DataSourceStatusProviderImpl,
+                                             DataSourceUpdateSinkImpl)
 from ldclient.impl.datasource.streaming import StreamingUpdateProcessor
-from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl, DataSourceStatusProviderImpl
-from ldclient.impl.datastore.status import DataStoreUpdateSinkImpl, DataStoreStatusProviderImpl
+from ldclient.impl.datastore.status import (DataStoreStatusProviderImpl,
+                                            DataStoreUpdateSinkImpl)
 from ldclient.impl.evaluator import Evaluator, error_reason
-from ldclient.impl.events.diagnostics import create_diagnostic_id, _DiagnosticAccumulator
+from ldclient.impl.events.diagnostics import (_DiagnosticAccumulator,
+                                              create_diagnostic_id)
 from ldclient.impl.events.event_processor import DefaultEventProcessor
 from ldclient.impl.events.types import EventFactory
-from ldclient.impl.model.feature_flag import FeatureFlag
+from ldclient.impl.flag_tracker import FlagTrackerImpl
 from ldclient.impl.listeners import Listeners
+from ldclient.impl.model.feature_flag import FeatureFlag
+from ldclient.impl.repeating_task import RepeatingTask
 from ldclient.impl.rwlock import ReadWriteLock
 from ldclient.impl.stubs import NullEventProcessor, NullUpdateProcessor
 from ldclient.impl.util import check_uwsgi, log
-from ldclient.impl.repeating_task import RepeatingTask
-from ldclient.interfaces import BigSegmentStoreStatusProvider, DataSourceStatusProvider, FeatureStore, FlagTracker, DataStoreUpdateSink, DataStoreStatus, DataStoreStatusProvider
+from ldclient.interfaces import (BigSegmentStoreStatusProvider,
+                                 DataSourceStatusProvider, DataStoreStatus,
+                                 DataStoreStatusProvider, DataStoreUpdateSink,
+                                 FeatureStore, FlagTracker)
+from ldclient.migrations import OpTracker, Stage
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS, VersionedDataKind
-from ldclient.migrations import Stage, OpTracker
-from ldclient.impl.flag_tracker import FlagTrackerImpl
+
+from .impl import AnyNum
 
 
 class _FeatureStoreClientWrapper(FeatureStore):

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -173,7 +173,7 @@ class LDClient:
     Client instances are thread-safe.
     """
 
-    def __init__(self, config: Config, start_wait: float=5):
+    def __init__(self, config: Config, start_wait: float = 5):
         """Constructs a new LDClient instance.
 
         :param config: optional custom configuration
@@ -210,10 +210,7 @@ class LDClient:
         self.__big_segment_store_manager = big_segment_store_manager
 
         self._evaluator = Evaluator(
-            lambda key: _get_store_item(store, FEATURES, key),
-            lambda key: _get_store_item(store, SEGMENTS, key),
-            lambda key: big_segment_store_manager.get_user_membership(key),
-            log
+            lambda key: _get_store_item(store, FEATURES, key), lambda key: _get_store_item(store, SEGMENTS, key), lambda key: big_segment_store_manager.get_user_membership(key), log
         )
 
         if self._config.offline:
@@ -239,8 +236,7 @@ class LDClient:
         if self._update_processor.initialized() is True:
             log.info("Started LaunchDarkly Client: OK")
         else:
-            log.warning("Initialization timeout exceeded for LaunchDarkly Client or an error occurred. "
-                     "Feature Flags may not yet be available.")
+            log.warning("Initialization timeout exceeded for LaunchDarkly Client or an error occurred. " "Feature Flags may not yet be available.")
 
     def _set_event_processor(self, config):
         if config.offline or not config.send_events:
@@ -276,8 +272,7 @@ class LDClient:
         return PollingUpdateProcessor(config, feature_requester, store, ready)
 
     def get_sdk_key(self) -> Optional[str]:
-        """Returns the configured SDK key.
-        """
+        """Returns the configured SDK key."""
         return self._config.sdk_key
 
     def close(self):
@@ -320,8 +315,7 @@ class LDClient:
 
         self._send_event(event)
 
-    def track(self, event_name: str, context: Context, data: Optional[Any]=None,
-              metric_value: Optional[AnyNum]=None):
+    def track(self, event_name: str, context: Context, data: Optional[Any] = None, metric_value: Optional[AnyNum] = None):
         """Tracks that an application-defined event occurred.
 
         This method creates a "custom" analytics event containing the specified event name (key)
@@ -340,8 +334,7 @@ class LDClient:
         if not context.valid:
             log.warning("Invalid context for track (%s)" % context.error)
         else:
-            self._send_event(self._event_factory_default.new_custom_event(event_name,
-                                                                          context, data, metric_value))
+            self._send_event(self._event_factory_default.new_custom_event(event_name, context, data, metric_value))
 
     def identify(self, context: Context):
         """Reports details about an evaluation context.
@@ -363,8 +356,7 @@ class LDClient:
             self._send_event(self._event_factory_default.new_identify_event(context))
 
     def is_offline(self) -> bool:
-        """Returns true if the client is in offline mode.
-        """
+        """Returns true if the client is in offline mode."""
         return self._config.offline
 
     def is_initialized(self) -> bool:
@@ -398,6 +390,7 @@ class LDClient:
           available from LaunchDarkly
         :return: the variation for the given context, or the ``default`` value if the flag cannot be evaluated
         """
+
         def evaluate():
             detail, _ = self._evaluate_internal(key, context, default, self._event_factory_default)
             return _EvaluationWithHookResult(evaluation_detail=detail)
@@ -418,6 +411,7 @@ class LDClient:
         :return: an :class:`ldclient.evaluation.EvaluationDetail` object that includes the feature
           flag value and evaluation reason
         """
+
         def evaluate():
             detail, _ = self._evaluate_internal(key, context, default, self._event_factory_with_reasons)
             return _EvaluationWithHookResult(evaluation_detail=detail)
@@ -643,10 +637,7 @@ class LDClient:
         return evaluation_result
 
     def __execute_before_evaluation(self, hooks: List[Hook], series_context: EvaluationSeriesContext) -> List[dict]:
-        return [
-            self.__try_execute_stage("beforeEvaluation", hook.metadata.name, lambda: hook.before_evaluation(series_context, {}))
-            for hook in hooks
-        ]
+        return [self.__try_execute_stage("beforeEvaluation", hook.metadata.name, lambda: hook.before_evaluation(series_context, {})) for hook in hooks]
 
     def __execute_after_evaluation(self, hooks: List[Hook], series_context: EvaluationSeriesContext, hook_data: List[dict], evaluation_detail: EvaluationDetail) -> List[dict]:
         return [

--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -79,6 +79,7 @@ class BigSegmentsConfig:
     def stale_after(self) -> float:
         return self.__stale_after
 
+
 class HTTPConfig:
     """Advanced HTTP configuration options for the SDK client.
 
@@ -139,6 +140,7 @@ class HTTPConfig:
     @property
     def disable_ssl_verification(self) -> bool:
         return self.__disable_ssl_verification
+
 
 class Config:
     """Advanced configuration options for the SDK client.

--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -34,12 +34,8 @@ class BigSegmentsConfig:
             store = Redis.new_big_segment_store(url='redis://localhost:6379')
             config = Config(big_segments=BigSegmentsConfig(store = store))
     """
-    def __init__(self,
-                 store: Optional[BigSegmentStore] = None,
-                 context_cache_size: int=1000,
-                 context_cache_time: float=5,
-                 status_poll_interval: float=5,
-                 stale_after: float=120):
+
+    def __init__(self, store: Optional[BigSegmentStore] = None, context_cache_size: int = 1000, context_cache_time: float = 5, status_poll_interval: float = 5, stale_after: float = 120):
         """
         :param store: the implementation of :class:`ldclient.interfaces.BigSegmentStore` that will
             be used to query the Big Segments database
@@ -87,13 +83,16 @@ class HTTPConfig:
     If you need to set these, construct an ``HTTPConfig`` instance and pass it as the ``http`` parameter when
     you construct the main :class:`Config` for the SDK client.
     """
-    def __init__(self,
-                 connect_timeout: float=10,
-                 read_timeout: float=15,
-                 http_proxy: Optional[str]=None,
-                 ca_certs: Optional[str]=None,
-                 cert_file: Optional[str]=None,
-                 disable_ssl_verification: bool=False):
+
+    def __init__(
+        self,
+        connect_timeout: float = 10,
+        read_timeout: float = 15,
+        http_proxy: Optional[str] = None,
+        ca_certs: Optional[str] = None,
+        cert_file: Optional[str] = None,
+        disable_ssl_verification: bool = False,
+    ):
         """
         :param connect_timeout: The connect timeout for network connections in seconds.
         :param read_timeout: The read timeout for network connections in seconds.
@@ -148,38 +147,41 @@ class Config:
     To use these options, create an instance of ``Config`` and pass it to either :func:`ldclient.set_config()`
     if you are using the singleton client, or the :class:`ldclient.client.LDClient` constructor otherwise.
     """
-    def __init__(self,
-                 sdk_key: str,
-                 base_uri: str='https://app.launchdarkly.com',
-                 events_uri: str='https://events.launchdarkly.com',
-                 events_max_pending: int=10000,
-                 flush_interval: float=5,
-                 stream_uri: str='https://stream.launchdarkly.com',
-                 stream: bool=True,
-                 initial_reconnect_delay: float=1,
-                 defaults: dict={},
-                 send_events: Optional[bool]=None,
-                 update_processor_class: Optional[Callable[['Config', FeatureStore, Event], UpdateProcessor]]=None,
-                 poll_interval: float=30,
-                 use_ldd: bool=False,
-                 feature_store: Optional[FeatureStore]=None,
-                 feature_requester_class=None,
-                 event_processor_class: Optional[Callable[['Config'], EventProcessor]]=None,
-                 private_attributes: Set[str]=set(),
-                 all_attributes_private: bool=False,
-                 offline: bool=False,
-                 context_keys_capacity: int=1000,
-                 context_keys_flush_interval: float=300,
-                 diagnostic_opt_out: bool=False,
-                 diagnostic_recording_interval: int=900,
-                 wrapper_name: Optional[str]=None,
-                 wrapper_version: Optional[str]=None,
-                 http: HTTPConfig=HTTPConfig(),
-                 big_segments: Optional[BigSegmentsConfig]=None,
-                 application: Optional[dict]=None,
-                 hooks: Optional[List[Hook]]=None,
-                 enable_event_compression: bool=False,
-                 omit_anonymous_contexts: bool=False):
+
+    def __init__(
+        self,
+        sdk_key: str,
+        base_uri: str = 'https://app.launchdarkly.com',
+        events_uri: str = 'https://events.launchdarkly.com',
+        events_max_pending: int = 10000,
+        flush_interval: float = 5,
+        stream_uri: str = 'https://stream.launchdarkly.com',
+        stream: bool = True,
+        initial_reconnect_delay: float = 1,
+        defaults: dict = {},
+        send_events: Optional[bool] = None,
+        update_processor_class: Optional[Callable[['Config', FeatureStore, Event], UpdateProcessor]] = None,
+        poll_interval: float = 30,
+        use_ldd: bool = False,
+        feature_store: Optional[FeatureStore] = None,
+        feature_requester_class=None,
+        event_processor_class: Optional[Callable[['Config'], EventProcessor]] = None,
+        private_attributes: Set[str] = set(),
+        all_attributes_private: bool = False,
+        offline: bool = False,
+        context_keys_capacity: int = 1000,
+        context_keys_flush_interval: float = 300,
+        diagnostic_opt_out: bool = False,
+        diagnostic_recording_interval: int = 900,
+        wrapper_name: Optional[str] = None,
+        wrapper_version: Optional[str] = None,
+        http: HTTPConfig = HTTPConfig(),
+        big_segments: Optional[BigSegmentsConfig] = None,
+        application: Optional[dict] = None,
+        hooks: Optional[List[Hook]] = None,
+        enable_event_compression: bool = False,
+        omit_anonymous_contexts: bool = False,
+    ):
         """
         :param sdk_key: The SDK key for your LaunchDarkly account. This is always required.
         :param base_uri: The base URL for the LaunchDarkly server. Most users should use the default
@@ -289,33 +291,35 @@ class Config:
 
         :param new_sdk_key: the new SDK key
         """
-        return Config(sdk_key=new_sdk_key,
-                      base_uri=self.__base_uri,
-                      events_uri=self.__events_uri,
-                      events_max_pending=self.__events_max_pending,
-                      flush_interval=self.__flush_interval,
-                      stream_uri=self.__stream_uri,
-                      stream=self.__stream,
-                      initial_reconnect_delay=self.__initial_reconnect_delay,
-                      defaults=self.__defaults,
-                      send_events=self.__send_events,
-                      update_processor_class=self.__update_processor_class,
-                      poll_interval=self.__poll_interval,
-                      use_ldd=self.__use_ldd,
-                      feature_store=self.__feature_store,
-                      feature_requester_class=self.__feature_requester_class,
-                      event_processor_class=self.__event_processor_class,
-                      private_attributes=self.__private_attributes,
-                      all_attributes_private=self.__all_attributes_private,
-                      offline=self.__offline,
-                      context_keys_capacity=self.__context_keys_capacity,
-                      context_keys_flush_interval=self.__context_keys_flush_interval,
-                      diagnostic_opt_out=self.__diagnostic_opt_out,
-                      diagnostic_recording_interval=self.__diagnostic_recording_interval,
-                      wrapper_name=self.__wrapper_name,
-                      wrapper_version=self.__wrapper_version,
-                      http=self.__http,
-                      big_segments=self.__big_segments)
+        return Config(
+            sdk_key=new_sdk_key,
+            base_uri=self.__base_uri,
+            events_uri=self.__events_uri,
+            events_max_pending=self.__events_max_pending,
+            flush_interval=self.__flush_interval,
+            stream_uri=self.__stream_uri,
+            stream=self.__stream,
+            initial_reconnect_delay=self.__initial_reconnect_delay,
+            defaults=self.__defaults,
+            send_events=self.__send_events,
+            update_processor_class=self.__update_processor_class,
+            poll_interval=self.__poll_interval,
+            use_ldd=self.__use_ldd,
+            feature_store=self.__feature_store,
+            feature_requester_class=self.__feature_requester_class,
+            event_processor_class=self.__event_processor_class,
+            private_attributes=self.__private_attributes,
+            all_attributes_private=self.__all_attributes_private,
+            offline=self.__offline,
+            context_keys_capacity=self.__context_keys_capacity,
+            context_keys_flush_interval=self.__context_keys_flush_interval,
+            diagnostic_opt_out=self.__diagnostic_opt_out,
+            diagnostic_recording_interval=self.__diagnostic_recording_interval,
+            wrapper_name=self.__wrapper_name,
+            wrapper_version=self.__wrapper_version,
+            http=self.__http,
+            big_segments=self.__big_segments,
+        )
 
     # for internal use only - probably should be part of the client logic
     def get_default(self, key, default):
@@ -365,6 +369,7 @@ class Config:
     @property
     def initial_reconnect_delay(self) -> float:
         return self.__initial_reconnect_delay
+
     @property
     def poll_interval(self) -> float:
         return self.__poll_interval
@@ -495,5 +500,6 @@ class Config:
     def _validate(self):
         if self.offline is False and self.sdk_key is None or self.sdk_key == '':
             log.warning("Missing or blank sdk_key.")
+
 
 __all__ = ['Config', 'BigSegmentsConfig', 'HTTPConfig']

--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -4,13 +4,14 @@ This submodule contains the :class:`Config` class for custom configuration of th
 Note that the same class can also be imported from the ``ldclient.client`` submodule.
 """
 
-from typing import Optional, Callable, List, Set
 from threading import Event
+from typing import Callable, List, Optional, Set
 
 from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.hook import Hook
 from ldclient.impl.util import log, validate_application_info
-from ldclient.interfaces import BigSegmentStore, EventProcessor, FeatureStore, UpdateProcessor, DataSourceUpdateSink
+from ldclient.interfaces import (BigSegmentStore, DataSourceUpdateSink,
+                                 EventProcessor, FeatureStore, UpdateProcessor)
 
 GET_LATEST_FEATURES_PATH = '/sdk/latest-flags'
 STREAM_FLAGS_PATH = '/flags'

--- a/ldclient/context.py
+++ b/ldclient/context.py
@@ -65,8 +65,8 @@ class Context:
         private_attributes: Optional[list[str]] = None,
         multi_contexts: Optional[list[Context]] = None,
         allow_empty_key: bool = False,
-        error: Optional[str] = None
-        ):
+        error: Optional[str] = None,
+    ):
         """
         Constructs an instance, setting all properties. Avoid using this constructor directly.
 
@@ -129,8 +129,7 @@ class Context:
         self.__attributes = attributes
         self.__private = private_attributes
         self.__multi = None
-        self.__full_key = key if kind == Context.DEFAULT_KIND else \
-            '%s:%s' % (kind, _escape_key_for_fully_qualified_key(key))
+        self.__full_key = key if kind == Context.DEFAULT_KIND else '%s:%s' % (kind, _escape_key_for_fully_qualified_key(key))
         self.__error = None
 
     @classmethod
@@ -644,9 +643,15 @@ class Context:
         """
         if not isinstance(other, Context):
             return False
-        if self.__kind != other.__kind or self.__key != other.__key or self.__name != other.__name or \
-            self.__anonymous != other.__anonymous or self.__attributes != other.__attributes or \
-            self.__private != other.__private or self.__error != other.__error:
+        if (
+            self.__kind != other.__kind
+            or self.__key != other.__key
+            or self.__name != other.__name
+            or self.__anonymous != other.__anonymous
+            or self.__attributes != other.__attributes
+            or self.__private != other.__private
+            or self.__error != other.__error
+        ):
             return False
         # Note that it's OK to compare __attributes because Python does a deep-equality check for dicts,
         # and it's OK to compare __private_attributes because we have canonicalized them by sorting.
@@ -702,6 +707,7 @@ class ContextBuilder:
 
     :param key: the context key
     """
+
     def __init__(self, key: str, copy_from: Optional[Context] = None):
         self.__key = key
         if copy_from is None:
@@ -737,10 +743,9 @@ class ContextBuilder:
 
         :return: a new :class:`ldclient.Context`
         """
-        self.__copy_on_write_attrs = (self.__attributes is not None)
-        self.__copy_on_write_private = (self.__private is not None)
-        return Context(self.__kind, self.__key, self.__name, self.__anonymous, self.__attributes, self.__private,
-            None, self.__allow_empty_key)
+        self.__copy_on_write_attrs = self.__attributes is not None
+        self.__copy_on_write_private = self.__private is not None
+        return Context(self.__kind, self.__key, self.__name, self.__anonymous, self.__attributes, self.__private, None, self.__allow_empty_key)
 
     def key(self, key: str) -> ContextBuilder:
         """
@@ -947,6 +952,7 @@ class ContextMultiBuilder:
             .add(Context.new("my-org-key", "organization")) \
             .build
     """
+
     def __init__(self):
         self.__contexts = []  # type: list[Context]
         self.__copy_on_write = False

--- a/ldclient/context.py
+++ b/ldclient/context.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 import json
 import re
-import warnings
 from typing import Any, Dict, Optional, Union
 
 

--- a/ldclient/context.py
+++ b/ldclient/context.py
@@ -13,10 +13,12 @@ from typing import Any, Dict, Optional, Union
 _INVALID_KIND_REGEX = re.compile('[^-a-zA-Z0-9._]')
 _USER_STRING_ATTRS = {'name', 'firstName', 'lastName', 'email', 'country', 'avatar', 'ip'}
 
+
 def _escape_key_for_fully_qualified_key(key: str) -> str:
     # When building a fully-qualified key, ':' and '%' are percent-escaped; we do not use a full
     # URL-encoding function because implementations of this are inconsistent across platforms.
     return key.replace('%', '%25').replace(':', '%3A')
+
 
 def _validate_kind(kind: str) -> Optional[str]:
     if kind == '':

--- a/ldclient/context.py
+++ b/ldclient/context.py
@@ -3,11 +3,11 @@ This submodule implements the SDK's evaluation context model.
 """
 
 from __future__ import annotations
-from collections.abc import Iterable
+
 import json
 import re
+from collections.abc import Iterable
 from typing import Any, Dict, Optional, Union
-
 
 _INVALID_KIND_REGEX = re.compile('[^-a-zA-Z0-9._]')
 _USER_STRING_ATTRS = {'name', 'firstName', 'lastName', 'email', 'country', 'avatar', 'ip'}

--- a/ldclient/evaluation.py
+++ b/ldclient/evaluation.py
@@ -2,6 +2,7 @@ import json
 import time
 from typing import Any, Dict, Optional
 
+
 class EvaluationDetail:
     """
     The return type of :func:`ldclient.client.LDClient.variation_detail()`, combining the result of a

--- a/ldclient/evaluation.py
+++ b/ldclient/evaluation.py
@@ -8,9 +8,9 @@ class EvaluationDetail:
     The return type of :func:`ldclient.client.LDClient.variation_detail()`, combining the result of a
     flag evaluation with information about how it was calculated.
     """
+
     def __init__(self, value: object, variation_index: Optional[int], reason: dict):
-        """Constructs an instance.
-        """
+        """Constructs an instance."""
         self.__value = value
         self.__variation_index = variation_index
         self.__reason = reason
@@ -85,6 +85,7 @@ class BigSegmentsStatus:
     Indicates that the Big Segment query involved in the flag evaluation was successful, and
     the segment state is considered up to date.
     """
+
     HEALTHY = "HEALTHY"
 
     """
@@ -114,9 +115,10 @@ class FeatureFlagsState:
     appropriate data structure for bootstrapping the LaunchDarkly JavaScript client. See the
     JavaScript SDK Reference Guide on `Bootstrapping <https://docs.launchdarkly.com/sdk/features/bootstrapping#javascript>`_.
     """
+
     def __init__(self, valid: bool):
-        self.__flag_values = {} # type: Dict[str, Any]
-        self.__flag_metadata = {} # type: Dict[str, Any]
+        self.__flag_values = {}  # type: Dict[str, Any]
+        self.__flag_metadata = {}  # type: Dict[str, Any]
         self.__valid = valid
 
     # Used internally to build the state map
@@ -161,7 +163,6 @@ class FeatureFlagsState:
         """
         return self.__valid
 
-
     def get_flag_value(self, key: str) -> object:
         """Returns the value of an individual feature flag at the time the state was recorded.
 
@@ -200,11 +201,9 @@ class FeatureFlagsState:
         return ret
 
     def to_json_string(self) -> str:
-        """Same as to_json_dict, but serializes the JSON structure into a string.
-        """
+        """Same as to_json_dict, but serializes the JSON structure into a string."""
         return json.dumps(self.to_json_dict())
 
     def __getstate__(self) -> dict:
-        """Equivalent to to_json_dict() - used if you are serializing the object with jsonpickle.
-        """
+        """Equivalent to to_json_dict() - used if you are serializing the object with jsonpickle."""
         return self.to_json_dict()

--- a/ldclient/feature_store.py
+++ b/ldclient/feature_store.py
@@ -16,15 +16,12 @@ from ldclient.versioned_data_kind import VersionedDataKind
 
 
 class CacheConfig:
-    """Encapsulates caching parameters for feature store implementations that support local caching.
-    """
+    """Encapsulates caching parameters for feature store implementations that support local caching."""
 
     DEFAULT_EXPIRATION = 15.0
     DEFAULT_CAPACITY = 1000
 
-    def __init__(self,
-                 expiration: float = DEFAULT_EXPIRATION,
-                 capacity: int = DEFAULT_CAPACITY):
+    def __init__(self, expiration: float = DEFAULT_EXPIRATION, capacity: int = DEFAULT_CAPACITY):
         """Constructs an instance of CacheConfig.
 
         :param expiration: the cache TTL, in seconds. Items will be evicted from the cache after
@@ -44,36 +41,30 @@ class CacheConfig:
 
     @staticmethod
     def disabled() -> 'CacheConfig':
-        """Returns an instance of CacheConfig specifying that caching should be disabled.
-        """
-        return CacheConfig(expiration = 0)
+        """Returns an instance of CacheConfig specifying that caching should be disabled."""
+        return CacheConfig(expiration=0)
 
     @property
     def enabled(self) -> bool:
-        """Returns True if caching is enabled in this configuration.
-        """
+        """Returns True if caching is enabled in this configuration."""
         return self._expiration > 0
 
     @property
     def expiration(self) -> float:
-        """Returns the configured cache TTL, in seconds.
-        """
+        """Returns the configured cache TTL, in seconds."""
         return self._expiration
 
     @property
     def capacity(self) -> int:
-        """Returns the configured maximum number of cacheable items.
-        """
+        """Returns the configured maximum number of cacheable items."""
         return self._capacity
 
 
 class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
-    """The default feature store implementation, which holds all data in a thread-safe data structure in memory.
-    """
+    """The default feature store implementation, which holds all data in a thread-safe data structure in memory."""
 
     def __init__(self):
-        """Constructs an instance of InMemoryFeatureStore.
-        """
+        """Constructs an instance of InMemoryFeatureStore."""
         self._lock = ReadWriteLock()
         self._initialized = False
         self._items = defaultdict(dict)
@@ -84,9 +75,8 @@ class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
     def is_available(self) -> bool:
         return True
 
-    def get(self, kind: VersionedDataKind, key: str, callback: Callable[[Any], Any]=lambda x: x) -> Any:
-        """
-        """
+    def get(self, kind: VersionedDataKind, key: str, callback: Callable[[Any], Any] = lambda x: x) -> Any:
+        """ """
         try:
             self._lock.rlock()
             itemsOfKind = self._items[kind]
@@ -102,8 +92,7 @@ class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
             self._lock.runlock()
 
     def all(self, kind, callback):
-        """
-        """
+        """ """
         try:
             self._lock.rlock()
             itemsOfKind = self._items[kind]
@@ -112,8 +101,7 @@ class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
             self._lock.runlock()
 
     def init(self, all_data):
-        """
-        """
+        """ """
         all_decoded = {}
         for kind, items in all_data.items():
             items_decoded = {}
@@ -132,8 +120,7 @@ class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
 
     # noinspection PyShadowingNames
     def delete(self, kind, key: str, version: int):
-        """
-        """
+        """ """
         try:
             self._lock.rlock()
             itemsOfKind = self._items[kind]
@@ -145,8 +132,7 @@ class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
             self._lock.runlock()
 
     def upsert(self, kind, item):
-        """
-        """
+        """ """
         decoded_item = kind.decode(item)
         key = item['key']
         try:
@@ -161,8 +147,7 @@ class InMemoryFeatureStore(FeatureStore, DiagnosticDescription):
 
     @property
     def initialized(self) -> bool:
-        """
-        """
+        """ """
         try:
             self._lock.rlock()
             return self._initialized
@@ -178,19 +163,22 @@ class _FeatureStoreDataSetSorter:
     Implements a dependency graph ordering for data to be stored in a feature store. We must use this
     on every data set that will be passed to the feature store's init() method.
     """
+
     @staticmethod
     def sort_all_collections(all_data):
-        """ Returns a copy of the input data that has the following guarantees: the iteration order of the outer
+        """Returns a copy of the input data that has the following guarantees: the iteration order of the outer
         dictionary will be in ascending order by the VersionDataKind's :priority property (if any), and for each
         data kind that has a "get_dependency_keys" function, the inner dictionary will have an iteration order
         where B is before A if A has a dependency on B.
         """
         outer_hash = OrderedDict()
         kinds = list(all_data.keys())
+
         def priority_order(kind):
             if hasattr(kind, 'priority'):
                 return kind.priority
             return len(kind.namespace)  # use arbitrary order if there's no priority
+
         kinds.sort(key=priority_order)
         for kind in kinds:
             items = all_data[kind]

--- a/ldclient/feature_store.py
+++ b/ldclient/feature_store.py
@@ -6,9 +6,9 @@ received from LaunchDarkly. This submodule does not include specific integration
 storage systems; those are in :class:`ldclient.integrations`.
 """
 
-from typing import Callable, Any
-
 from collections import OrderedDict, defaultdict
+from typing import Any, Callable
+
 from ldclient.impl.rwlock import ReadWriteLock
 from ldclient.impl.util import log
 from ldclient.interfaces import DiagnosticDescription, FeatureStore

--- a/ldclient/feature_store_helpers.py
+++ b/ldclient/feature_store_helpers.py
@@ -9,11 +9,14 @@ from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStor
 from ldclient.versioned_data_kind import VersionedDataKind
 from ldclient.feature_store import CacheConfig
 
+
 def _ensure_encoded(kind, item):
     return item if isinstance(item, dict) else kind.encode(item)
 
+
 def _is_deleted(item):
     return item is not None and item.get('deleted') is True
+
 
 class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
     """A partial implementation of :class:`ldclient.interfaces.FeatureStore`.
@@ -21,7 +24,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
     This class delegates the basic functionality to an implementation of
     :class:`ldclient.interfaces.FeatureStoreCore` - while adding optional caching behavior and other logic
     that would otherwise be repeated in every feature store implementation. This makes it easier to create
-    new database integrations by implementing only the database-specific logic. 
+    new database integrations by implementing only the database-specific logic.
     """
     __INITED_CACHE_KEY__ = "$inited"
 
@@ -96,7 +99,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         if self._cache is not None:
             self._cache[cache_key] = items
         return callback(items)
-    
+
     def delete(self, kind, key, version):
         """
         """
@@ -134,7 +137,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         if callable(getattr(self._core, 'describe_configuration', None)):
             return self._core.describe_configuration(config)
         return "custom"
-    
+
     @staticmethod
     def _item_cache_key(kind, key):
         return "{0}:{1}".format(kind.namespace, key)
@@ -142,7 +145,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
     @staticmethod
     def _all_cache_key(kind):
         return kind.namespace
-    
+
     @staticmethod
     def _items_if_not_deleted(items):
         results = {}
@@ -151,4 +154,3 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
                 if not item.get('deleted', False):
                     results[key] = item
         return results
-    

--- a/ldclient/feature_store_helpers.py
+++ b/ldclient/feature_store_helpers.py
@@ -26,6 +26,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
     that would otherwise be repeated in every feature store implementation. This makes it easier to create
     new database integrations by implementing only the database-specific logic.
     """
+
     __INITED_CACHE_KEY__ = "$inited"
 
     def __init__(self, core: FeatureStoreCore, cache_config: CacheConfig):
@@ -51,8 +52,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         return self._core.is_available() if self.__has_available_method else False  # type: ignore
 
     def init(self, all_encoded_data: Mapping[VersionedDataKind, Mapping[str, Dict[Any, Any]]]):
-        """
-        """
+        """ """
         self._core.init_internal(all_encoded_data)  # currently FeatureStoreCore expects to receive dicts
         if self._cache is not None:
             self._cache.clear()
@@ -60,15 +60,14 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
                 decoded_items = {}  # we don't want to cache dicts, we want to cache FeatureFlags/Segments
                 for key, item in items.items():
                     decoded_item = kind.decode(item)
-                    self._cache[self._item_cache_key(kind, key)] = [decoded_item] # note array wrapper
+                    self._cache[self._item_cache_key(kind, key)] = [decoded_item]  # note array wrapper
                     if not _is_deleted(decoded_item):
                         decoded_items[key] = decoded_item
                 self._cache[self._all_cache_key(kind)] = decoded_items
         self._inited = True
 
     def get(self, kind, key, callback=lambda x: x):
-        """
-        """
+        """ """
         if self._cache is not None:
             cache_key = self._item_cache_key(kind, key)
             cached_item = self._cache.get(cache_key)
@@ -83,8 +82,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         return callback(None if _is_deleted(item) else item)
 
     def all(self, kind, callback=lambda x: x):
-        """
-        """
+        """ """
         if self._cache is not None:
             cache_key = self._all_cache_key(kind)
             cached_items = self._cache.get(cache_key)
@@ -101,14 +99,12 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         return callback(items)
 
     def delete(self, kind, key, version):
-        """
-        """
-        deleted_item = { "key": key, "version": version, "deleted": True }
+        """ """
+        deleted_item = {"key": key, "version": version, "deleted": True}
         self.upsert(kind, deleted_item)
 
     def upsert(self, kind, encoded_item):
-        """
-        """
+        """ """
         encoded_item = _ensure_encoded(kind, encoded_item)
         new_state = self._core.upsert_internal(kind, encoded_item)
         new_decoded_item = kind.decode(new_state)
@@ -118,8 +114,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
 
     @property
     def initialized(self) -> bool:
-        """
-        """
+        """ """
         if self._inited:
             return True
         if self._cache is None:

--- a/ldclient/feature_store_helpers.py
+++ b/ldclient/feature_store_helpers.py
@@ -2,12 +2,14 @@
 This submodule contains support code for writing feature store implementations.
 """
 
-from typing import Dict, Mapping, Any
+from typing import Any, Dict, Mapping
+
 from expiringdict import ExpiringDict
 
-from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStoreCore
-from ldclient.versioned_data_kind import VersionedDataKind
 from ldclient.feature_store import CacheConfig
+from ldclient.interfaces import (DiagnosticDescription, FeatureStore,
+                                 FeatureStoreCore)
+from ldclient.versioned_data_kind import VersionedDataKind
 
 
 def _ensure_encoded(kind, item):

--- a/ldclient/hook.py
+++ b/ldclient/hook.py
@@ -38,6 +38,7 @@ class Hook:
     allows LaunchDarkly to expand the list of hook handlers without breaking
     customer integrations.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractproperty

--- a/ldclient/hook.py
+++ b/ldclient/hook.py
@@ -1,9 +1,9 @@
-from ldclient.context import Context
-from ldclient.evaluation import EvaluationDetail
-
 from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from typing import Any
+
+from ldclient.context import Context
+from ldclient.evaluation import EvaluationDetail
 
 
 @dataclass

--- a/ldclient/impl/big_segments.py
+++ b/ldclient/impl/big_segments.py
@@ -1,15 +1,17 @@
+import base64
+import time
+from hashlib import sha256
+from typing import Callable, Optional, Tuple
+
+from expiringdict import ExpiringDict
+
 from ldclient.config import BigSegmentsConfig
 from ldclient.evaluation import BigSegmentsStatus
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.repeating_task import RepeatingTask
 from ldclient.impl.util import log
-from ldclient.interfaces import BigSegmentStoreStatus, BigSegmentStoreStatusProvider
-
-import base64
-from expiringdict import ExpiringDict
-from hashlib import sha256
-import time
-from typing import Callable, Optional, Tuple
+from ldclient.interfaces import (BigSegmentStoreStatus,
+                                 BigSegmentStoreStatusProvider)
 
 
 class BigSegmentStoreStatusProviderImpl(BigSegmentStoreStatusProvider):

--- a/ldclient/impl/big_segments.py
+++ b/ldclient/impl/big_segments.py
@@ -80,7 +80,7 @@ class BigSegmentStoreManager:
 
     def get_user_membership(self, user_key: str) -> Tuple[Optional[dict], str]:
         if not self.__store:
-            return (None, BigSegmentsStatus.NOT_CONFIGURED)
+            return None, BigSegmentsStatus.NOT_CONFIGURED
         membership = self.__cache.get(user_key)
         if membership is None:
             user_hash = _hash_for_user_key(user_key)
@@ -91,13 +91,13 @@ class BigSegmentStoreManager:
                 self.__cache[user_key] = membership
             except Exception as e:
                 log.exception("Big Segment store membership query returned error: %s" % e)
-                return (None, BigSegmentsStatus.STORE_ERROR)
+                return None, BigSegmentsStatus.STORE_ERROR
         status = self.__last_status
         if not status:
             status = self.poll_store_and_update_status()
         if not status.available:
-            return (membership, BigSegmentsStatus.STORE_ERROR)
-        return (membership, BigSegmentsStatus.STALE if status.stale else BigSegmentsStatus.HEALTHY)
+            return membership, BigSegmentsStatus.STORE_ERROR
+        return membership, BigSegmentsStatus.STALE if status.stale else BigSegmentsStatus.HEALTHY
 
     def get_status(self) -> BigSegmentStoreStatus:
         status = self.__last_status

--- a/ldclient/impl/datasource/feature_requester.py
+++ b/ldclient/impl/datasource/feature_requester.py
@@ -2,15 +2,15 @@
 Default implementation of feature flag polling requests.
 """
 
-from collections import namedtuple
 import json
+from collections import namedtuple
+
 import urllib3
 
 from ldclient.impl.http import _http_factory
 from ldclient.impl.util import _headers, log, throw_if_unsuccessful_response
 from ldclient.interfaces import FeatureRequester
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
 
 LATEST_ALL_URI = '/sdk/latest-all'
 

--- a/ldclient/impl/datasource/feature_requester.py
+++ b/ldclient/impl/datasource/feature_requester.py
@@ -32,10 +32,7 @@ class FeatureRequesterImpl(FeatureRequester):
         hdrs['Accept-Encoding'] = 'gzip'
         if cache_entry is not None:
             hdrs['If-None-Match'] = cache_entry.etag
-        r = self._http.request('GET', uri,
-                               headers=hdrs,
-                               timeout=urllib3.Timeout(connect=self._config.http.connect_timeout, read=self._config.http.read_timeout),
-                               retries=1)
+        r = self._http.request('GET', uri, headers=hdrs, timeout=urllib3.Timeout(connect=self._config.http.connect_timeout, read=self._config.http.read_timeout), retries=1)
         throw_if_unsuccessful_response(r)
         if r.status == 304 and cache_entry is not None:
             data = cache_entry.data
@@ -47,10 +44,6 @@ class FeatureRequesterImpl(FeatureRequester):
             from_cache = False
             if etag is not None:
                 self._cache[uri] = CacheEntry(data=data, etag=etag)
-        log.debug("%s response status:[%d] From cache? [%s] ETag:[%s]",
-            uri, r.status, from_cache, etag)
+        log.debug("%s response status:[%d] From cache? [%s] ETag:[%s]", uri, r.status, from_cache, etag)
 
-        return {
-            FEATURES: data['flags'],
-            SEGMENTS: data['segments']
-        }
+        return {FEATURES: data['flags'], SEGMENTS: data['segments']}

--- a/ldclient/impl/datasource/polling.py
+++ b/ldclient/impl/datasource/polling.py
@@ -1,6 +1,7 @@
 """
 Default implementation of the polling component.
 """
+
 # currently excluded from documentation - see docs/README.md
 
 from threading import Event
@@ -40,10 +41,7 @@ class PollingUpdateProcessor(UpdateProcessor):
         if self._data_source_update_sink is None:
             return
 
-        self._data_source_update_sink.update_status(
-            DataSourceState.OFF,
-            error
-        )
+        self._data_source_update_sink.update_status(DataSourceState.OFF, error)
 
     def _sink_or_store(self):
         """
@@ -73,12 +71,7 @@ class PollingUpdateProcessor(UpdateProcessor):
             if self._data_source_update_sink is not None:
                 self._data_source_update_sink.update_status(DataSourceState.VALID, None)
         except UnsuccessfulResponseException as e:
-            error_info = DataSourceErrorInfo(
-                DataSourceErrorKind.ERROR_RESPONSE,
-                e.status,
-                time.time(),
-                str(e)
-            )
+            error_info = DataSourceErrorInfo(DataSourceErrorKind.ERROR_RESPONSE, e.status, time.time(), str(e))
 
             http_error_message_result = http_error_message(e.status, "polling request")
             if not is_http_error_recoverable(e.status):
@@ -89,16 +82,9 @@ class PollingUpdateProcessor(UpdateProcessor):
                 log.warning(http_error_message_result)
 
                 if self._data_source_update_sink is not None:
-                    self._data_source_update_sink.update_status(
-                        DataSourceState.INTERRUPTED,
-                        error_info
-                    )
+                    self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, error_info)
         except Exception as e:
-            log.exception(
-                'Error: Exception encountered when updating flags. %s' % e)
+            log.exception('Error: Exception encountered when updating flags. %s' % e)
 
             if self._data_source_update_sink is not None:
-                self._data_source_update_sink.update_status(
-                    DataSourceState.INTERRUPTED,
-                    DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time, str(e))
-                )
+                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time, str(e)))

--- a/ldclient/impl/datasource/polling.py
+++ b/ldclient/impl/datasource/polling.py
@@ -4,15 +4,19 @@ Default implementation of the polling component.
 
 # currently excluded from documentation - see docs/README.md
 
+import time
 from threading import Event
+from typing import Optional
 
 from ldclient.config import Config
 from ldclient.impl.repeating_task import RepeatingTask
-from ldclient.impl.util import UnsuccessfulResponseException, http_error_message, is_http_error_recoverable, log
-from ldclient.interfaces import FeatureRequester, FeatureStore, UpdateProcessor, DataSourceUpdateSink, DataSourceErrorInfo, DataSourceErrorKind, DataSourceState
-
-import time
-from typing import Optional
+from ldclient.impl.util import (UnsuccessfulResponseException,
+                                http_error_message, is_http_error_recoverable,
+                                log)
+from ldclient.interfaces import (DataSourceErrorInfo, DataSourceErrorKind,
+                                 DataSourceState, DataSourceUpdateSink,
+                                 FeatureRequester, FeatureStore,
+                                 UpdateProcessor)
 
 
 class PollingUpdateProcessor(UpdateProcessor):

--- a/ldclient/impl/datasource/status.py
+++ b/ldclient/impl/datasource/status.py
@@ -1,13 +1,15 @@
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-from ldclient.impl.dependency_tracker import DependencyTracker
-from ldclient.impl.listeners import Listeners
-from ldclient.interfaces import DataSourceStatusProvider, DataSourceUpdateSink, DataSourceStatus, FeatureStore, DataSourceState, DataSourceErrorInfo, DataSourceErrorKind, FlagChange
-from ldclient.impl.rwlock import ReadWriteLock
-from ldclient.versioned_data_kind import VersionedDataKind
-from ldclient.impl.dependency_tracker import KindAndKey
-
 import time
 from typing import Callable, Mapping, Optional, Set
+
+from ldclient.impl.dependency_tracker import DependencyTracker, KindAndKey
+from ldclient.impl.listeners import Listeners
+from ldclient.impl.rwlock import ReadWriteLock
+from ldclient.interfaces import (DataSourceErrorInfo, DataSourceErrorKind,
+                                 DataSourceState, DataSourceStatus,
+                                 DataSourceStatusProvider,
+                                 DataSourceUpdateSink, FeatureStore,
+                                 FlagChange)
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS, VersionedDataKind
 
 
 class DataSourceUpdateSinkImpl(DataSourceUpdateSink):

--- a/ldclient/impl/datasource/status.py
+++ b/ldclient/impl/datasource/status.py
@@ -18,11 +18,7 @@ class DataSourceUpdateSinkImpl(DataSourceUpdateSink):
         self.__tracker = DependencyTracker()
 
         self.__lock = ReadWriteLock()
-        self.__status = DataSourceStatus(
-            DataSourceState.INITIALIZING,
-            time.time(),
-            None
-        )
+        self.__status = DataSourceStatus(DataSourceState.INITIALIZING, time.time(), None)
 
     @property
     def status(self) -> DataSourceStatus:
@@ -50,9 +46,7 @@ class DataSourceUpdateSinkImpl(DataSourceUpdateSink):
         if old_data is None:
             return
 
-        self.__send_change_events(
-            self.__compute_changed_items_for_full_data_set(old_data, all_data)
-        )
+        self.__send_change_events(self.__compute_changed_items_for_full_data_set(old_data, all_data))
 
     def upsert(self, kind: VersionedDataKind, item: dict):
         self.__monitor_store_update(lambda: self.__store.upsert(kind, item))
@@ -79,11 +73,7 @@ class DataSourceUpdateSinkImpl(DataSourceUpdateSink):
             if new_state == old_status.state and new_error is None:
                 return
 
-            self.__status = DataSourceStatus(
-                new_state,
-                self.__status.since if new_state == self.__status.state else time.time(),
-                self.__status.error if new_error is None else new_error
-            )
+            self.__status = DataSourceStatus(new_state, self.__status.since if new_state == self.__status.state else time.time(), self.__status.error if new_error is None else new_error)
 
             status_to_broadcast = self.__status
         finally:
@@ -96,12 +86,7 @@ class DataSourceUpdateSinkImpl(DataSourceUpdateSink):
         try:
             fn()
         except Exception as e:
-            error_info = DataSourceErrorInfo(
-                DataSourceErrorKind.STORE_ERROR,
-                0,
-                time.time(),
-                str(e)
-            )
+            error_info = DataSourceErrorInfo(DataSourceErrorKind.STORE_ERROR, 0, time.time(), str(e))
             self.update_status(DataSourceState.INTERRUPTED, error_info)
             raise
 

--- a/ldclient/impl/datasource/streaming.py
+++ b/ldclient/impl/datasource/streaming.py
@@ -208,7 +208,7 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
     def _parse_path(path: str):
         for kind in [FEATURES, SEGMENTS]:
             if path.startswith(kind.stream_api_path):
-                return ParsedPath(kind=kind, key=path[len(kind.stream_api_path) :])
+                return ParsedPath(kind=kind, key=path[len(kind.stream_api_path):])
         return None
 
     # magic methods for "with" statement (used in testing)

--- a/ldclient/impl/datasource/streaming.py
+++ b/ldclient/impl/datasource/streaming.py
@@ -1,20 +1,21 @@
-from collections import namedtuple
 import json
+import time
+from collections import namedtuple
 from threading import Thread
 from typing import Optional
 
-import time
-
-from ldclient.interfaces import DataSourceErrorInfo, DataSourceErrorKind, DataSourceState
-from ldclient.impl.http import HTTPFactory, _http_factory
-from ldclient.impl.util import http_error_message, is_http_error_recoverable, log
-from ldclient.interfaces import UpdateProcessor
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
 from ld_eventsource import SSEClient
 from ld_eventsource.actions import Event, Fault
-from ld_eventsource.config import ConnectStrategy, ErrorStrategy, RetryDelayStrategy
+from ld_eventsource.config import (ConnectStrategy, ErrorStrategy,
+                                   RetryDelayStrategy)
 from ld_eventsource.errors import HTTPStatusError
+
+from ldclient.impl.http import HTTPFactory, _http_factory
+from ldclient.impl.util import (http_error_message, is_http_error_recoverable,
+                                log)
+from ldclient.interfaces import (DataSourceErrorInfo, DataSourceErrorKind,
+                                 DataSourceState, UpdateProcessor)
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 # allows for up to 5 minutes to elapse without any data sent across the stream. The heartbeats sent as comments on the
 # stream will keep this from triggering

--- a/ldclient/impl/datasource/streaming.py
+++ b/ldclient/impl/datasource/streaming.py
@@ -62,17 +62,9 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                     self._sse.interrupt()
 
                     if self._data_source_update_sink is not None:
-                        error_info = DataSourceErrorInfo(
-                            DataSourceErrorKind.UNKNOWN,
-                            0,
-                            time.time(),
-                            str(e)
-                        )
+                        error_info = DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(e))
 
-                        self._data_source_update_sink.update_status(
-                            DataSourceState.INTERRUPTED,
-                            error_info
-                        )
+                        self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, error_info)
 
                 if message_ok:
                     self._record_stream_init(False)
@@ -103,24 +95,16 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
     def _create_sse_client(self) -> SSEClient:
         # We don't want the stream to use the same read timeout as the rest of the SDK.
         http_factory = _http_factory(self._config)
-        stream_http_factory = HTTPFactory(http_factory.base_headers, http_factory.http_config,
-                                          override_read_timeout=stream_read_timeout)
+        stream_http_factory = HTTPFactory(http_factory.base_headers, http_factory.http_config, override_read_timeout=stream_read_timeout)
         return SSEClient(
             connect=ConnectStrategy.http(
-                url=self._uri,
-                headers=http_factory.base_headers,
-                pool=stream_http_factory.create_pool_manager(1, self._uri),
-                urllib3_request_options={"timeout": stream_http_factory.timeout}
+                url=self._uri, headers=http_factory.base_headers, pool=stream_http_factory.create_pool_manager(1, self._uri), urllib3_request_options={"timeout": stream_http_factory.timeout}
             ),
             error_strategy=ErrorStrategy.always_continue(),  # we'll make error-handling decisions when we see a Fault
             initial_retry_delay=self._config.initial_reconnect_delay,
-            retry_delay_strategy=RetryDelayStrategy.default(
-                max_delay=MAX_RETRY_DELAY,
-                backoff_multiplier=2,
-                jitter_multiplier=JITTER_RATIO
-            ),
+            retry_delay_strategy=RetryDelayStrategy.default(max_delay=MAX_RETRY_DELAY, backoff_multiplier=2, jitter_multiplier=JITTER_RATIO),
             retry_delay_reset_threshold=BACKOFF_RESET_INTERVAL,
-            logger=log
+            logger=log,
         )
 
     def stop(self):
@@ -133,10 +117,7 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
         if self._data_source_update_sink is None:
             return
 
-        self._data_source_update_sink.update_status(
-            DataSourceState.OFF,
-            error
-        )
+        self._data_source_update_sink.update_status(DataSourceState.OFF, error)
 
     def _sink_or_store(self):
         if self._data_source_update_sink is None:
@@ -151,12 +132,8 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
     def _process_message(self, store, msg: Event) -> bool:
         if msg.event == 'put':
             all_data = json.loads(msg.data)
-            init_data = {
-                FEATURES: all_data['data']['flags'],
-                SEGMENTS: all_data['data']['segments']
-            }
-            log.debug("Received put event with %d flags and %d segments",
-                      len(init_data[FEATURES]), len(init_data[SEGMENTS]))
+            init_data = {FEATURES: all_data['data']['flags'], SEGMENTS: all_data['data']['segments']}
+            log.debug("Received put event with %d flags and %d segments", len(init_data[FEATURES]), len(init_data[SEGMENTS]))
             store.init(init_data)
             return True
         elif msg.event == 'patch':
@@ -190,32 +167,19 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
             return False  # don't retry if we've been deliberately stopped
 
         if isinstance(error, json.decoder.JSONDecodeError):
-            error_info = DataSourceErrorInfo(
-                DataSourceErrorKind.INVALID_DATA,
-                0,
-                time.time(),
-                str(error)
-            )
+            error_info = DataSourceErrorInfo(DataSourceErrorKind.INVALID_DATA, 0, time.time(), str(error))
 
             log.error("Unexpected error on stream connection: %s, will retry" % error)
             self._record_stream_init(True)
             self._connection_attempt_start_time = None
 
             if self._data_source_update_sink is not None:
-                self._data_source_update_sink.update_status(
-                    DataSourceState.INTERRUPTED,
-                    error_info
-                )
+                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, error_info)
         elif isinstance(error, HTTPStatusError):
             self._record_stream_init(True)
             self._connection_attempt_start_time = None
 
-            error_info = DataSourceErrorInfo(
-                DataSourceErrorKind.ERROR_RESPONSE,
-                error.status,
-                time.time(),
-                str(error)
-            )
+            error_info = DataSourceErrorInfo(DataSourceErrorKind.ERROR_RESPONSE, error.status, time.time(), str(error))
 
             http_error_message_result = http_error_message(error.status, "stream connection")
             if not is_http_error_recoverable(error.status):
@@ -228,20 +192,14 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                 log.warning(http_error_message_result)
 
                 if self._data_source_update_sink is not None:
-                    self._data_source_update_sink.update_status(
-                        DataSourceState.INTERRUPTED,
-                        error_info
-                    )
+                    self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, error_info)
         else:
             log.warning("Unexpected error on stream connection: %s, will retry" % error)
             self._record_stream_init(True)
             self._connection_attempt_start_time = None
 
             if self._data_source_update_sink is not None:
-                self._data_source_update_sink.update_status(
-                    DataSourceState.INTERRUPTED,
-                    DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(error))
-                )
+                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(error)))
             # no stacktrace here because, for a typical connection error, it'll just be a lengthy tour of urllib3 internals
         self._connection_attempt_start_time = time.time() + self._sse.next_retry_delay
         return True
@@ -250,7 +208,7 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
     def _parse_path(path: str):
         for kind in [FEATURES, SEGMENTS]:
             if path.startswith(kind.stream_api_path):
-                return ParsedPath(kind = kind, key = path[len(kind.stream_api_path):])
+                return ParsedPath(kind=kind, key=path[len(kind.stream_api_path) :])
         return None
 
     # magic methods for "with" statement (used in testing)

--- a/ldclient/impl/datastore/status.py
+++ b/ldclient/impl/datastore/status.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING
-from copy import copy
 
-from ldclient.interfaces import DataStoreStatusProvider, DataStoreStatus, DataStoreUpdateSink
+from copy import copy
+from typing import TYPE_CHECKING, Callable
+
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.rwlock import ReadWriteLock
+from ldclient.interfaces import (DataStoreStatus, DataStoreStatusProvider,
+                                 DataStoreUpdateSink)
 
 if TYPE_CHECKING:
     from ldclient.client import _FeatureStoreClientWrapper

--- a/ldclient/impl/dependency_tracker.py
+++ b/ldclient/impl/dependency_tracker.py
@@ -1,9 +1,9 @@
+from typing import Dict, List, NamedTuple, Optional, Set, Union
+
+from ldclient.impl.model.clause import Clause
 from ldclient.impl.model.feature_flag import FeatureFlag
 from ldclient.impl.model.segment import Segment
-from ldclient.impl.model.clause import Clause
-from ldclient.versioned_data_kind import VersionedDataKind, SEGMENTS, FEATURES
-
-from typing import Set, List, Dict, NamedTuple, Union, Optional
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS, VersionedDataKind
 
 
 class KindAndKey(NamedTuple):

--- a/ldclient/impl/evaluator.py
+++ b/ldclient/impl/evaluator.py
@@ -1,12 +1,12 @@
+import hashlib
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
 from ldclient.context import Context
 from ldclient.evaluation import BigSegmentsStatus, EvaluationDetail
 from ldclient.impl import operators
 from ldclient.impl.events.types import EventFactory, EventInputEvaluation
 from ldclient.impl.model import *
-
-import hashlib
-import logging
-from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # For consistency with past logging behavior, we are pretending that the evaluation logic still lives in
 # the ldclient.evaluation module.

--- a/ldclient/impl/evaluator.py
+++ b/ldclient/impl/evaluator.py
@@ -180,7 +180,7 @@ class Evaluator:
             # old-style data has only targets for users
             if len(user_targets) != 0:
                 user_context = context.get_individual_context(Context.DEFAULT_KIND)
-                if (user_context is None):
+                if user_context is None:
                     return None
                 key = user_context.key
                 for t in user_targets:
@@ -359,14 +359,14 @@ def _get_value_for_variation_or_rollout(flag: FeatureFlag, vr: VariationOrRollou
 def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, context: Context) -> Tuple[Optional[int], bool]:
     var = vr.variation
     if var is not None:
-        return (var, False)
+        return var, False
 
     rollout = vr.rollout
     if rollout is None:
-        return (None, False)
+        return None, False
     variations = rollout.variations
     if len(variations) == 0:
-        return (None, False)
+        return None, False
 
     bucket_by = None if rollout.is_experiment else rollout.bucket_by
     bucket = _bucket_context(
@@ -386,7 +386,7 @@ def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, cont
         sum += wv.weight / 100000.0
         if bucket < sum:
             is_experiment_partition = is_experiment and not wv.untracked
-            return (wv.variation, is_experiment_partition)
+            return wv.variation, is_experiment_partition
 
     # The context's bucket value was greater than or equal to the end of the last bucket. This could happen due
     # to a rounding error, or due to the fact that we are scaling to 100000 rather than 99999, or the flag
@@ -394,7 +394,7 @@ def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, cont
     # this case (or changing the scaling, which would potentially change the results for *all* contexts), we
     # will simply put the context in the last bucket.
     is_experiment_partition = is_experiment and not variations[-1].untracked
-    return (variations[-1].variation, is_experiment_partition)
+    return variations[-1].variation, is_experiment_partition
 
 def _bucket_context(
     seed: Optional[int],

--- a/ldclient/impl/evaluator.py
+++ b/ldclient/impl/evaluator.py
@@ -71,6 +71,7 @@ class Evaluator:
     that is provided in the constructor. It also produces feature events as appropriate for any referenced prerequisite
     flags, but does not send them.
     """
+
     def __init__(
         self,
         get_flag: Callable[[str], Optional[FeatureFlag]],
@@ -342,11 +343,13 @@ def _get_variation(flag: FeatureFlag, variation: int, reason: dict) -> Evaluatio
         return EvaluationDetail(None, None, error_reason('MALFORMED_FLAG'))
     return EvaluationDetail(vars[variation], variation, reason)
 
+
 def _get_off_value(flag: FeatureFlag, reason: dict) -> EvaluationDetail:
     off_var = flag.off_variation
     if off_var is None:
         return EvaluationDetail(None, None, reason)
     return _get_variation(flag, off_var, reason)
+
 
 def _get_value_for_variation_or_rollout(flag: FeatureFlag, vr: VariationOrRollout, context: Context, reason: dict) -> EvaluationDetail:
     index, inExperiment = _variation_index_for_context(flag, vr, context)
@@ -355,6 +358,7 @@ def _get_value_for_variation_or_rollout(flag: FeatureFlag, vr: VariationOrRollou
     if inExperiment:
         reason['inExperiment'] = inExperiment
     return _get_variation(flag, index, reason)
+
 
 def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, context: Context) -> Tuple[Optional[int], bool]:
     var = vr.variation
@@ -396,6 +400,7 @@ def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, cont
     is_experiment_partition = is_experiment and not variations[-1].untracked
     return variations[-1].variation, is_experiment_partition
 
+
 def _bucket_context(
     seed: Optional[int],
     context: Context,
@@ -423,6 +428,7 @@ def _bucket_context(
     result = hash_val / __LONG_SCALE__
     return result
 
+
 def _bucketable_string_value(u_value) -> Optional[str]:
     if isinstance(u_value, bool):
         return None
@@ -431,11 +437,13 @@ def _bucketable_string_value(u_value) -> Optional[str]:
 
     return None
 
+
 def _context_key_is_in_target_list(context: Context, context_kind: Optional[str], keys: Set[str]) -> bool:
     if keys is None or len(keys) == 0:
         return False
     match_context = context.get_individual_context(context_kind or Context.DEFAULT_KIND)
     return match_context is not None and match_context.key in keys
+
 
 def _get_context_value_by_attr_ref(context: Context, attr: AttributeRef) -> Any:
     if attr is None:
@@ -455,6 +463,7 @@ def _get_context_value_by_attr_ref(context: Context, attr: AttributeRef) -> Any:
         i += 1
     return value
 
+
 def _match_single_context_value(clause: Clause, context_value: Any) -> bool:
     op_fn = operators.ops.get(clause.op)
     if op_fn is None:
@@ -466,6 +475,7 @@ def _match_single_context_value(clause: Clause, context_value: Any) -> bool:
             return True
     return False
 
+
 def _match_clause_by_kind(clause: Clause, context: Context) -> bool:
     # If attribute is "kind", then we treat operator and values as a match expression against a list
     # of all individual kinds in the context. That is, for a multi-kind context with kinds of "org"
@@ -476,8 +486,10 @@ def _match_clause_by_kind(clause: Clause, context: Context) -> bool:
             return True
     return False
 
+
 def _maybe_negate(clause: Clause, val: bool) -> bool:
     return not val if clause.negate else val
+
 
 def _make_big_segment_ref(segment: Segment) -> str:
     # The format of Big Segment references is independent of what store implementation is being
@@ -485,8 +497,10 @@ def _make_big_segment_ref(segment: Segment) -> str:
     # the data model. The Relay Proxy will use the same format when writing to the store.
     return "%s.g%d" % (segment.key, segment.generation or 0)
 
+
 def _target_match_result(flag: FeatureFlag, var: int) -> EvaluationDetail:
     return _get_variation(flag, var, {'kind': 'TARGET_MATCH'})
+
 
 def error_reason(error_kind: str) -> dict:
     return {'kind': 'ERROR', 'errorKind': error_kind}

--- a/ldclient/impl/evaluator.py
+++ b/ldclient/impl/evaluator.py
@@ -14,8 +14,7 @@ log = logging.getLogger('ldclient.flag')
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
-__BUILTINS__ = ["key", "secondary", "ip", "country", "email",
-                "firstName", "lastName", "avatar", "name", "anonymous"]
+__BUILTINS__ = ["key", "secondary", "ip", "country", "email", "firstName", "lastName", "avatar", "name", "anonymous"]
 
 
 # EvalResult is used internally to hold the EvaluationDetail result of an evaluation along with
@@ -23,8 +22,7 @@ __BUILTINS__ = ["key", "secondary", "ip", "country", "email",
 # prerequisite evaluations, and the cached state of any Big Segments query that we may have
 # ended up having to do for the context.
 class EvalResult:
-    __slots__ = ['detail', 'events', 'big_segments_status', 'big_segments_membership',
-        'original_flag_key', 'prereq_stack', 'segment_stack', 'depth', 'prerequisites']
+    __slots__ = ['detail', 'events', 'big_segments_status', 'big_segments_membership', 'original_flag_key', 'prereq_stack', 'segment_stack', 'depth', 'prerequisites']
 
     def __init__(self):
         self.detail = None
@@ -77,7 +75,7 @@ class Evaluator:
         get_flag: Callable[[str], Optional[FeatureFlag]],
         get_segment: Callable[[str], Optional[Segment]],
         get_big_segments_membership: Callable[[str], Tuple[Optional[dict], str]],
-        logger: Optional[logging.Logger] = None
+        logger: Optional[logging.Logger] = None,
     ):
         """
         :param get_flag: function provided by LDClient that takes a flag key and returns either the flag or None
@@ -121,8 +119,7 @@ class Evaluator:
         # Now walk through the rules to see if any match
         for index, rule in enumerate(flag.rules):
             if self._rule_matches_context(rule, context, state):
-                return _get_value_for_variation_or_rollout(flag, rule.variation_or_rollout, context,
-                    {'kind': 'RULE_MATCH', 'ruleIndex': index, 'ruleId': rule.id})
+                return _get_value_for_variation_or_rollout(flag, rule.variation_or_rollout, context, {'kind': 'RULE_MATCH', 'ruleIndex': index, 'ruleId': rule.id})
 
         # Walk through fallthrough and see if it matches
         return _get_value_for_variation_or_rollout(flag, flag.fallthrough, context, {'kind': 'FALLTHROUGH'})
@@ -146,10 +143,8 @@ class Evaluator:
 
             for prereq in flag.prerequisites:
                 prereq_key = prereq.key
-                if (prereq_key == state.original_flag_key or
-                    (state.prereq_stack is not None and prereq.key in state.prereq_stack)):
-                    raise EvaluationException(('prerequisite relationship to "%s" caused a circular reference;' +
-                        ' this is probably a temporary condition due to an incomplete update') % prereq_key)
+                if prereq_key == state.original_flag_key or (state.prereq_stack is not None and prereq.key in state.prereq_stack):
+                    raise EvaluationException(('prerequisite relationship to "%s" caused a circular reference;' + ' this is probably a temporary condition due to an incomplete update') % prereq_key)
 
                 prereq_flag = self.__get_flag(prereq_key)
                 state.record_prerequisite(prereq_key)
@@ -242,8 +237,7 @@ class Evaluator:
 
     def _segment_matches_context(self, segment: Segment, context: Context, state: EvalResult) -> bool:
         if state.segment_stack is not None and segment.key in state.segment_stack:
-            raise EvaluationException(('segment rule referencing segment "%s" caused a circular reference;' +
-                ' this is probably a temporary condition due to an incomplete update') % segment.key)
+            raise EvaluationException(('segment rule referencing segment "%s" caused a circular reference;' + ' this is probably a temporary condition due to an incomplete update') % segment.key)
         if segment.unbounded:
             return self._big_segment_match_context(segment, context, state)
         return self._simple_segment_match_context(segment, context, state, True)
@@ -337,6 +331,7 @@ class Evaluator:
 # The following functions are declared outside Evaluator because they do not depend on any
 # of Evaluator's state.
 
+
 def _get_variation(flag: FeatureFlag, variation: int, reason: dict) -> EvaluationDetail:
     vars = flag.variations
     if variation < 0 or variation >= len(vars):
@@ -373,14 +368,7 @@ def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, cont
         return None, False
 
     bucket_by = None if rollout.is_experiment else rollout.bucket_by
-    bucket = _bucket_context(
-        rollout.seed,
-        context,
-        rollout.context_kind,
-        flag.key,
-        flag.salt,
-        bucket_by
-        )
+    bucket = _bucket_context(rollout.seed, context, rollout.context_kind, flag.key, flag.salt, bucket_by)
     is_experiment = rollout.is_experiment and bucket >= 0
     # _bucket_context returns a negative value if the context didn't exist, in which case we
     # still end up returning the first bucket, but we will force the "in experiment" state to be false.
@@ -401,14 +389,7 @@ def _variation_index_for_context(flag: FeatureFlag, vr: VariationOrRollout, cont
     return variations[-1].variation, is_experiment_partition
 
 
-def _bucket_context(
-    seed: Optional[int],
-    context: Context,
-    context_kind: Optional[str],
-    key: str,
-    salt: str,
-    bucket_by: Optional[AttributeRef]
-    ) -> float:
+def _bucket_context(seed: Optional[int], context: Context, context_kind: Optional[str], key: str, salt: str, bucket_by: Optional[AttributeRef]) -> float:
     match_context = context.get_individual_context(context_kind or Context.DEFAULT_KIND)
     if match_context is None:
         return -1

--- a/ldclient/impl/events/diagnostics.py
+++ b/ldclient/impl/events/diagnostics.py
@@ -17,9 +17,7 @@ class _DiagnosticAccumulator:
 
     def record_stream_init(self, timestamp, duration, failed):
         with self._state_lock:
-            self._stream_inits.append({'timestamp': timestamp,
-                                       'durationMillis': duration,
-                                       'failed': failed})
+            self._stream_inits.append({'timestamp': timestamp, 'durationMillis': duration, 'failed': failed})
 
     def record_events_in_batch(self, events_in_batch):
         with self._state_lock:
@@ -34,68 +32,62 @@ class _DiagnosticAccumulator:
 
         current_time = int(time.time() * 1000)
         periodic_event = _diagnostic_base_fields('diagnostic', current_time, self.diagnostic_id)
-        periodic_event.update({'dataSinceDate': self.data_since_date,
-                               'droppedEvents': dropped_events,
-                               'deduplicatedUsers': deduplicated_users,
-                               'eventsInLastBatch': events_in_batch,
-                               'streamInits': stream_inits})
+        periodic_event.update(
+            {'dataSinceDate': self.data_since_date, 'droppedEvents': dropped_events, 'deduplicatedUsers': deduplicated_users, 'eventsInLastBatch': events_in_batch, 'streamInits': stream_inits}
+        )
         self.data_since_date = current_time
         return periodic_event
 
 
 def create_diagnostic_id(config):
-    return {'diagnosticId': str(uuid.uuid4()),
-            'sdkKeySuffix': '' if not config.sdk_key else config.sdk_key[-6:]}
+    return {'diagnosticId': str(uuid.uuid4()), 'sdkKeySuffix': '' if not config.sdk_key else config.sdk_key[-6:]}
 
 
 def create_diagnostic_init(creation_date, diagnostic_id, config):
     base_object = _diagnostic_base_fields('diagnostic-init', creation_date, diagnostic_id)
-    base_object.update({'configuration': _create_diagnostic_config_object(config),
-                        'sdk': _create_diagnostic_sdk_object(config),
-                        'platform': _create_diagnostic_platform_object()})
+    base_object.update({'configuration': _create_diagnostic_config_object(config), 'sdk': _create_diagnostic_sdk_object(config), 'platform': _create_diagnostic_platform_object()})
     return base_object
 
 
 def _diagnostic_base_fields(kind, creation_date, diagnostic_id):
-    return {'kind': kind,
-            'creationDate': creation_date,
-            'id': diagnostic_id}
+    return {'kind': kind, 'creationDate': creation_date, 'id': diagnostic_id}
 
 
 def _create_diagnostic_config_object(config):
     default_config = Config("SDK_KEY")
-    return {'customBaseURI': config.base_uri != default_config.base_uri,
-            'customEventsURI': config.events_uri != default_config.events_uri,
-            'customStreamURI': config.stream_base_uri != default_config.stream_base_uri,
-            'eventsCapacity': config.events_max_pending,
-            'connectTimeoutMillis': config.http.connect_timeout * 1000,
-            'socketTimeoutMillis': config.http.read_timeout * 1000,
-            'eventsFlushIntervalMillis': config.flush_interval * 1000,
-            'usingProxy': config.http.http_proxy is not None,
-            'streamingDisabled': not config.stream,
-            'usingRelayDaemon': config.use_ldd,
-            'allAttributesPrivate': config.all_attributes_private,
-            'pollingIntervalMillis': config.poll_interval * 1000,
-            'userKeysCapacity': config.context_keys_capacity,
-            'userKeysFlushIntervalMillis': config.context_keys_flush_interval * 1000,
-            'diagnosticRecordingIntervalMillis': config.diagnostic_recording_interval * 1000,
-            'dataStoreType': _get_component_type_name(config.feature_store, config, 'memory')}
+    return {
+        'customBaseURI': config.base_uri != default_config.base_uri,
+        'customEventsURI': config.events_uri != default_config.events_uri,
+        'customStreamURI': config.stream_base_uri != default_config.stream_base_uri,
+        'eventsCapacity': config.events_max_pending,
+        'connectTimeoutMillis': config.http.connect_timeout * 1000,
+        'socketTimeoutMillis': config.http.read_timeout * 1000,
+        'eventsFlushIntervalMillis': config.flush_interval * 1000,
+        'usingProxy': config.http.http_proxy is not None,
+        'streamingDisabled': not config.stream,
+        'usingRelayDaemon': config.use_ldd,
+        'allAttributesPrivate': config.all_attributes_private,
+        'pollingIntervalMillis': config.poll_interval * 1000,
+        'userKeysCapacity': config.context_keys_capacity,
+        'userKeysFlushIntervalMillis': config.context_keys_flush_interval * 1000,
+        'diagnosticRecordingIntervalMillis': config.diagnostic_recording_interval * 1000,
+        'dataStoreType': _get_component_type_name(config.feature_store, config, 'memory'),
+    }
 
 
 def _create_diagnostic_sdk_object(config):
-    return {'name': 'python-server-sdk',
-            'version': VERSION,
-            'wrapperName': config.wrapper_name,
-            'wrapperVersion': config.wrapper_version}
+    return {'name': 'python-server-sdk', 'version': VERSION, 'wrapperName': config.wrapper_name, 'wrapperVersion': config.wrapper_version}
 
 
 def _create_diagnostic_platform_object():
-    return {'name': 'python',
-            'osArch': platform.machine(),
-            'osName': _normalize_os_name(platform.system()),
-            'osVersion': platform.release(),
-            'pythonVersion': platform.python_version(),
-            'pythonImplementation': platform.python_implementation()}
+    return {
+        'name': 'python',
+        'osArch': platform.machine(),
+        'osName': _normalize_os_name(platform.system()),
+        'osVersion': platform.release(),
+        'pythonVersion': platform.python_version(),
+        'pythonImplementation': platform.python_implementation(),
+    }
 
 
 def _get_component_type_name(component, config, default_name):

--- a/ldclient/impl/events/diagnostics.py
+++ b/ldclient/impl/events/diagnostics.py
@@ -1,7 +1,7 @@
+import platform
 import threading
 import time
 import uuid
-import platform
 
 from ldclient.config import Config
 from ldclient.version import VERSION

--- a/ldclient/impl/events/diagnostics.py
+++ b/ldclient/impl/events/diagnostics.py
@@ -6,6 +6,7 @@ import platform
 from ldclient.config import Config
 from ldclient.version import VERSION
 
+
 class _DiagnosticAccumulator:
     def __init__(self, diagnostic_id):
         self.diagnostic_id = diagnostic_id
@@ -41,9 +42,11 @@ class _DiagnosticAccumulator:
         self.data_since_date = current_time
         return periodic_event
 
+
 def create_diagnostic_id(config):
     return {'diagnosticId': str(uuid.uuid4()),
             'sdkKeySuffix': '' if not config.sdk_key else config.sdk_key[-6:]}
+
 
 def create_diagnostic_init(creation_date, diagnostic_id, config):
     base_object = _diagnostic_base_fields('diagnostic-init', creation_date, diagnostic_id)
@@ -52,10 +55,12 @@ def create_diagnostic_init(creation_date, diagnostic_id, config):
                         'platform': _create_diagnostic_platform_object()})
     return base_object
 
+
 def _diagnostic_base_fields(kind, creation_date, diagnostic_id):
     return {'kind': kind,
             'creationDate': creation_date,
             'id': diagnostic_id}
+
 
 def _create_diagnostic_config_object(config):
     default_config = Config("SDK_KEY")
@@ -76,11 +81,13 @@ def _create_diagnostic_config_object(config):
             'diagnosticRecordingIntervalMillis': config.diagnostic_recording_interval * 1000,
             'dataStoreType': _get_component_type_name(config.feature_store, config, 'memory')}
 
+
 def _create_diagnostic_sdk_object(config):
     return {'name': 'python-server-sdk',
             'version': VERSION,
             'wrapperName': config.wrapper_name,
             'wrapperVersion': config.wrapper_version}
+
 
 def _create_diagnostic_platform_object():
     return {'name': 'python',
@@ -90,12 +97,14 @@ def _create_diagnostic_platform_object():
             'pythonVersion': platform.python_version(),
             'pythonImplementation': platform.python_implementation()}
 
+
 def _get_component_type_name(component, config, default_name):
     if component is not None:
         if callable(getattr(component, 'describe_configuration', None)):
             return component.describe_configuration(config)
         return "custom"
     return default_name
+
 
 def _normalize_os_name(name):
     if name == 'Darwin':

--- a/ldclient/impl/events/event_context_formatter.py
+++ b/ldclient/impl/events/event_context_formatter.py
@@ -6,8 +6,7 @@ from ldclient.impl.model import AttributeRef
 
 class EventContextFormatter:
     IGNORE_ATTRS = frozenset(['key', 'custom', 'anonymous'])
-    ALLOWED_TOP_LEVEL_ATTRS = frozenset(['key', 'secondary', 'ip', 'country', 'email',
-        'firstName', 'lastName', 'avatar', 'name', 'anonymous', 'custom'])
+    ALLOWED_TOP_LEVEL_ATTRS = frozenset(['key', 'secondary', 'ip', 'country', 'email', 'firstName', 'lastName', 'avatar', 'name', 'anonymous', 'custom'])
 
     def __init__(self, all_attributes_private: bool, private_attributes: List[str]):
         self._all_attributes_private = all_attributes_private
@@ -85,8 +84,7 @@ class EventContextFormatter:
                 return True
         return False
 
-    def _redact_json_value(self, parent_path: Optional[List[str]], name: str, value: Any, all_private: List[AttributeRef],
-                           redacted: List[str]) -> Any:
+    def _redact_json_value(self, parent_path: Optional[List[str]], name: str, value: Any, all_private: List[AttributeRef], redacted: List[str]) -> Any:
         if not isinstance(value, dict) or len(value) == 0:
             return value
         ret = {}

--- a/ldclient/impl/events/event_context_formatter.py
+++ b/ldclient/impl/events/event_context_formatter.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
 
 from ldclient.context import Context
 from ldclient.impl.model import AttributeRef

--- a/ldclient/impl/events/event_summarizer.py
+++ b/ldclient/impl/events/event_summarizer.py
@@ -16,9 +16,8 @@ class EventSummaryCounter:
         self.value = value
 
     def __eq__(self, other: Any) -> bool:  # used only in tests
-        return isinstance(other, EventSummaryCounter) and \
-            other.count == self.count and other.value == self.value
-    
+        return isinstance(other, EventSummaryCounter) and other.count == self.count and other.value == self.value
+
     def __repr__(self) -> str:  # used only in test debugging
         return "EventSummaryCounter(%d, %s)" % (self.count, self.value)
 
@@ -32,9 +31,8 @@ class EventSummaryFlag:
         self.default = default
 
     def __eq__(self, other: Any) -> bool:  # used only in tests
-        return isinstance(other, EventSummaryFlag) and \
-            other.context_kinds == self.context_kinds and other.counters == self.counters and other.default == self.default
-    
+        return isinstance(other, EventSummaryFlag) and other.context_kinds == self.context_kinds and other.counters == self.counters and other.default == self.default
+
     def __repr__(self) -> str:  # used only in test debugging
         return "EventSummaryFlag(%s, %s, %s)" % (self.context_kinds, self.counters, self.default)
 
@@ -46,7 +44,7 @@ class EventSummary:
         self.start_date = start_date
         self.end_date = end_date
         self.flags = flags
-    
+
     def is_empty(self) -> bool:
         return len(self.flags) == 0
 
@@ -60,18 +58,19 @@ class EventSummarizer:
     """
     Add this event to our counters, if it is a type of event we need to count.
     """
+
     def summarize_event(self, event: EventInputEvaluation):
         flag_data = self.flags.get(event.key)
         if flag_data is None:
             flag_data = EventSummaryFlag(set(), event.default_value, dict())
             self.flags[event.key] = flag_data
-        
+
         context = event.context
         for i in range(context.individual_context_count):
             c = context.get_individual_context(i)
             if c is not None:
                 flag_data.context_kinds.add(c.kind)
-        
+
         counter_key = (event.variation, None if event.flag is None else event.flag.version)
         counter = flag_data.counters.get(counter_key)
         if counter is None:
@@ -89,8 +88,9 @@ class EventSummarizer:
     """
     Return the current summarized event data.
     """
+
     def snapshot(self):
-        return EventSummary(start_date = self.start_date, end_date = self.end_date, flags = self.flags)
+        return EventSummary(start_date=self.start_date, end_date=self.end_date, flags=self.flags)
 
     def clear(self):
         self.start_date = 0

--- a/ldclient/impl/events/types.py
+++ b/ldclient/impl/events/types.py
@@ -1,11 +1,11 @@
+import json
+from typing import Any, Callable, Optional
+
 from ldclient.context import Context
 from ldclient.evaluation import EvaluationDetail
 from ldclient.impl import AnyNum
 from ldclient.impl.model import FeatureFlag
 from ldclient.impl.util import current_time_millis
-
-import json
-from typing import Any, Callable, Optional
 
 # These event types are not the event data that is sent to LaunchDarkly; they're the input
 # parameters that are passed to EventProcessor, which translates them into event data (for

--- a/ldclient/impl/fixed_thread_pool.py
+++ b/ldclient/impl/fixed_thread_pool.py
@@ -16,7 +16,7 @@ class FixedThreadPool:
         self._event = Event()
         self._job_queue = queue.Queue()
         for i in range(0, size):
-            thread = Thread(target = self._run_worker)
+            thread = Thread(target=self._run_worker)
             thread.name = "%s.%d" % (name, i + 1)
             thread.daemon = True
             thread.start()
@@ -25,6 +25,7 @@ class FixedThreadPool:
     Schedules a job for execution if there is an available worker thread, and returns
     true if successful; returns false if all threads are busy.
     """
+
     def execute(self, jobFn):
         with self._lock:
             if self._busy_count >= self._size:
@@ -36,6 +37,7 @@ class FixedThreadPool:
     """
     Waits until all currently busy worker threads have completed their jobs.
     """
+
     def wait(self):
         while True:
             with self._lock:
@@ -47,13 +49,14 @@ class FixedThreadPool:
     """
     Tells all the worker threads to terminate once all active jobs have completed.
     """
+
     def stop(self):
         for i in range(0, self._size):
             self._job_queue.put('stop')
 
     def _run_worker(self):
         while True:
-            item = self._job_queue.get(block = True)
+            item = self._job_queue.get(block=True)
             if item == 'stop':
                 return
             try:

--- a/ldclient/impl/fixed_thread_pool.py
+++ b/ldclient/impl/fixed_thread_pool.py
@@ -1,5 +1,5 @@
-from threading import Event, Lock, Thread
 import queue
+from threading import Event, Lock, Thread
 
 from ldclient.impl.util import log
 

--- a/ldclient/impl/fixed_thread_pool.py
+++ b/ldclient/impl/fixed_thread_pool.py
@@ -3,10 +3,12 @@ import queue
 
 from ldclient.impl.util import log
 
-"""
-A simple fixed-size thread pool that rejects jobs when its limit is reached.
-"""
+
 class FixedThreadPool:
+    """
+    A simple fixed-size thread pool that rejects jobs when its limit is reached.
+    """
+
     def __init__(self, size, name):
         self._size = size
         self._lock = Lock()

--- a/ldclient/impl/flag_tracker.py
+++ b/ldclient/impl/flag_tracker.py
@@ -1,9 +1,9 @@
-from ldclient.interfaces import FlagTracker, FlagChange, FlagValueChange
-from ldclient.impl.listeners import Listeners
-from ldclient.context import Context
-from ldclient.impl.rwlock import ReadWriteLock
-
 from typing import Callable
+
+from ldclient.context import Context
+from ldclient.impl.listeners import Listeners
+from ldclient.impl.rwlock import ReadWriteLock
+from ldclient.interfaces import FlagChange, FlagTracker, FlagValueChange
 
 
 class FlagValueChangeListener:

--- a/ldclient/impl/http.py
+++ b/ldclient/impl/http.py
@@ -145,7 +145,7 @@ def _get_target_host_and_port(uri: str) -> Tuple[str, int, bool]:
     """
     if '//' not in uri:
         parts = uri.split(':')
-        return (parts[0], int(parts[1]) if len(parts) > 1 else 80, False)
+        return parts[0], int(parts[1]) if len(parts) > 1 else 80, False
 
     parsed = urlparse(uri)
     is_https = parsed.scheme == 'https'

--- a/ldclient/impl/http.py
+++ b/ldclient/impl/http.py
@@ -21,9 +21,7 @@ def _application_header_value(application: dict) -> str:
 
 
 def _base_headers(config):
-    headers = {'Authorization': config.sdk_key or '',
-               'User-Agent': 'PythonClient/' + VERSION
-               }
+    headers = {'Authorization': config.sdk_key or '', 'User-Agent': 'PythonClient/' + VERSION}
 
     app_value = _application_header_value(config.application)
     if app_value:
@@ -46,10 +44,7 @@ class HTTPFactory:
     def __init__(self, base_headers, http_config, override_read_timeout=None):
         self.__base_headers = base_headers
         self.__http_config = http_config
-        self.__timeout = urllib3.Timeout(
-            connect=http_config.connect_timeout,
-            read=http_config.read_timeout if override_read_timeout is None else override_read_timeout
-        )
+        self.__timeout = urllib3.Timeout(connect=http_config.connect_timeout, read=http_config.read_timeout if override_read_timeout is None else override_read_timeout)
 
     @property
     def base_headers(self):
@@ -74,11 +69,7 @@ class HTTPFactory:
             ca_certs = self.__http_config.ca_certs or certifi.where()
 
         if proxy_url is None:
-            return urllib3.PoolManager(
-                num_pools=num_pools,
-                cert_reqs=cert_reqs,
-                ca_certs=ca_certs
-            )
+            return urllib3.PoolManager(num_pools=num_pools, cert_reqs=cert_reqs, ca_certs=ca_certs)
         else:
             # Get proxy authentication, if provided
             url = urllib3.util.parse_url(proxy_url)
@@ -86,13 +77,7 @@ class HTTPFactory:
             if url.auth is not None:
                 proxy_headers = urllib3.util.make_headers(proxy_basic_auth=url.auth)
             # Create a proxied connection
-            return urllib3.ProxyManager(
-                proxy_url,
-                num_pools=num_pools,
-                cert_reqs=cert_reqs,
-                ca_certs=ca_certs,
-                proxy_headers=proxy_headers
-            )
+            return urllib3.ProxyManager(proxy_url, num_pools=num_pools, cert_reqs=cert_reqs, ca_certs=ca_certs, proxy_headers=proxy_headers)
 
 
 def _get_proxy_url(target_base_uri):

--- a/ldclient/impl/http.py
+++ b/ldclient/impl/http.py
@@ -1,9 +1,11 @@
-from ldclient.version import VERSION
-import certifi
 from os import environ
-import urllib3
-from urllib.parse import urlparse
 from typing import Tuple
+from urllib.parse import urlparse
+
+import certifi
+import urllib3
+
+from ldclient.version import VERSION
 
 
 def _application_header_value(application: dict) -> str:

--- a/ldclient/impl/integrations/consul/consul_feature_store.py
+++ b/ldclient/impl/integrations/consul/consul_feature_store.py
@@ -1,4 +1,6 @@
 import json
+from ldclient import log
+from ldclient.interfaces import DiagnosticDescription, FeatureStoreCore
 
 have_consul = False
 try:
@@ -7,11 +9,6 @@ try:
     have_consul = True
 except ImportError:
     pass
-
-from ldclient import log
-from ldclient.feature_store import CacheConfig
-from ldclient.feature_store_helpers import CachingStoreWrapper
-from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStoreCore
 
 #
 # Internal implementation of the Consul feature store.

--- a/ldclient/impl/integrations/consul/consul_feature_store.py
+++ b/ldclient/impl/integrations/consul/consul_feature_store.py
@@ -1,4 +1,5 @@
 import json
+
 from ldclient import log
 from ldclient.interfaces import DiagnosticDescription, FeatureStoreCore
 

--- a/ldclient/impl/integrations/consul/consul_feature_store.py
+++ b/ldclient/impl/integrations/consul/consul_feature_store.py
@@ -12,11 +12,11 @@ from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
 from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStoreCore
 
-# 
+#
 # Internal implementation of the Consul feature store.
-# 
+#
 # Implementation notes:
-# 
+#
 # * Feature flags, segments, and any other kind of entity the LaunchDarkly client may wish
 # to store, are stored as individual items with the key "{prefix}/features/{flag-key}",
 # "{prefix}/segments/{segment-key}", etc.
@@ -31,7 +31,8 @@ from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStor
 # deleting new data from another process, but that would be the case anyway if the Init
 # happened to execute later than the Upsert; we are relying on the fact that normally the
 # process that did the Init will also receive the new data shortly and do its own Upsert.
-# 
+#
+
 
 class _ConsulFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
     def __init__(self, host, port, prefix, consul_opts):
@@ -74,7 +75,7 @@ class _ConsulFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
         # Now delete any previously existing items whose keys were not in the current data
         for key in unused_old_keys:
             self._client.kv.delete(key)
-        
+
         # Now set the special key that we check in initialized_internal()
         self._client.kv.put(inited_key, "")
 
@@ -124,7 +125,7 @@ class _ConsulFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
 
     def describe_configuration(self, config):
         return 'Consul'
-    
+
     def _kind_key(self, kind):
         return self._prefix + kind.namespace
 

--- a/ldclient/impl/integrations/consul/consul_feature_store.py
+++ b/ldclient/impl/integrations/consul/consul_feature_store.py
@@ -3,6 +3,7 @@ import json
 have_consul = False
 try:
     import consul
+
     have_consul = True
 except ImportError:
     pass

--- a/ldclient/impl/integrations/consul/consul_feature_store.py
+++ b/ldclient/impl/integrations/consul/consul_feature_store.py
@@ -120,7 +120,7 @@ class _ConsulFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
 
     def initialized_internal(self):
         index, resp = self._client.kv.get(self._inited_key())
-        return (resp is not None)
+        return resp is not None
 
     def describe_configuration(self, config):
         return 'Consul'
@@ -132,4 +132,4 @@ class _ConsulFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
         return self._kind_key(kind) + '/' + key
 
     def _inited_key(self):
-        return self._prefix + ('$inited')
+        return self._prefix + '$inited'

--- a/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
@@ -1,3 +1,6 @@
+from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
+from typing import List, Optional
+
 have_dynamodb = False
 try:
     import boto3
@@ -5,10 +8,6 @@ try:
     have_dynamodb = True
 except ImportError:
     pass
-
-from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
-
-from typing import List, Optional
 
 
 class _DynamoDBBigSegmentStore(BigSegmentStore):

--- a/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
@@ -1,5 +1,6 @@
-from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 from typing import List, Optional
+
+from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 
 have_dynamodb = False
 try:

--- a/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
@@ -1,4 +1,3 @@
-
 have_dynamodb = False
 try:
     import boto3
@@ -67,9 +66,9 @@ class _DynamoDBBigSegmentStore(BigSegmentStore):
     def stop(self):
         pass
 
+
 def _get_string_list(item: dict, attr_name: str) -> Optional[List[str]]:
     attr = item.get(attr_name)
     if attr is None:
         return None
     return attr.get('SS')
-   

--- a/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_big_segment_store.py
@@ -1,6 +1,7 @@
 have_dynamodb = False
 try:
     import boto3
+
     have_dynamodb = True
 except ImportError:
     pass
@@ -28,10 +29,7 @@ class _DynamoDBBigSegmentStore(BigSegmentStore):
 
     def get_metadata(self) -> BigSegmentStoreMetadata:
         key = self._prefix + self.KEY_METADATA
-        data = self._client.get_item(TableName=self._table_name, Key={
-            self.PARTITION_KEY: { "S": key },
-            self.SORT_KEY: { "S": key }
-        })
+        data = self._client.get_item(TableName=self._table_name, Key={self.PARTITION_KEY: {"S": key}, self.SORT_KEY: {"S": key}})
         if data is not None:
             item = data.get('Item')
             if item is not None:
@@ -42,10 +40,7 @@ class _DynamoDBBigSegmentStore(BigSegmentStore):
         return BigSegmentStoreMetadata(None)
 
     def get_membership(self, user_hash: str) -> Optional[dict]:
-        data = self._client.get_item(TableName=self._table_name, Key={
-            self.PARTITION_KEY: { "S": self._prefix + self.KEY_USER_DATA },
-            self.SORT_KEY: { "S": user_hash }
-        })
+        data = self._client.get_item(TableName=self._table_name, Key={self.PARTITION_KEY: {"S": self._prefix + self.KEY_USER_DATA}, self.SORT_KEY: {"S": user_hash}})
         if data is not None:
             item = data.get('Item')
             if item is not None:

--- a/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
@@ -1,4 +1,6 @@
 import json
+from ldclient import log
+from ldclient.interfaces import FeatureStoreCore
 
 have_dynamodb = False
 try:
@@ -8,10 +10,6 @@ try:
 except ImportError:
     pass
 
-from ldclient import log
-from ldclient.feature_store import CacheConfig
-from ldclient.feature_store_helpers import CachingStoreWrapper
-from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStoreCore
 
 #
 # Internal implementation of the DynamoDB feature store.
@@ -181,5 +179,5 @@ class _DynamoDBHelpers:
     @staticmethod
     def batch_write_requests(client, table_name, requests):
         batch_size = 25
-        for batch in (requests[i : i + batch_size] for i in range(0, len(requests), batch_size)):
+        for batch in (requests[i: i + batch_size] for i in range(0, len(requests), batch_size)):
             client.batch_write_item(RequestItems={table_name: batch})

--- a/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
@@ -1,4 +1,5 @@
 import json
+
 from ldclient import log
 from ldclient.interfaces import FeatureStoreCore
 

--- a/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
@@ -40,6 +40,7 @@ from ldclient.interfaces import DiagnosticDescription, FeatureStore, FeatureStor
 # stored as a single item, this mechanism will not work for extremely large flags or segments.
 #
 
+
 class _DynamoDBFeatureStoreCore(FeatureStoreCore):
     PARTITION_KEY = 'namespace'
     SORT_KEY = 'key'

--- a/ldclient/impl/integrations/files/file_data_source.py
+++ b/ldclient/impl/integrations/files/file_data_source.py
@@ -1,11 +1,14 @@
 import json
 import os
-import traceback
 import time
+import traceback
 from typing import Optional
+
 from ldclient.impl.repeating_task import RepeatingTask
 from ldclient.impl.util import log
-from ldclient.interfaces import UpdateProcessor, DataSourceUpdateSink, DataSourceState, DataSourceErrorInfo, DataSourceErrorKind
+from ldclient.interfaces import (DataSourceErrorInfo, DataSourceErrorKind,
+                                 DataSourceState, DataSourceUpdateSink,
+                                 UpdateProcessor)
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 have_yaml = False

--- a/ldclient/impl/integrations/files/file_data_source.py
+++ b/ldclient/impl/integrations/files/file_data_source.py
@@ -7,6 +7,7 @@ from typing import Optional
 have_yaml = False
 try:
     import yaml
+
     have_yaml = True
 except ImportError:
     pass
@@ -16,6 +17,7 @@ try:
     import watchdog
     import watchdog.events
     import watchdog.observers
+
     have_watchdog = True
 except ImportError:
     pass
@@ -39,7 +41,7 @@ class _FileDataSource(UpdateProcessor):
         self._inited = False
         self._paths = paths
         if isinstance(self._paths, str):
-            self._paths = [ self._paths ]
+            self._paths = [self._paths]
         self._auto_update = auto_update
         self._auto_updater = None
         self._poll_interval = poll_interval
@@ -80,7 +82,7 @@ class _FileDataSource(UpdateProcessor):
         return self._inited
 
     def _load_all(self):
-        all_data = { FEATURES: {}, SEGMENTS: {} }
+        all_data = {FEATURES: {}, SEGMENTS: {}}
         for path in self._paths:
             try:
                 self._load_file(path, all_data)
@@ -88,10 +90,7 @@ class _FileDataSource(UpdateProcessor):
                 log.error('Unable to load flag data from "%s": %s' % (path, repr(e)))
                 traceback.print_exc()
                 if self._data_source_update_sink is not None:
-                    self._data_source_update_sink.update_status(
-                        DataSourceState.INTERRUPTED,
-                        DataSourceErrorInfo(DataSourceErrorKind.INVALID_DATA, 0, time.time, str(e))
-                    )
+                    self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.INVALID_DATA, 0, time.time, str(e)))
                 return
         try:
             self._sink_or_store().init(all_data)
@@ -102,10 +101,7 @@ class _FileDataSource(UpdateProcessor):
             log.error('Unable to store data: %s' % repr(e))
             traceback.print_exc()
             if self._data_source_update_sink is not None:
-                self._data_source_update_sink.update_status(
-                    DataSourceState.INTERRUPTED,
-                    DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time, str(e))
-                )
+                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time, str(e)))
 
     def _load_file(self, path, all_data):
         content = None
@@ -135,15 +131,7 @@ class _FileDataSource(UpdateProcessor):
             raise Exception('In %s, key "%s" was used more than once' % (kind.namespace, key))
 
     def _make_flag_with_value(self, key, value):
-        return {
-            'key': key,
-            'version': 1,
-            'on': True,
-            'fallthrough': {
-                'variation': 0
-            },
-            'variations': [ value ]
-        }
+        return {'key': key, 'version': 1, 'on': True, 'fallthrough': {'variation': 0}, 'variations': [value]}
 
     def _start_auto_updater(self):
         resolved_paths = []

--- a/ldclient/impl/integrations/files/file_data_source.py
+++ b/ldclient/impl/integrations/files/file_data_source.py
@@ -3,6 +3,10 @@ import os
 import traceback
 import time
 from typing import Optional
+from ldclient.impl.repeating_task import RepeatingTask
+from ldclient.impl.util import log
+from ldclient.interfaces import UpdateProcessor, DataSourceUpdateSink, DataSourceState, DataSourceErrorInfo, DataSourceErrorKind
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 have_yaml = False
 try:
@@ -21,11 +25,6 @@ try:
     have_watchdog = True
 except ImportError:
     pass
-
-from ldclient.impl.repeating_task import RepeatingTask
-from ldclient.impl.util import log
-from ldclient.interfaces import UpdateProcessor, DataSourceUpdateSink, DataSourceState, DataSourceErrorInfo, DataSourceErrorKind
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 
 def _sanitize_json_item(item):
@@ -138,7 +137,7 @@ class _FileDataSource(UpdateProcessor):
         for path in self._paths:
             try:
                 resolved_paths.append(os.path.realpath(path))
-            except:
+            except Exception:
                 log.warning('Cannot watch for changes to data file "%s" because it is an invalid path' % path)
         if have_watchdog and not self._force_polling:
             return _FileDataSource.WatchdogAutoUpdater(resolved_paths, self._load_all)
@@ -199,6 +198,6 @@ class _FileDataSource(UpdateProcessor):
             for path in self._paths:
                 try:
                     ret[path] = os.path.getmtime(path)
-                except:
+                except Exception:
                     ret[path] = None
             return ret

--- a/ldclient/impl/integrations/redis/redis_big_segment_store.py
+++ b/ldclient/impl/integrations/redis/redis_big_segment_store.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Dict, Set, cast
 have_redis = False
 try:
     import redis
+
     have_redis = True
 except ImportError:
     pass

--- a/ldclient/impl/integrations/redis/redis_big_segment_store.py
+++ b/ldclient/impl/integrations/redis/redis_big_segment_store.py
@@ -1,8 +1,8 @@
-from ldclient import log
-from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
-from ldclient.impl.util import redact_password
+from typing import Any, Dict, Optional, Set, cast
 
-from typing import Any, Optional, Dict, Set, cast
+from ldclient import log
+from ldclient.impl.util import redact_password
+from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 
 have_redis = False
 try:

--- a/ldclient/impl/integrations/redis/redis_feature_store.py
+++ b/ldclient/impl/integrations/redis/redis_feature_store.py
@@ -3,6 +3,7 @@ import json
 have_redis = False
 try:
     import redis
+
     have_redis = True
 except ImportError:
     pass
@@ -36,7 +37,7 @@ class _RedisFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
 
     def init_internal(self, all_data):
         pipe = redis.Redis(connection_pool=self._pool).pipeline()
-        
+
         all_count = 0
 
         for kind, items in all_data.items():
@@ -85,9 +86,14 @@ class _RedisFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
             if self.test_update_hook is not None:
                 self.test_update_hook(base_key, key)
             if old and old['version'] >= item['version']:
-                log.debug('RedisFeatureStore: Attempted to %s key: %s version %d with a version that is the same or older: %d in "%s"',
+                log.debug(
+                    'RedisFeatureStore: Attempted to %s key: %s version %d with a version that is the same or older: %d in "%s"',
                     'delete' if item.get('deleted') else 'update',
-                    key, old['version'], item['version'], kind.namespace)
+                    key,
+                    old['version'],
+                    item['version'],
+                    kind.namespace,
+                )
                 pipeline.unwatch()
                 return old
             else:
@@ -108,7 +114,7 @@ class _RedisFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
 
     def describe_configuration(self, config):
         return 'Redis'
-    
+
     def _before_update_transaction(self, base_key, key):
         # exposed for testing
         pass

--- a/ldclient/impl/integrations/redis/redis_feature_store.py
+++ b/ldclient/impl/integrations/redis/redis_feature_store.py
@@ -1,9 +1,10 @@
 import json
+from typing import Any, Dict
+
 from ldclient import log
+from ldclient.impl.util import redact_password
 from ldclient.interfaces import DiagnosticDescription, FeatureStoreCore
 from ldclient.versioned_data_kind import FEATURES
-from ldclient.impl.util import redact_password
-from typing import Any, Dict
 
 have_redis = False
 try:

--- a/ldclient/impl/integrations/redis/redis_feature_store.py
+++ b/ldclient/impl/integrations/redis/redis_feature_store.py
@@ -1,4 +1,9 @@
 import json
+from ldclient import log
+from ldclient.interfaces import DiagnosticDescription, FeatureStoreCore
+from ldclient.versioned_data_kind import FEATURES
+from ldclient.impl.util import redact_password
+from typing import Any, Dict
 
 have_redis = False
 try:
@@ -7,13 +12,6 @@ try:
     have_redis = True
 except ImportError:
     pass
-
-from ldclient import log
-from ldclient.interfaces import DiagnosticDescription, FeatureStoreCore
-from ldclient.versioned_data_kind import FEATURES
-from ldclient.impl.util import redact_password
-
-from typing import Any, Dict
 
 
 class _RedisFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):

--- a/ldclient/impl/integrations/test_data/test_data_source.py
+++ b/ldclient/impl/integrations/test_data/test_data_source.py
@@ -1,5 +1,5 @@
-from ldclient.versioned_data_kind import FEATURES
 from ldclient.interfaces import UpdateProcessor
+from ldclient.versioned_data_kind import FEATURES
 
 # This is the internal component that's created when you initialize an SDK instance that is using
 # TestData. The TestData object manages the setup of the fake data, and it broadcasts the data

--- a/ldclient/impl/integrations/test_data/test_data_source.py
+++ b/ldclient/impl/integrations/test_data/test_data_source.py
@@ -6,6 +6,7 @@ from ldclient.interfaces import UpdateProcessor
 # through _TestDataSource to inject it into the SDK. If there are multiple SDK instances connected
 # to a TestData, each has its own _TestDataSource.
 
+
 class _TestDataSource(UpdateProcessor):
 
     def __init__(self, feature_store, test_data, ready):

--- a/ldclient/impl/listeners.py
+++ b/ldclient/impl/listeners.py
@@ -1,7 +1,7 @@
-from ldclient.impl.util import log
-
 from threading import RLock
 from typing import Any, Callable
+
+from ldclient.impl.util import log
 
 
 class Listeners:

--- a/ldclient/impl/lru_cache.py
+++ b/ldclient/impl/lru_cache.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+
 class SimpleLRUCache:
     """A dictionary-based cache that removes the oldest entries when its limit is exceeded.
     Values are only refreshed by writing, not by reading. Not thread-safe.

--- a/ldclient/impl/lru_cache.py
+++ b/ldclient/impl/lru_cache.py
@@ -5,6 +5,7 @@ class SimpleLRUCache:
     """A dictionary-based cache that removes the oldest entries when its limit is exceeded.
     Values are only refreshed by writing, not by reading. Not thread-safe.
     """
+
     def __init__(self, capacity):
         self.capacity = capacity
         self.cache = OrderedDict()
@@ -16,8 +17,9 @@ class SimpleLRUCache:
     Stores a value in the cache, evicting an old entry if necessary. Returns true if
     the item already existed, or false if it was newly added.
     '''
+
     def put(self, key, value):
-        found = (key in self.cache)
+        found = key in self.cache
         if found:
             self.cache.move_to_end(key)
         else:

--- a/ldclient/impl/model/attribute_ref.py
+++ b/ldclient/impl/model/attribute_ref.py
@@ -8,6 +8,7 @@ def req_attr_ref_with_opt_context_kind(attr_ref_str: str, context_kind: Optional
         return AttributeRef.from_literal(attr_ref_str)
     return AttributeRef.from_path(attr_ref_str)
 
+
 def opt_attr_ref_with_opt_context_kind(attr_ref_str: Optional[str], context_kind: Optional[str]) -> Optional[AttributeRef]:
     if attr_ref_str is None or attr_ref_str == '':
         return None
@@ -41,11 +42,11 @@ class AttributeRef:
     @property
     def error(self) -> Optional[str]:
         return self._error
-    
+
     @property
     def path(self) -> str:
         return self._raw
-    
+
     @property
     def depth(self) -> int:
         if self._error is not None:
@@ -53,7 +54,7 @@ class AttributeRef:
         if self._components is not None:
             return len(self._components)
         return 1
-    
+
     def __getitem__(self, index) -> Optional[str]:
         if self._error is not None:
             return None

--- a/ldclient/impl/model/attribute_ref.py
+++ b/ldclient/impl/model/attribute_ref.py
@@ -23,13 +23,7 @@ class AttributeRef:
 
     _ERR_EMPTY = 'attribute reference cannot be empty'
 
-    def __init__(
-        self,
-        raw: str,
-        single_component: Optional[str],
-        components: Optional[List[str]],
-        error: Optional[str]
-    ):
+    def __init__(self, raw: str, single_component: Optional[str], components: Optional[List[str]], error: Optional[str]):
         self._raw = raw
         self._single_component = single_component
         self._components = components

--- a/ldclient/impl/model/attribute_ref.py
+++ b/ldclient/impl/model/attribute_ref.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import re
 from typing import List, Optional
 

--- a/ldclient/impl/model/clause.py
+++ b/ldclient/impl/model/clause.py
@@ -6,6 +6,7 @@ from ldclient.impl.model.attribute_ref import AttributeRef, req_attr_ref_with_op
 from ldclient.impl.model.entity import *
 from ldclient.impl.model.value_parsing import parse_regex, parse_semver, parse_time
 
+
 class ClausePreprocessedValue:
     __slots__ = ['_as_time', '_as_regex', '_as_semver']
 
@@ -13,15 +14,15 @@ class ClausePreprocessedValue:
         self._as_time = as_time
         self._as_regex = as_regex
         self._as_semver = as_semver
-    
+
     @property
     def as_time(self) -> Optional[float]:
         return self._as_time
-    
+
     @property
     def as_regex(self) -> Optional[Pattern]:
         return self._as_regex
-    
+
     @property
     def as_semver(self) -> Optional[VersionInfo]:
         return self._as_semver
@@ -36,7 +37,7 @@ def _preprocess_clause_values(op: str, values: List[Any]) -> Optional[List[Claus
         return list(ClausePreprocessedValue(as_semver=parse_semver(value)) for value in values)
     return None
 
-    
+
 class Clause:
     __slots__ = ['_context_kind', '_attribute', '_op', '_negate', '_values', '_values_preprocessed']
 
@@ -59,7 +60,7 @@ class Clause:
     @property
     def negate(self) -> bool:
         return self._negate
-    
+
     @property
     def op(self) -> str:
         return self._op

--- a/ldclient/impl/model/clause.py
+++ b/ldclient/impl/model/clause.py
@@ -10,7 +10,7 @@ from ldclient.impl.model.value_parsing import parse_regex, parse_semver, parse_t
 class ClausePreprocessedValue:
     __slots__ = ['_as_time', '_as_regex', '_as_semver']
 
-    def __init__(self, as_time: Optional[float]=None, as_regex: Optional[Pattern]=None, as_semver: Optional[VersionInfo]=None):
+    def __init__(self, as_time: Optional[float] = None, as_regex: Optional[Pattern] = None, as_semver: Optional[VersionInfo] = None):
         self._as_time = as_time
         self._as_regex = as_regex
         self._as_semver = as_semver

--- a/ldclient/impl/model/clause.py
+++ b/ldclient/impl/model/clause.py
@@ -1,10 +1,13 @@
 from re import Pattern
-from semver import VersionInfo
 from typing import Any, List, Optional
 
-from ldclient.impl.model.attribute_ref import AttributeRef, req_attr_ref_with_opt_context_kind
+from semver import VersionInfo
+
+from ldclient.impl.model.attribute_ref import (
+    AttributeRef, req_attr_ref_with_opt_context_kind)
 from ldclient.impl.model.entity import *
-from ldclient.impl.model.value_parsing import parse_regex, parse_semver, parse_time
+from ldclient.impl.model.value_parsing import (parse_regex, parse_semver,
+                                               parse_time)
 
 
 class ClausePreprocessedValue:

--- a/ldclient/impl/model/encoder.py
+++ b/ldclient/impl/model/encoder.py
@@ -2,6 +2,7 @@ from ldclient.impl.model.entity import ModelEntity
 
 import json
 
+
 class ModelEncoder(json.JSONEncoder):
     """
     A JSON encoder customized to serialize our data model types correctly. We should

--- a/ldclient/impl/model/encoder.py
+++ b/ldclient/impl/model/encoder.py
@@ -1,6 +1,6 @@
-from ldclient.impl.model.entity import ModelEntity
-
 import json
+
+from ldclient.impl.model.entity import ModelEntity
 
 
 class ModelEncoder(json.JSONEncoder):

--- a/ldclient/impl/model/encoder.py
+++ b/ldclient/impl/model/encoder.py
@@ -10,7 +10,7 @@ class ModelEncoder(json.JSONEncoder):
     """
 
     def __init__(self):
-        super().__init__(separators=(',',':'))
+        super().__init__(separators=(',', ':'))
 
     def default(self, obj):
         if isinstance(obj, ModelEntity):

--- a/ldclient/impl/model/entity.py
+++ b/ldclient/impl/model/entity.py
@@ -18,6 +18,7 @@ from typing import Any, List, Optional, Union
 # invalid types to get into the evaluation/event logic where they would cause errors that
 # are harder to diagnose.
 
+
 def opt_type(data: dict, name: str, desired_type) -> Any:
     value = data.get(name)
     if value is not None and not isinstance(value, desired_type):
@@ -25,17 +26,22 @@ def opt_type(data: dict, name: str, desired_type) -> Any:
             (name, desired_type, value.__class__))
     return value
 
+
 def opt_bool(data: dict, name: str) -> bool:
     return opt_type(data, name, bool) is True
+
 
 def opt_dict(data: dict, name: str) -> Optional[dict]:
     return opt_type(data, name, dict)
 
+
 def opt_dict_list(data: dict, name: str) -> list:
     return validate_list_type(opt_list(data, name), name, dict)
 
+
 def opt_int(data: dict, name: str) -> Optional[int]:
     return opt_type(data, name, int)
+
 
 def opt_number(data: dict, name: str) -> Optional[Union[int, float]]:
     value = data.get(name)
@@ -44,14 +50,18 @@ def opt_number(data: dict, name: str) -> Optional[Union[int, float]]:
             (name, value.__class__))
     return value
 
+
 def opt_list(data: dict, name: str) -> list:
     return opt_type(data, name, list) or []
+
 
 def opt_str(data: dict, name: str) -> Optional[str]:
     return opt_type(data, name, str)
 
+
 def opt_str_list(data: dict, name: str) -> List[str]:
     return validate_list_type(opt_list(data, name), name, str)
+
 
 def req_type(data: dict, name: str, desired_type) -> Any:
     value = opt_type(data, name, desired_type)
@@ -59,20 +69,26 @@ def req_type(data: dict, name: str, desired_type) -> Any:
         raise ValueError('error in flag/segment data: required property "%s" is missing' %  name)
     return value
 
+
 def req_dict_list(data: dict, name: str) -> list:
     return validate_list_type(req_list(data, name), name, dict)
+
 
 def req_int(data: dict, name: str) -> int:
     return req_type(data, name, int)
 
+
 def req_list(data: dict, name: str) -> list:
     return req_type(data, name, list)
+
 
 def req_str(data: dict, name: str) -> str:
     return req_type(data, name, str)
 
+
 def req_str_list(data: dict, name: str) -> List[str]:
     return validate_list_type(req_list(data, name), name, str)
+
 
 def validate_list_type(items: list, name: str, desired_type) -> list:
     for item in items:
@@ -85,7 +101,7 @@ def validate_list_type(items: list, name: str, desired_type) -> list:
 class ModelEntity:
     def __init__(self, data: dict):
         self._data = data
-    
+
     def to_json_dict(self):
         return self._data
 

--- a/ldclient/impl/model/entity.py
+++ b/ldclient/impl/model/entity.py
@@ -22,8 +22,7 @@ from typing import Any, List, Optional, Union
 def opt_type(data: dict, name: str, desired_type) -> Any:
     value = data.get(name)
     if value is not None and not isinstance(value, desired_type):
-        raise ValueError('error in flag/segment data: property "%s" should be type %s but was %s"' % \
-            (name, desired_type, value.__class__))
+        raise ValueError('error in flag/segment data: property "%s" should be type %s but was %s"' % (name, desired_type, value.__class__))
     return value
 
 
@@ -46,8 +45,7 @@ def opt_int(data: dict, name: str) -> Optional[int]:
 def opt_number(data: dict, name: str) -> Optional[Union[int, float]]:
     value = data.get(name)
     if value is not None and not isinstance(value, int) and not isinstance(value, float):
-        raise ValueError('error in flag/segment data: property "%s" should be a number but was %s"' % \
-            (name, value.__class__))
+        raise ValueError('error in flag/segment data: property "%s" should be a number but was %s"' % (name, value.__class__))
     return value
 
 
@@ -66,7 +64,7 @@ def opt_str_list(data: dict, name: str) -> List[str]:
 def req_type(data: dict, name: str, desired_type) -> Any:
     value = opt_type(data, name, desired_type)
     if value is None:
-        raise ValueError('error in flag/segment data: required property "%s" is missing' %  name)
+        raise ValueError('error in flag/segment data: required property "%s" is missing' % name)
     return value
 
 
@@ -93,8 +91,7 @@ def req_str_list(data: dict, name: str) -> List[str]:
 def validate_list_type(items: list, name: str, desired_type) -> list:
     for item in items:
         if not isinstance(item, desired_type):
-            raise ValueError('error in flag/segment data: property %s should be an array of %s but an item was %s' % \
-                (name, desired_type, item.__class__))
+            raise ValueError('error in flag/segment data: property %s should be an array of %s but an item was %s' % (name, desired_type, item.__class__))
     return items
 
 
@@ -105,7 +102,7 @@ class ModelEntity:
     def to_json_dict(self):
         return self._data
 
-    def get(self, attribute, default = None) -> Any:
+    def get(self, attribute, default=None) -> Any:
         return self._data.get(attribute, default)
 
     def __getitem__(self, attribute) -> Any:
@@ -118,4 +115,4 @@ class ModelEntity:
         return self.__class__ == other.__class__ and self._data == other._data
 
     def __repr__(self) -> str:
-        return json.dumps(self._data, separators=(',',':'))
+        return json.dumps(self._data, separators=(',', ':'))

--- a/ldclient/impl/model/entity.py
+++ b/ldclient/impl/model/entity.py
@@ -1,5 +1,4 @@
 import json
-
 from typing import Any, List, Optional, Union
 
 # This file provides support for our data model classes.

--- a/ldclient/impl/model/feature_flag.py
+++ b/ldclient/impl/model/feature_flag.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Set, Union, Dict
+from typing import Any, Dict, List, Optional, Set, Union
 
 from ldclient.impl.model.clause import Clause
 from ldclient.impl.model.entity import *

--- a/ldclient/impl/model/feature_flag.py
+++ b/ldclient/impl/model/feature_flag.py
@@ -80,9 +80,23 @@ class MigrationSettings:
 
 
 class FeatureFlag(ModelEntity):
-    __slots__ = ['_data', '_key', '_version', '_deleted', '_variations', '_on',
-        '_off_variation', '_fallthrough', '_prerequisites', '_targets', '_context_targets', '_rules',
-        '_salt', '_track_events', '_debug_events_until_date']
+    __slots__ = [
+        '_data',
+        '_key',
+        '_version',
+        '_deleted',
+        '_variations',
+        '_on',
+        '_off_variation',
+        '_fallthrough',
+        '_prerequisites',
+        '_targets',
+        '_context_targets',
+        '_rules',
+        '_salt',
+        '_track_events',
+        '_debug_events_until_date',
+    ]
 
     def __init__(self, data: dict):
         super().__init__(data)

--- a/ldclient/impl/model/segment.py
+++ b/ldclient/impl/model/segment.py
@@ -8,14 +8,14 @@ from ldclient.impl.model.entity import *
 class SegmentTarget:
     __slots__ = ['_context_kind', '_values']
 
-    def __init__(self, data: dict, logger = None):
+    def __init__(self, data: dict, logger=None):
         self._context_kind = opt_str(data, 'contextKind')
         self._values = set(req_str_list(data, 'values'))
-    
+
     @property
     def context_kind(self) -> Optional[str]:
         return self._context_kind
-    
+
     @property
     def values(self) -> Set[str]:
         return self._values
@@ -41,16 +41,28 @@ class SegmentRule:
     @property
     def rollout_context_kind(self) -> Optional[str]:
         return self._rollout_context_kind
-    
+
     @property
     def weight(self) -> Optional[int]:
         return self._weight
 
 
 class Segment(ModelEntity):
-    __slots__ = ['_data', '_key', '_version', '_deleted', '_included', '_excluded',
-        '_included_contexts', '_excluded_contexts', '_rules', '_salt', '_unbounded',
-        '_unbounded_context_kind', '_generation']
+    __slots__ = [
+        '_data',
+        '_key',
+        '_version',
+        '_deleted',
+        '_included',
+        '_excluded',
+        '_included_contexts',
+        '_excluded_contexts',
+        '_rules',
+        '_salt',
+        '_unbounded',
+        '_unbounded_context_kind',
+        '_generation',
+    ]
 
     def __init__(self, data: dict):
         super().__init__(data)
@@ -72,11 +84,11 @@ class Segment(ModelEntity):
         self._unbounded = opt_bool(data, 'unbounded')
         self._unbounded_context_kind = opt_str(data, 'unboundedContextKind')
         self._generation = opt_int(data, 'generation')
-    
+
     @property
     def key(self) -> str:
         return self._key
-    
+
     @property
     def version(self) -> int:
         return self._version
@@ -84,11 +96,11 @@ class Segment(ModelEntity):
     @property
     def deleted(self) -> bool:
         return self._deleted
-    
+
     @property
     def included(self) -> Set[str]:
         return self._included
-    
+
     @property
     def excluded(self) -> Set[str]:
         return self._excluded
@@ -100,19 +112,19 @@ class Segment(ModelEntity):
     @property
     def excluded_contexts(self) -> List[SegmentTarget]:
         return self._excluded_contexts
-    
+
     @property
     def rules(self) -> List[Any]:
         return self._rules
-    
+
     @property
     def salt(self) -> str:
         return self._salt
-    
+
     @property
     def unbounded(self) -> bool:
         return self._unbounded
-    
+
     @property
     def unbounded_context_kind(self) -> Optional[str]:
         return self._unbounded_context_kind

--- a/ldclient/impl/model/segment.py
+++ b/ldclient/impl/model/segment.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional, Set
 
-from ldclient.impl.model.attribute_ref import AttributeRef, opt_attr_ref_with_opt_context_kind
+from ldclient.impl.model.attribute_ref import (
+    AttributeRef, opt_attr_ref_with_opt_context_kind)
 from ldclient.impl.model.clause import Clause
 from ldclient.impl.model.entity import *
 

--- a/ldclient/impl/model/value_parsing.py
+++ b/ldclient/impl/model/value_parsing.py
@@ -1,11 +1,11 @@
 import re
-from re import Pattern
-from semver import VersionInfo
-from datetime import tzinfo, timedelta, datetime, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 from numbers import Number
+from re import Pattern
 from typing import Any, Optional
 
 import pyrfc3339
+from semver import VersionInfo
 
 _ZERO = timedelta(0)
 

--- a/ldclient/impl/model/value_parsing.py
+++ b/ldclient/impl/model/value_parsing.py
@@ -60,6 +60,7 @@ def parse_time(input: Any) -> Optional[float]:
 
     return None
 
+
 def parse_semver(input: Any) -> Optional[VersionInfo]:
     if not isinstance(input, str):
         return None
@@ -78,6 +79,7 @@ def parse_semver(input: Any) -> Optional[VersionInfo]:
                 return input
             except ValueError as e:
                 return None
+
 
 def _add_zero_version_component(input):
     m = re.search("^([0-9.]*)(.*)", input)

--- a/ldclient/impl/model/value_parsing.py
+++ b/ldclient/impl/model/value_parsing.py
@@ -76,7 +76,6 @@ def parse_semver(input: Any) -> Optional[VersionInfo]:
             try:
                 input = _add_zero_version_component(input)
                 return VersionInfo.parse(input)
-                return input
             except ValueError as e:
                 return None
 

--- a/ldclient/impl/model/variation_or_rollout.py
+++ b/ldclient/impl/model/variation_or_rollout.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
-from ldclient.impl.model.attribute_ref import AttributeRef, opt_attr_ref_with_opt_context_kind
+from ldclient.impl.model.attribute_ref import (
+    AttributeRef, opt_attr_ref_with_opt_context_kind)
 from ldclient.impl.model.entity import *
 
 

--- a/ldclient/impl/operators.py
+++ b/ldclient/impl/operators.py
@@ -15,8 +15,7 @@ def _numeric_operator(context_value: Any, clause_value: Any, fn: Callable[[float
     return is_number(context_value) and is_number(clause_value) and fn(float(context_value), float(clause_value))
 
 
-def _time_operator(clause_preprocessed: Optional[ClausePreprocessedValue],
-        context_value: Any, fn: Callable[[float, float], bool]) -> bool:
+def _time_operator(clause_preprocessed: Optional[ClausePreprocessedValue], context_value: Any, fn: Callable[[float, float], bool]) -> bool:
     clause_time = None if clause_preprocessed is None else clause_preprocessed.as_time
     if clause_time is None:
         return False
@@ -24,8 +23,7 @@ def _time_operator(clause_preprocessed: Optional[ClausePreprocessedValue],
     return context_time is not None and fn(context_time, clause_time)
 
 
-def _semver_operator(clause_preprocessed: Optional[ClausePreprocessedValue],
-        context_value: Any, fn: Callable[[VersionInfo, VersionInfo], bool]) -> bool:
+def _semver_operator(clause_preprocessed: Optional[ClausePreprocessedValue], context_value: Any, fn: Callable[[VersionInfo, VersionInfo], bool]) -> bool:
     clause_ver = None if clause_preprocessed is None else clause_preprocessed.as_semver
     if clause_ver is None:
         return False
@@ -106,7 +104,7 @@ ops = {
     "after": _after,
     "semVerEqual": _semver_equal,
     "semVerLessThan": _semver_less_than,
-    "semVerGreaterThan": _semver_greater_than
+    "semVerGreaterThan": _semver_greater_than,
 }
 
 

--- a/ldclient/impl/operators.py
+++ b/ldclient/impl/operators.py
@@ -1,10 +1,12 @@
-from ldclient.impl.model.clause import ClausePreprocessedValue
-from ldclient.impl.model.value_parsing import is_number, parse_semver, parse_time
-
 from collections import defaultdict
 from numbers import Number
-from semver import VersionInfo
 from typing import Any, Callable, Optional
+
+from semver import VersionInfo
+
+from ldclient.impl.model.clause import ClausePreprocessedValue
+from ldclient.impl.model.value_parsing import (is_number, parse_semver,
+                                               parse_time)
 
 
 def _string_operator(context_value: Any, clause_value: Any, fn: Callable[[str, str], bool]) -> bool:

--- a/ldclient/impl/repeating_task.py
+++ b/ldclient/impl/repeating_task.py
@@ -1,8 +1,8 @@
-from ldclient.impl.util import log
-
-from threading import Event, Thread
 import time
+from threading import Event, Thread
 from typing import Callable
+
+from ldclient.impl.util import log
 
 
 class RepeatingTask:

--- a/ldclient/impl/rwlock.py
+++ b/ldclient/impl/rwlock.py
@@ -2,7 +2,7 @@ import threading
 
 
 class ReadWriteLock:
-    """ A lock object that allows many simultaneous "read locks", but
+    """A lock object that allows many simultaneous "read locks", but
     only one "write lock." """
 
     def __init__(self):
@@ -10,8 +10,8 @@ class ReadWriteLock:
         self._readers = 0
 
     def rlock(self):
-        """ Acquire a read lock. Blocks only if a thread has
-        acquired the write lock. """
+        """Acquire a read lock. Blocks only if a thread has
+        acquired the write lock."""
         self._read_ready.acquire()
         try:
             self._readers += 1
@@ -19,7 +19,7 @@ class ReadWriteLock:
             self._read_ready.release()
 
     def runlock(self):
-        """ Release a read lock. """
+        """Release a read lock."""
         self._read_ready.acquire()
         try:
             self._readers -= 1
@@ -29,12 +29,12 @@ class ReadWriteLock:
             self._read_ready.release()
 
     def lock(self):
-        """ Acquire a write lock. Blocks until there are no
-        acquired read or write locks. """
+        """Acquire a write lock. Blocks until there are no
+        acquired read or write locks."""
         self._read_ready.acquire()
         while self._readers > 0:
             self._read_ready.wait()
 
     def unlock(self):
-        """ Release a write lock. """
+        """Release a write lock."""
         self._read_ready.release()

--- a/ldclient/impl/stubs.py
+++ b/ldclient/impl/stubs.py
@@ -1,4 +1,3 @@
-
 from ldclient.interfaces import EventProcessor, UpdateProcessor
 
 
@@ -25,15 +24,15 @@ class NullEventProcessor(EventProcessor):
 class NullUpdateProcessor(UpdateProcessor):
     def __init__(self, config, store, ready):
         self._ready = ready
-    
+
     def start(self):
         self._ready.set()
-    
+
     def stop(self):
         pass
-    
+
     def is_alive(self):
         return False
-    
+
     def initialized(self):
         return True

--- a/ldclient/impl/util.py
+++ b/ldclient/impl/util.py
@@ -19,8 +19,6 @@ def timedelta_millis(delta: timedelta) -> float:
 
 log = logging.getLogger('ldclient.util')  # historical logger name
 
-import queue
-
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
@@ -32,11 +30,13 @@ __BASE_TYPES__ = (str, float, int, bool)
 
 _retryable_statuses = [400, 408, 429]
 
+
 def validate_application_info(application: dict, logger: logging.Logger) -> dict:
     return {
         "id": validate_application_value(application.get("id", ""), "id", logger),
         "version": validate_application_value(application.get("version", ""), "version", logger),
     }
+
 
 def validate_application_value(value: Any, name: str, logger: logging.Logger) -> str:
     if not isinstance(value, str):
@@ -52,10 +52,12 @@ def validate_application_value(value: Any, name: str, logger: logging.Logger) ->
 
     return value
 
+
 def _headers(config):
     base_headers = _base_headers(config)
     base_headers.update({'Content-Type': "application/json"})
     return base_headers
+
 
 def check_uwsgi():
     if 'uwsgi' in sys.modules:
@@ -138,6 +140,7 @@ def stringify_attrs(attrdict, attrs):
                 newdict = attrdict.copy()
             newdict[attr] = str(val)
     return attrdict if newdict is None else newdict
+
 
 def redact_password(url: str) -> str:
     """

--- a/ldclient/impl/util.py
+++ b/ldclient/impl/util.py
@@ -2,11 +2,11 @@ import logging
 import re
 import sys
 import time
-
-from typing import Any, Optional
-from ldclient.impl.http import _base_headers
-from urllib.parse import urlparse, urlunparse
 from datetime import timedelta
+from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
+
+from ldclient.impl.http import _base_headers
 
 
 def current_time_millis() -> int:

--- a/ldclient/impl/util.py
+++ b/ldclient/impl/util.py
@@ -22,8 +22,7 @@ log = logging.getLogger('ldclient.util')  # historical logger name
 
 __LONG_SCALE__ = float(0xFFFFFFFFFFFFFFF)
 
-__BUILTINS__ = ["key", "ip", "country", "email",
-                "firstName", "lastName", "avatar", "name", "anonymous"]
+__BUILTINS__ = ["key", "ip", "country", "email", "firstName", "lastName", "avatar", "name", "anonymous"]
 
 __BASE_TYPES__ = (str, float, int, bool)
 
@@ -63,6 +62,7 @@ def check_uwsgi():
     if 'uwsgi' in sys.modules:
         # noinspection PyPackageRequirements,PyUnresolvedReferences
         import uwsgi
+
         if not hasattr(uwsgi, 'opt'):
             # means that we are not running under uwsgi
             return
@@ -71,8 +71,10 @@ def check_uwsgi():
             return
         if uwsgi.opt.get('threads') is not None and int(uwsgi.opt.get('threads')) > 1:
             return
-        log.error("The LaunchDarkly client requires the 'enable-threads' or 'threads' option be passed to uWSGI. "
-                    'To learn more, read https://docs.launchdarkly.com/sdk/server-side/python#configuring-uwsgi')
+        log.error(
+            "The LaunchDarkly client requires the 'enable-threads' or 'threads' option be passed to uWSGI. "
+            'To learn more, read https://docs.launchdarkly.com/sdk/server-side/python#configuring-uwsgi'
+        )
 
 
 class Event:
@@ -103,7 +105,7 @@ def throw_if_unsuccessful_response(resp):
 
 def is_http_error_recoverable(status):
     if status >= 400 and status < 500:
-        return status in _retryable_statuses # all other 4xx besides these are unrecoverable
+        return status in _retryable_statuses  # all other 4xx besides these are unrecoverable
     return True  # all other errors are recoverable
 
 
@@ -111,12 +113,8 @@ def http_error_description(status):
     return "HTTP error %d%s" % (status, " (invalid SDK key)" if (status == 401 or status == 403) else "")
 
 
-def http_error_message(status, context, retryable_message = "will retry"):
-    return "Received %s for %s - %s" % (
-        http_error_description(status),
-        context,
-        retryable_message if is_http_error_recoverable(status) else "giving up permanently"
-        )
+def http_error_message(status, context, retryable_message="will retry"):
+    return "Received %s for %s - %s" % (http_error_description(status), context, retryable_message if is_http_error_recoverable(status) else "giving up permanently")
 
 
 def check_if_error_is_recoverable_and_log(error_context, status_code, error_desc, recoverable_message):

--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -17,18 +17,15 @@ from typing import Any, Dict, List, Mapping, Optional
 
 
 class Consul:
-    """Provides factory methods for integrations between the LaunchDarkly SDK and Consul.
-    """
+    """Provides factory methods for integrations between the LaunchDarkly SDK and Consul."""
 
     """The key prefix that is used if you do not specify one."""
     DEFAULT_PREFIX = "launchdarkly"
 
     @staticmethod
-    def new_feature_store(host: Optional[str]=None,
-                          port: Optional[int]=None,
-                          prefix: Optional[str]=None,
-                          consul_opts: Optional[dict]=None,
-                          caching: CacheConfig=CacheConfig.default()) -> CachingStoreWrapper:
+    def new_feature_store(
+        host: Optional[str] = None, port: Optional[int] = None, prefix: Optional[str] = None, consul_opts: Optional[dict] = None, caching: CacheConfig = CacheConfig.default()
+    ) -> CachingStoreWrapper:
         """Creates a Consul-backed implementation of :class:`ldclient.interfaces.FeatureStore`.
         For more details about how and why you can use a persistent feature store, see the
         `SDK reference guide <https://docs.launchdarkly.com/sdk/concepts/data-stores>`_.
@@ -56,14 +53,10 @@ class Consul:
 
 
 class DynamoDB:
-    """Provides factory methods for integrations between the LaunchDarkly SDK and DynamoDB.
-    """
+    """Provides factory methods for integrations between the LaunchDarkly SDK and DynamoDB."""
 
     @staticmethod
-    def new_feature_store(table_name: str,
-                          prefix: Optional[str]=None,
-                          dynamodb_opts: Mapping[str, Any]={},
-                          caching: CacheConfig=CacheConfig.default()) -> CachingStoreWrapper:
+    def new_feature_store(table_name: str, prefix: Optional[str] = None, dynamodb_opts: Mapping[str, Any] = {}, caching: CacheConfig = CacheConfig.default()) -> CachingStoreWrapper:
         """Creates a DynamoDB-backed implementation of :class:`ldclient.interfaces.FeatureStore`.
         For more details about how and why you can use a persistent feature store, see the
         `SDK reference guide <https://docs.launchdarkly.com/sdk/concepts/data-stores>`_.
@@ -97,7 +90,7 @@ class DynamoDB:
         return CachingStoreWrapper(core, caching)
 
     @staticmethod
-    def new_big_segment_store(table_name: str, prefix: Optional[str]=None, dynamodb_opts: Mapping[str, Any]={}):
+    def new_big_segment_store(table_name: str, prefix: Optional[str] = None, dynamodb_opts: Mapping[str, Any] = {}):
         """
         Creates a DynamoDB-backed Big Segment store.
 
@@ -132,18 +125,16 @@ class DynamoDB:
 
 
 class Redis:
-    """Provides factory methods for integrations between the LaunchDarkly SDK and Redis.
-    """
+    """Provides factory methods for integrations between the LaunchDarkly SDK and Redis."""
+
     DEFAULT_URL = 'redis://localhost:6379/0'
     DEFAULT_PREFIX = 'launchdarkly'
     DEFAULT_MAX_CONNECTIONS = 16
 
     @staticmethod
-    def new_feature_store(url: str='redis://localhost:6379/0',
-                          prefix: str='launchdarkly',
-                          max_connections: int=16,
-                          caching: CacheConfig=CacheConfig.default(),
-                          redis_opts: Dict[str, Any] = {}) -> CachingStoreWrapper:
+    def new_feature_store(
+        url: str = 'redis://localhost:6379/0', prefix: str = 'launchdarkly', max_connections: int = 16, caching: CacheConfig = CacheConfig.default(), redis_opts: Dict[str, Any] = {}
+    ) -> CachingStoreWrapper:
         """
         Creates a Redis-backed implementation of :class:`~ldclient.interfaces.FeatureStore`.
         For more details about how and why you can use a persistent feature store, see the
@@ -174,10 +165,7 @@ class Redis:
         return wrapper
 
     @staticmethod
-    def new_big_segment_store(url: str='redis://localhost:6379/0',
-                              prefix: str='launchdarkly',
-                              max_connections: int=16,
-                              redis_opts: Dict[str, Any] = {}) -> BigSegmentStore:
+    def new_big_segment_store(url: str = 'redis://localhost:6379/0', prefix: str = 'launchdarkly', max_connections: int = 16, redis_opts: Dict[str, Any] = {}) -> BigSegmentStore:
         """
         Creates a Redis-backed Big Segment store.
 
@@ -205,14 +193,10 @@ class Redis:
 
 
 class Files:
-    """Provides factory methods for integrations with filesystem data.
-    """
+    """Provides factory methods for integrations with filesystem data."""
 
     @staticmethod
-    def new_data_source(paths: List[str],
-                        auto_update: bool=False,
-                        poll_interval: float=1,
-                        force_polling: bool=False) -> object:
+    def new_data_source(paths: List[str], auto_update: bool = False, poll_interval: float = 1, force_polling: bool = False) -> object:
         """Provides a way to use local files as a source of feature flag state. This would typically be
         used in a test environment, to operate using a predetermined feature flag state without an
         actual LaunchDarkly connection.
@@ -253,4 +237,4 @@ class Files:
 
         :return: an object (actually a lambda) to be stored in the ``update_processor_class`` configuration property
         """
-        return lambda config, store, ready : _FileDataSource(store, config.data_source_update_sink, ready, paths, auto_update, poll_interval, force_polling)
+        return lambda config, store, ready: _FileDataSource(store, config.data_source_update_sink, ready, paths, auto_update, poll_interval, force_polling)

--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -15,6 +15,7 @@ from ldclient.interfaces import BigSegmentStore
 
 from typing import Any, Dict, List, Mapping, Optional
 
+
 class Consul:
     """Provides factory methods for integrations between the LaunchDarkly SDK and Consul.
     """
@@ -201,6 +202,7 @@ class Redis:
         """
 
         return _RedisBigSegmentStore(url, prefix, redis_opts)
+
 
 class Files:
     """Provides factory methods for integrations with filesystem data.

--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -3,17 +3,22 @@ This submodule contains factory/configuration methods for integrating the SDK wi
 other than LaunchDarkly.
 """
 
+from typing import Any, Dict, List, Mapping, Optional
+
 from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
-from ldclient.impl.integrations.consul.consul_feature_store import _ConsulFeatureStoreCore
-from ldclient.impl.integrations.dynamodb.dynamodb_big_segment_store import _DynamoDBBigSegmentStore
-from ldclient.impl.integrations.dynamodb.dynamodb_feature_store import _DynamoDBFeatureStoreCore
+from ldclient.impl.integrations.consul.consul_feature_store import \
+    _ConsulFeatureStoreCore
+from ldclient.impl.integrations.dynamodb.dynamodb_big_segment_store import \
+    _DynamoDBBigSegmentStore
+from ldclient.impl.integrations.dynamodb.dynamodb_feature_store import \
+    _DynamoDBFeatureStoreCore
 from ldclient.impl.integrations.files.file_data_source import _FileDataSource
-from ldclient.impl.integrations.redis.redis_big_segment_store import _RedisBigSegmentStore
-from ldclient.impl.integrations.redis.redis_feature_store import _RedisFeatureStoreCore
+from ldclient.impl.integrations.redis.redis_big_segment_store import \
+    _RedisBigSegmentStore
+from ldclient.impl.integrations.redis.redis_feature_store import \
+    _RedisFeatureStoreCore
 from ldclient.interfaces import BigSegmentStore
-
-from typing import Any, Dict, List, Mapping, Optional
 
 
 class Consul:

--- a/ldclient/integrations/test_data.py
+++ b/ldclient/integrations/test_data.py
@@ -15,7 +15,7 @@ def _variation_for_boolean(variation):
     else:
         return FALSE_VARIATION_INDEX
 
-class TestData():
+class TestData:
     """A mechanism for providing dynamically updatable feature flag state in a
     simplified form to an SDK client in test scenarios.
 
@@ -140,7 +140,7 @@ class TestData():
         finally:
             self._lock.unlock()
 
-class FlagBuilder():
+class FlagBuilder:
     """A builder for feature flag configurations to be used with :class:`ldclient.integrations.test_data.TestData`.
 
     :see: :meth:`ldclient.integrations.test_data.TestData.flag()`
@@ -352,7 +352,7 @@ class FlagBuilder():
             self._targets[context_kind] = targets
 
         for idx, var in enumerate(self._variations):
-            if (idx == variation):
+            if idx == variation:
                 # If there is no set at the current variation, set it to be empty
                 target_for_variation = targets.get(idx)
                 if target_for_variation is None:
@@ -523,7 +523,7 @@ class FlagBuilder():
         return base_flag_object
 
 
-class FlagRuleBuilder():
+class FlagRuleBuilder:
     """
     A builder for feature flag rules to be used with :class:`ldclient.integrations.test_data.FlagBuilder`.
 

--- a/ldclient/integrations/test_data.py
+++ b/ldclient/integrations/test_data.py
@@ -251,7 +251,7 @@ class FlagBuilder:
             return self.variations(True, False).fallthrough_variation(TRUE_VARIATION_INDEX).off_variation(FALSE_VARIATION_INDEX)
 
     def _is_boolean_flag(self):
-        return len(self._variations) == 2 and self._variations[TRUE_VARIATION_INDEX] == True and self._variations[FALSE_VARIATION_INDEX] == False
+        return len(self._variations) == 2 and self._variations[TRUE_VARIATION_INDEX] is True and self._variations[FALSE_VARIATION_INDEX] is False
 
     def variations(self, *variations) -> 'FlagBuilder':
         """Changes the allowable variation values for the flag.

--- a/ldclient/integrations/test_data.py
+++ b/ldclient/integrations/test_data.py
@@ -133,7 +133,7 @@ class TestData:
         return self
 
     def _make_init_data(self) -> dict:
-        return { FEATURES: copy.copy(self._current_flags) }
+        return {FEATURES: copy.copy(self._current_flags)}
 
     def _closed_instance(self, instance):
         try:
@@ -149,9 +149,9 @@ class FlagBuilder:
     :see: :meth:`ldclient.integrations.test_data.TestData.flag()`
     :see: :meth:`ldclient.integrations.test_data.TestData.update()`
     """
+
     def __init__(self, key: str):
-        """:param str key: The name of the flag
-        """
+        """:param str key: The name of the flag"""
         self._key = key
         self._on = True
         self._variations = []  # type: List[Any]
@@ -215,7 +215,7 @@ class FlagBuilder:
             self._fallthrough_variation = variation
             return self
 
-    def off_variation(self, variation: Union[bool, int]) -> 'FlagBuilder' :
+    def off_variation(self, variation: Union[bool, int]) -> 'FlagBuilder':
         """Specifies the fallthrough variation. This is the variation that is returned
         whenever targeting is off.
 
@@ -248,14 +248,10 @@ class FlagBuilder:
         if self._is_boolean_flag():
             return self
         else:
-            return (self.variations(True, False)
-                .fallthrough_variation(TRUE_VARIATION_INDEX)
-                .off_variation(FALSE_VARIATION_INDEX))
+            return self.variations(True, False).fallthrough_variation(TRUE_VARIATION_INDEX).off_variation(FALSE_VARIATION_INDEX)
 
     def _is_boolean_flag(self):
-        return (len(self._variations) == 2
-            and self._variations[TRUE_VARIATION_INDEX] == True
-            and self._variations[FALSE_VARIATION_INDEX] == False)
+        return len(self._variations) == 2 and self._variations[TRUE_VARIATION_INDEX] == True and self._variations[FALSE_VARIATION_INDEX] == False
 
     def variations(self, *variations) -> 'FlagBuilder':
         """Changes the allowable variation values for the flag.
@@ -481,40 +477,20 @@ class FlagBuilder:
         :param version: the version number of the rule
         :return: the dictionary representation of the flag
         """
-        base_flag_object = {
-            'key': self._key,
-            'version': version,
-            'on': self._on,
-            'variations': self._variations,
-            'prerequisites': [],
-            'salt': ''
-        }
+        base_flag_object = {'key': self._key, 'version': version, 'on': self._on, 'variations': self._variations, 'prerequisites': [], 'salt': ''}
 
         base_flag_object['offVariation'] = self._off_variation
-        base_flag_object['fallthrough'] = {
-                'variation': self._fallthrough_variation
-            }
+        base_flag_object['fallthrough'] = {'variation': self._fallthrough_variation}
 
         targets = []
         context_targets = []
         for target_context_kind, target_variations in self._targets.items():
             for var_index, target_keys in target_variations.items():
                 if target_context_kind == Context.DEFAULT_KIND:
-                    targets.append({
-                        'variation': var_index,
-                        'values': sorted(list(target_keys))  # sorting just for test determinacy
-                    })
-                    context_targets.append({
-                        'contextKind': target_context_kind,
-                        'variation': var_index,
-                        'values': []
-                    })
+                    targets.append({'variation': var_index, 'values': sorted(list(target_keys))})  # sorting just for test determinacy
+                    context_targets.append({'contextKind': target_context_kind, 'variation': var_index, 'values': []})
                 else:
-                    context_targets.append({
-                        'contextKind': target_context_kind,
-                        'variation': var_index,
-                        'values': sorted(list(target_keys))  # sorting just for test determinacy
-                    })
+                    context_targets.append({'contextKind': target_context_kind, 'variation': var_index, 'values': sorted(list(target_keys))})  # sorting just for test determinacy
         base_flag_object['targets'] = targets
         base_flag_object['contextTargets'] = context_targets
 
@@ -543,6 +519,7 @@ class FlagRuleBuilder:
     Finally, call :meth:`ldclient.integrations.test_data.FlagRuleBuilder.then_return()`
     to finish defining the rule.
     """
+
     def __init__(self, flag_builder: FlagBuilder):
         self._flag_builder = flag_builder
         self._clauses = []  # type: List[dict]
@@ -586,13 +563,7 @@ class FlagRuleBuilder:
         :param values: values to compare to
         :return: the flag rule builder
         """
-        self._clauses.append({
-                'contextKind': context_kind,
-                'attribute': attribute,
-                'op': 'in',
-                'values': list(values),
-                'negate': False
-            })
+        self._clauses.append({'contextKind': context_kind, 'attribute': attribute, 'op': 'in', 'values': list(values), 'negate': False})
         return self
 
     def and_not_match(self, attribute: str, *values) -> 'FlagRuleBuilder':
@@ -633,13 +604,7 @@ class FlagRuleBuilder:
         :param values: values to compare to
         :return: the flag rule builder
         """
-        self._clauses.append({
-                'contextKind': context_kind,
-                'attribute': attribute,
-                'op': 'in',
-                'values': list(values),
-                'negate': True
-            })
+        self._clauses.append({'contextKind': context_kind, 'attribute': attribute, 'op': 'in', 'values': list(values), 'negate': True})
         return self
 
     def then_return(self, variation: Union[bool, int]) -> 'FlagBuilder':
@@ -669,8 +634,4 @@ class FlagRuleBuilder:
         :param id: the rule id
         :return: the dictionary representation of the rule
         """
-        return {
-            'id': 'rule' + id,
-            'variation': self._variation,
-            'clauses': self._clauses
-        }
+        return {'id': 'rule' + id, 'variation': self._variation, 'clauses': self._clauses}

--- a/ldclient/integrations/test_data.py
+++ b/ldclient/integrations/test_data.py
@@ -2,9 +2,10 @@ import copy
 from typing import Any, Dict, List, Optional, Set, Union
 
 from ldclient.context import Context
-from ldclient.versioned_data_kind import FEATURES
-from ldclient.impl.integrations.test_data.test_data_source import _TestDataSource
+from ldclient.impl.integrations.test_data.test_data_source import \
+    _TestDataSource
 from ldclient.impl.rwlock import ReadWriteLock
+from ldclient.versioned_data_kind import FEATURES
 
 TRUE_VARIATION_INDEX = 0
 FALSE_VARIATION_INDEX = 1

--- a/ldclient/integrations/test_data.py
+++ b/ldclient/integrations/test_data.py
@@ -9,11 +9,13 @@ from ldclient.impl.rwlock import ReadWriteLock
 TRUE_VARIATION_INDEX = 0
 FALSE_VARIATION_INDEX = 1
 
+
 def _variation_for_boolean(variation):
     if variation:
         return TRUE_VARIATION_INDEX
     else:
         return FALSE_VARIATION_INDEX
+
 
 class TestData:
     """A mechanism for providing dynamically updatable feature flag state in a
@@ -139,6 +141,7 @@ class TestData:
             self._instances.remove(instance)
         finally:
             self._lock.unlock()
+
 
 class FlagBuilder:
     """A builder for feature flag configurations to be used with :class:`ldclient.integrations.test_data.TestData`.

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -4,13 +4,14 @@ This submodule contains interfaces for various components of the SDK.
 They may be useful in writing new implementations of these components, or for testing.
 """
 
+from abc import ABCMeta, abstractmethod, abstractproperty
+from enum import Enum
+from typing import Any, Callable, Mapping, Optional
+
 from ldclient.context import Context
 from ldclient.impl.listeners import Listeners
 
-from abc import ABCMeta, abstractmethod, abstractproperty
 from .versioned_data_kind import VersionedDataKind
-from typing import Any, Callable, Mapping, Optional
-from enum import Enum
 
 
 class FeatureStore:

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -3,6 +3,7 @@ This submodule contains interfaces for various components of the SDK.
 
 They may be useful in writing new implementations of these components, or for testing.
 """
+
 from ldclient.context import Context
 from ldclient.impl.listeners import Listeners
 
@@ -27,6 +28,7 @@ class FeatureStore:
     These semantics support the primary use case for the store, which synchronizes a collection
     of objects based on update messages that may be received out-of-order.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -152,6 +154,7 @@ class FeatureStoreCore:
     commonly be needed in any such implementation, such as caching. Instead, they can implement
     only ``FeatureStoreCore`` and then create a ``CachingStoreWrapper``.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -264,6 +267,7 @@ class UpdateProcessor(BackgroundOperation):
     :class:`FeatureStore`. The built-in implementations of this are the client's standard streaming
     or polling behavior. For testing purposes, there is also :func:`ldclient.integrations.Files.new_data_source()`.
     """
+
     __metaclass__ = ABCMeta
 
     def initialized(self) -> bool:  # type: ignore[empty-body]
@@ -277,6 +281,7 @@ class EventProcessor:
     Interface for the component that buffers analytics events and sends them to LaunchDarkly.
     The default implementation can be replaced for testing purposes.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -306,6 +311,7 @@ class FeatureRequester:
     Interface for the component that acquires feature flag data in polling mode. The default
     implementation can be replaced for testing purposes.
     """
+
     __metaclass__ = ABCMeta
 
     def get_all(self):
@@ -657,6 +663,7 @@ class DataSourceStatusProvider:
     :func:`ldclient.client.LDClient.data_source_status_provider`. Application code never needs to
     implement this interface.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractproperty
@@ -707,6 +714,7 @@ class DataSourceUpdateSink:
     the data store directly, so that the SDK can perform any other
     necessary operations that must happen when data is updated.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -831,6 +839,7 @@ class FlagTracker:
     An implementation of this interface is returned by :class:`ldclient.client.LDClient.flag_tracker`.
     Application code never needs to implement this interface.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -909,6 +918,7 @@ class DataStoreStatus:
     """
     Information about the data store's status.
     """
+
     __metaclass__ = ABCMeta
 
     def __init__(self, available: bool, stale: bool):
@@ -949,6 +959,7 @@ class DataStoreUpdateSink:
     Interface that a data store implementation can use to report information
     back to the SDK.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -985,6 +996,7 @@ class DataStoreStatusProvider:
     An implementation of this interface is returned by :func:`ldclient.client.LDClient.data_store_status_provider`.
     Application code should not implement this interface.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractproperty

--- a/ldclient/migrations/__init__.py
+++ b/ldclient/migrations/__init__.py
@@ -7,9 +7,7 @@ __all__ = [
     'MigratorBuilder',
     'MigratorCompareFn',
     'MigratorFn',
-
     'OpTracker',
-
     'ExecutionOrder',
     'MigrationConfig',
     'Operation',

--- a/ldclient/migrations/migrator.py
+++ b/ldclient/migrations/migrator.py
@@ -18,6 +18,7 @@ class Migrator:
     A migrator is the interface through which migration support is executed. A
     migrator is configured through the :class:`MigratorBuilder`.
     """
+
     __metaclass__ = ABCMeta
 
     @abstractmethod
@@ -50,14 +51,7 @@ class MigratorImpl(Migrator):
     """
 
     def __init__(
-        self,
-        sampler: Sampler,
-        client: LDClient,
-        read_execution_order: ExecutionOrder,
-        read_config: MigrationConfig,
-        write_config: MigrationConfig,
-        measure_latency: bool,
-        measure_errors: bool
+        self, sampler: Sampler, client: LDClient, read_execution_order: ExecutionOrder, read_config: MigrationConfig, write_config: MigrationConfig, measure_latency: bool, measure_errors: bool
     ):
         self.__sampler = sampler
         self.__client = client
@@ -293,15 +287,7 @@ class Executor:
     built-in migration measurements.
     """
 
-    def __init__(
-        self,
-        origin: Origin,
-        fn: MigratorFn,
-        tracker: OpTracker,
-        measure_latency: bool,
-        measure_errors: bool,
-        payload: Any
-    ):
+    def __init__(self, origin: Origin, fn: MigratorFn, tracker: OpTracker, measure_latency: bool, measure_errors: bool, payload: Any):
         self.__origin = origin
         self.__fn = fn
         self.__tracker = tracker

--- a/ldclient/migrations/migrator.py
+++ b/ldclient/migrations/migrator.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
+
 import concurrent.futures
-from datetime import datetime
 from abc import ABCMeta, abstractmethod
+from datetime import datetime
 from random import Random
-from typing import Optional, Union, Any, Tuple, TYPE_CHECKING
-from ldclient.migrations.types import ExecutionOrder, OperationResult, WriteResult, Stage, MigrationConfig, MigratorFn, MigratorCompareFn, Operation, Origin
-from ldclient.migrations.tracker import OpTracker
-from ldclient.impl.util import Result
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+
 from ldclient.impl.sampler import Sampler
+from ldclient.impl.util import Result
+from ldclient.migrations.tracker import OpTracker
+from ldclient.migrations.types import (ExecutionOrder, MigrationConfig,
+                                       MigratorCompareFn, MigratorFn,
+                                       Operation, OperationResult, Origin,
+                                       Stage, WriteResult)
 
 if TYPE_CHECKING:
-    from ldclient import LDClient, Context
+    from ldclient import Context, LDClient
 
 
 class Migrator:

--- a/ldclient/migrations/tracker.py
+++ b/ldclient/migrations/tracker.py
@@ -1,15 +1,16 @@
-from typing import Callable, Optional, Union, Set, Dict
 import time
 from datetime import timedelta
 from random import Random
-from ldclient.impl.sampler import Sampler
-from ldclient.evaluation import EvaluationDetail
-from ldclient.context import Context
-from ldclient.impl.model import FeatureFlag
 from threading import Lock
+from typing import Callable, Dict, Optional, Set, Union
+
+from ldclient.context import Context
+from ldclient.evaluation import EvaluationDetail
 from ldclient.impl.events.types import EventInput
-from ldclient.migrations.types import Stage, Operation, Origin
+from ldclient.impl.model import FeatureFlag
+from ldclient.impl.sampler import Sampler
 from ldclient.impl.util import log
+from ldclient.migrations.types import Operation, Origin, Stage
 
 
 class MigrationOpEvent(EventInput):

--- a/ldclient/migrations/tracker.py
+++ b/ldclient/migrations/tracker.py
@@ -23,9 +23,24 @@ class MigrationOpEvent(EventInput):
     This event should not be constructed directly; rather, it should be built
     through :class:`ldclient.migrations.OpTracker()`.
     """
+
     __slots__ = ['key', 'flag', 'operation', 'default_stage', 'detail', 'invoked', 'consistent', 'consistent_ratio', 'errors', 'latencies']
 
-    def __init__(self, timestamp: int, context: Context, key: str, flag: Optional[FeatureFlag], operation: Operation, default_stage: Stage, detail: EvaluationDetail, invoked: Set[Origin], consistent: Optional[bool], consistent_ratio: Optional[int], errors: Set[Origin], latencies: Dict[Origin, timedelta]):
+    def __init__(
+        self,
+        timestamp: int,
+        context: Context,
+        key: str,
+        flag: Optional[FeatureFlag],
+        operation: Operation,
+        default_stage: Stage,
+        detail: EvaluationDetail,
+        invoked: Set[Origin],
+        consistent: Optional[bool],
+        consistent_ratio: Optional[int],
+        errors: Set[Origin],
+        latencies: Dict[Origin, timedelta],
+    ):
         sampling_ratio = None if flag is None else flag.sampling_ratio
         super().__init__(timestamp, context, sampling_ratio)
 
@@ -69,14 +84,7 @@ class OpTracker:
     the returned tracker instance.
     """
 
-    def __init__(
-        self,
-        key: str,
-        flag: Optional[FeatureFlag],
-        context: Context,
-        detail: EvaluationDetail,
-        default_stage: Stage
-    ):
+    def __init__(self, key: str, flag: Optional[FeatureFlag], context: Context, detail: EvaluationDetail, default_stage: Stage):
         self.__key = key
         self.__flag = flag
         self.__context = context
@@ -214,7 +222,8 @@ class OpTracker:
                 self.__consistent,
                 None if self.__consistent is None else self.__consistent_ratio,
                 self.__errors.copy(),
-                self.__latencies.copy())
+                self.__latencies.copy(),
+            )
 
     def __check_invoked_consistency(self) -> Optional[str]:
         for origin in Origin:

--- a/ldclient/migrations/types.py
+++ b/ldclient/migrations/types.py
@@ -1,5 +1,6 @@
-from typing import Callable, Optional, Any
 from enum import Enum
+from typing import Any, Callable, Optional
+
 from ldclient.impl.util import Result
 
 MigratorFn = Callable[[Optional[Any]], Result]

--- a/ldclient/testing/builders.py
+++ b/ldclient/testing/builders.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Any, List, Optional
 
 from ldclient.context import Context

--- a/ldclient/testing/builders.py
+++ b/ldclient/testing/builders.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, List ,Optional
+from typing import Any, List, Optional
 
 from ldclient.context import Context
 from ldclient.impl.model import *
@@ -27,19 +27,9 @@ class BaseBuilder:
 
 class FlagBuilder(BaseBuilder):
     def __init__(self, key):
-        super().__init__({
-            'key': key,
-            'version': 1,
-            'on': False,
-            'variations': [],
-            'offVariation': None,
-            'fallthrough': {},
-            'prerequisites': [],
-            'targets': [],
-            'contextTargets': [],
-            'rules': [],
-            'salt': ''
-        })
+        super().__init__(
+            {'key': key, 'version': 1, 'on': False, 'variations': [], 'offVariation': None, 'fallthrough': {}, 'prerequisites': [], 'targets': [], 'contextTargets': [], 'rules': [], 'salt': ''}
+        )
 
     def build(self):
         return FeatureFlag(self.data.copy())
@@ -72,8 +62,7 @@ class FlagBuilder(BaseBuilder):
         return self._append('targets', {'variation': variation, 'values': list(keys)})
 
     def context_target(self, context_kind: str, variation: int, *keys: str) -> FlagBuilder:
-        return self._append('contextTargets',
-            {'contextKind': context_kind, 'variation': variation, 'values': list(keys)})
+        return self._append('contextTargets', {'contextKind': context_kind, 'variation': variation, 'values': list(keys)})
 
     def rules(self, *rules: dict) -> FlagBuilder:
         return self._append_all('rules', list(rules))
@@ -130,17 +119,7 @@ class FlagRuleBuilder(BaseBuilder):
 
 class SegmentBuilder(BaseBuilder):
     def __init__(self, key):
-        super().__init__({
-            'key': key,
-            'version': 1,
-            'included': [],
-            'excluded': [],
-            'includedContexts': [],
-            'excludedContexts': [],
-            'rules': [],
-            'unbounded': False,
-            'salt': ''
-        })
+        super().__init__({'key': key, 'version': 1, 'included': [], 'excluded': [], 'includedContexts': [], 'excludedContexts': [], 'rules': [], 'unbounded': False, 'salt': ''})
 
     def build(self):
         return Segment(self.data.copy())

--- a/ldclient/testing/builders.py
+++ b/ldclient/testing/builders.py
@@ -199,14 +199,18 @@ class SegmentRuleBuilder(BaseBuilder):
 def build_off_flag_with_value(key: str, value: Any) -> FlagBuilder:
     return FlagBuilder(key).version(100).on(False).variations(value).off_variation(0)
 
+
 def make_boolean_flag_matching_segment(segment: Segment) -> FeatureFlag:
     return make_boolean_flag_with_clauses(make_clause_matching_segment_key(segment.key))
+
 
 def make_boolean_flag_with_clauses(*clauses: dict) -> FeatureFlag:
     return make_boolean_flag_with_rules(FlagRuleBuilder().clauses(*clauses).variation(0).build())
 
+
 def make_boolean_flag_with_rules(*rules: dict) -> FeatureFlag:
     return FlagBuilder('flagkey').on(True).variations(True, False).fallthrough_variation(1).rules(*rules).build()
+
 
 def make_clause(context_kind: Optional[str], attr: str, op: str, *values: Any) -> dict:
     ret = {'attribute': attr, 'op': op, 'values': list(values)}
@@ -214,14 +218,18 @@ def make_clause(context_kind: Optional[str], attr: str, op: str, *values: Any) -
         ret['contextKind'] = context_kind
     return ret
 
+
 def make_clause_matching_context(context: Context) -> dict:
     return {'contextKind': context.kind, 'attribute': 'key', 'op': 'in', 'values': [context.key]}
+
 
 def make_clause_matching_segment_key(*segment_keys: str) -> dict:
     return {'attribute': '', 'op': 'segmentMatch', 'values': list(segment_keys)}
 
+
 def make_segment_rule_matching_context(context: Context) -> dict:
     return SegmentRuleBuilder().clauses(make_clause_matching_context(context)).build()
+
 
 def negate_clause(clause: dict) -> dict:
     c = clause.copy()

--- a/ldclient/testing/feature_store_test_base.py
+++ b/ldclient/testing/feature_store_test_base.py
@@ -43,6 +43,7 @@ class StoreTestScope:
 # - Tests in this class use "with self.store(tester)" or "with self.inited_store(tester)" to
 #   create an instance of the store and ensure that it is torn down afterward.
 
+
 class FeatureStoreTestBase:
     @abstractmethod
     def all_testers(self):
@@ -53,12 +54,14 @@ class FeatureStoreTestBase:
 
     def inited_store(self, tester):
         scope = StoreTestScope(tester.create_feature_store())
-        scope.store.init({
-            FEATURES: {
-                'foo': self.make_feature('foo', 10).to_json_dict(),
-                'bar': self.make_feature('bar', 10).to_json_dict(),
+        scope.store.init(
+            {
+                FEATURES: {
+                    'foo': self.make_feature('foo', 10).to_json_dict(),
+                    'bar': self.make_feature('bar', 10).to_json_dict(),
+                }
             }
-        })
+        )
         return scope
 
     @staticmethod

--- a/ldclient/testing/feature_store_test_base.py
+++ b/ldclient/testing/feature_store_test_base.py
@@ -12,6 +12,7 @@ import pytest
 # database integrations, see testing.integrations.persistent_feature_store_test_base which extends
 # them with additional tests.
 
+
 class FeatureStoreTester:
     @abstractmethod
     def create_feature_store(self) -> FeatureStore:

--- a/ldclient/testing/feature_store_test_base.py
+++ b/ldclient/testing/feature_store_test_base.py
@@ -1,10 +1,10 @@
-from ldclient.interfaces import FeatureStore
-from ldclient.versioned_data_kind import FEATURES
-
-from ldclient.testing.builders import *
-
 from abc import abstractmethod
+
 import pytest
+
+from ldclient.interfaces import FeatureStore
+from ldclient.testing.builders import *
+from ldclient.versioned_data_kind import FEATURES
 
 # The basic test suite to be run against all feature store implementations.
 #

--- a/ldclient/testing/http_util.py
+++ b/ldclient/testing/http_util.py
@@ -1,11 +1,11 @@
 import json
+import queue
 import socket
 import ssl
-from ssl import SSLContext, PROTOCOL_TLSv1_2
-from threading import Thread
 import time
-import queue
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from ssl import PROTOCOL_TLSv1_2, SSLContext
+from threading import Thread
 
 
 def get_available_port():

--- a/ldclient/testing/http_util.py
+++ b/ldclient/testing/http_util.py
@@ -9,7 +9,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 
 
 def get_available_port():
-    s = socket.socket(socket.AF_INET, type = socket.SOCK_STREAM)
+    s = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
     s.bind(('localhost', 0))
     _, port = s.getsockname()
     s.close()
@@ -54,10 +54,7 @@ class MockServerWrapper(Thread):
         if secure:
             context = SSLContext(PROTOCOL_TLSv1_2)
             context.load_cert_chain('./ldclient/testing/selfsigned.pem', './ldclient/testing/selfsigned.key')
-            self.server.socket = context.wrap_socket(
-                self.server.socket,
-                server_side=True
-            )
+            self.server.socket = context.wrap_socket(self.server.socket, server_side=True)
         self.server.server_wrapper = self
         self.matchers = {}
         self.requests = queue.Queue()
@@ -134,7 +131,7 @@ class MockServerRequest:
 
 
 class BasicResponse:
-    def __init__(self, status, body = None, headers = None):
+    def __init__(self, status, body=None, headers=None):
         self.status = status
         self.body = body
         self.headers = headers or {}
@@ -153,14 +150,14 @@ class BasicResponse:
 
 
 class JsonResponse(BasicResponse):
-    def __init__(self, data, headers = None):
+    def __init__(self, data, headers=None):
         h = headers or {}
-        h.update({ 'Content-Type': 'application/json' })
+        h.update({'Content-Type': 'application/json'})
         BasicResponse.__init__(self, 200, json.dumps(data or {}), h)
 
 
 class ChunkedResponse:
-    def __init__(self, headers = None):
+    def __init__(self, headers=None):
         self.queue = queue.Queue()
         self.headers = headers or {}
 

--- a/ldclient/testing/http_util.py
+++ b/ldclient/testing/http_util.py
@@ -7,12 +7,14 @@ import time
 import queue
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
+
 def get_available_port():
     s = socket.socket(socket.AF_INET, type = socket.SOCK_STREAM)
     s.bind(('localhost', 0))
     _, port = s.getsockname()
     s.close()
     return port
+
 
 def poll_until_started(port):
     deadline = time.time() + 1
@@ -28,17 +30,20 @@ def poll_until_started(port):
         time.sleep(0.05)
     raise Exception("test server on port %d was not reachable" % port)
 
+
 def start_server():
     sw = MockServerWrapper(get_available_port(), False)
     sw.start()
     poll_until_started(sw.port)
     return sw
 
+
 def start_secure_server():
     sw = MockServerWrapper(get_available_port(), True)
     sw.start()
     poll_until_started(sw.port)
     return sw
+
 
 class MockServerWrapper(Thread):
     def __init__(self, port, secure):
@@ -92,6 +97,7 @@ class MockServerWrapper(Thread):
     def __exit__(self, type, value, traceback):
         self.close()
 
+
 class MockServerRequestHandler(BaseHTTPRequestHandler):
     def do_CONNECT(self):
         self._do_request()
@@ -111,6 +117,7 @@ class MockServerRequestHandler(BaseHTTPRequestHandler):
         else:
             self.send_error(404)
 
+
 class MockServerRequest:
     def __init__(self, request):
         self.method = request.command
@@ -124,6 +131,7 @@ class MockServerRequest:
 
     def __str__(self):
         return "%s %s" % (self.method, self.path)
+
 
 class BasicResponse:
     def __init__(self, status, body = None, headers = None):
@@ -143,11 +151,13 @@ class BasicResponse:
         if self.body:
             request.wfile.write(self.body.encode('UTF-8'))
 
+
 class JsonResponse(BasicResponse):
     def __init__(self, data, headers = None):
         h = headers or {}
         h.update({ 'Content-Type': 'application/json' })
         BasicResponse.__init__(self, 200, json.dumps(data or {}), h)
+
 
 class ChunkedResponse:
     def __init__(self, headers = None):
@@ -184,9 +194,11 @@ class ChunkedResponse:
     def __exit__(self, type, value, traceback):
         self.close()
 
+
 class CauseNetworkError:
     def write(self, request):
         raise Exception('intentional error')
+
 
 class SequentialHandler:
     def __init__(self, *argv):

--- a/ldclient/testing/impl/datasource/test_feature_requester.py
+++ b/ldclient/testing/impl/datasource/test_feature_requester.py
@@ -1,9 +1,10 @@
 from ldclient.config import Config
 from ldclient.impl.datasource.feature_requester import FeatureRequesterImpl
+from ldclient.testing.http_util import (BasicResponse, JsonResponse,
+                                        start_server)
+from ldclient.testing.proxy_test_util import do_proxy_tests
 from ldclient.version import VERSION
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-from ldclient.testing.http_util import start_server, BasicResponse, JsonResponse
-from ldclient.testing.proxy_test_util import do_proxy_tests
 
 
 def test_get_all_data_returns_data():

--- a/ldclient/testing/impl/datasource/test_feature_requester.py
+++ b/ldclient/testing/impl/datasource/test_feature_requester.py
@@ -127,7 +127,7 @@ def test_http_proxy(monkeypatch):
         if secure:
             try:
                 fr.get_all_data()
-            except:
+            except Exception:
                 pass  # we expect this to fail because we don't have a real HTTPS proxy server
         else:
             result = fr.get_all_data()

--- a/ldclient/testing/impl/datasource/test_feature_requester.py
+++ b/ldclient/testing/impl/datasource/test_feature_requester.py
@@ -8,13 +8,13 @@ from ldclient.testing.proxy_test_util import do_proxy_tests
 
 def test_get_all_data_returns_data():
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', base_uri = server.uri)
+        config = Config(sdk_key='sdk-key', base_uri=server.uri)
         fr = FeatureRequesterImpl(config)
 
-        flags = { 'flag1': { 'key': 'flag1' } }
-        segments = { 'segment1': { 'key': 'segment1' } }
-        resp_data = { 'flags': flags, 'segments': segments }
-        expected_data = { FEATURES: flags, SEGMENTS: segments }
+        flags = {'flag1': {'key': 'flag1'}}
+        segments = {'segment1': {'key': 'segment1'}}
+        resp_data = {'flags': flags, 'segments': segments}
+        expected_data = {FEATURES: flags, SEGMENTS: segments}
         server.for_path('/sdk/latest-all', JsonResponse(resp_data))
 
         result = fr.get_all_data()
@@ -23,10 +23,10 @@ def test_get_all_data_returns_data():
 
 def test_get_all_data_sends_headers():
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', base_uri = server.uri)
+        config = Config(sdk_key='sdk-key', base_uri=server.uri)
         fr = FeatureRequesterImpl(config)
 
-        resp_data = { 'flags': {}, 'segments': {} }
+        resp_data = {'flags': {}, 'segments': {}}
         server.for_path('/sdk/latest-all', JsonResponse(resp_data))
 
         fr.get_all_data()
@@ -40,11 +40,10 @@ def test_get_all_data_sends_headers():
 
 def test_get_all_data_sends_wrapper_header():
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', base_uri = server.uri,
-                        wrapper_name = 'Flask', wrapper_version = '0.1.0')
+        config = Config(sdk_key='sdk-key', base_uri=server.uri, wrapper_name='Flask', wrapper_version='0.1.0')
         fr = FeatureRequesterImpl(config)
 
-        resp_data = { 'flags': {}, 'segments': {} }
+        resp_data = {'flags': {}, 'segments': {}}
         server.for_path('/sdk/latest-all', JsonResponse(resp_data))
 
         fr.get_all_data()
@@ -54,11 +53,10 @@ def test_get_all_data_sends_wrapper_header():
 
 def test_get_all_data_sends_wrapper_header_without_version():
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', base_uri = server.uri,
-                        wrapper_name = 'Flask')
+        config = Config(sdk_key='sdk-key', base_uri=server.uri, wrapper_name='Flask')
         fr = FeatureRequesterImpl(config)
 
-        resp_data = { 'flags': {}, 'segments': {} }
+        resp_data = {'flags': {}, 'segments': {}}
         server.for_path('/sdk/latest-all', JsonResponse(resp_data))
 
         fr.get_all_data()
@@ -68,11 +66,10 @@ def test_get_all_data_sends_wrapper_header_without_version():
 
 def test_get_all_data_sends_tags_header():
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', base_uri = server.uri,
-                application = {"id": "my-id", "version": "my-version"})
+        config = Config(sdk_key='sdk-key', base_uri=server.uri, application={"id": "my-id", "version": "my-version"})
         fr = FeatureRequesterImpl(config)
 
-        resp_data = { 'flags': {}, 'segments': {} }
+        resp_data = {'flags': {}, 'segments': {}}
         server.for_path('/sdk/latest-all', JsonResponse(resp_data))
 
         fr.get_all_data()
@@ -82,38 +79,38 @@ def test_get_all_data_sends_tags_header():
 
 def test_get_all_data_can_use_cached_data():
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', base_uri = server.uri)
+        config = Config(sdk_key='sdk-key', base_uri=server.uri)
         fr = FeatureRequesterImpl(config)
 
         etag1 = 'my-etag-1'
         etag2 = 'my-etag-2'
-        resp_data1 = { 'flags': {}, 'segments': {} }
-        resp_data2 = { 'flags': { 'flag1': { 'key': 'flag1' } }, 'segments': {} }
-        expected_data1 = { FEATURES: {}, SEGMENTS: {} }
-        expected_data2 = { FEATURES: { 'flag1': { 'key': 'flag1' } }, SEGMENTS: {} }
+        resp_data1 = {'flags': {}, 'segments': {}}
+        resp_data2 = {'flags': {'flag1': {'key': 'flag1'}}, 'segments': {}}
+        expected_data1 = {FEATURES: {}, SEGMENTS: {}}
+        expected_data2 = {FEATURES: {'flag1': {'key': 'flag1'}}, SEGMENTS: {}}
         req_path = '/sdk/latest-all'
-        server.for_path(req_path, JsonResponse(resp_data1, { 'Etag': etag1 }))
+        server.for_path(req_path, JsonResponse(resp_data1, {'Etag': etag1}))
 
         result = fr.get_all_data()
         assert result == expected_data1
         req = server.require_request()
         assert 'If-None-Match' not in req.headers.keys()
 
-        server.for_path(req_path, BasicResponse(304, None, { 'Etag': etag1 }))
+        server.for_path(req_path, BasicResponse(304, None, {'Etag': etag1}))
 
         result = fr.get_all_data()
         assert result == expected_data1
         req = server.require_request()
         assert req.headers['If-None-Match'] == etag1
 
-        server.for_path(req_path, JsonResponse(resp_data2, { 'Etag': etag2 }))
+        server.for_path(req_path, JsonResponse(resp_data2, {'Etag': etag2}))
 
         result = fr.get_all_data()
         assert result == expected_data2
         req = server.require_request()
         assert req.headers['If-None-Match'] == etag1
 
-        server.for_path(req_path, BasicResponse(304, None, { 'Etag': etag2 }))
+        server.for_path(req_path, BasicResponse(304, None, {'Etag': etag2}))
 
         result = fr.get_all_data()
         assert result == expected_data2
@@ -123,16 +120,17 @@ def test_get_all_data_can_use_cached_data():
 
 def test_http_proxy(monkeypatch):
     def _feature_requester_proxy_test(server, config, secure):
-        resp_data = { 'flags': {}, 'segments': {} }
-        expected_data = { FEATURES: {}, SEGMENTS: {} }
+        resp_data = {'flags': {}, 'segments': {}}
+        expected_data = {FEATURES: {}, SEGMENTS: {}}
         server.for_path(config.base_uri + '/sdk/latest-all', JsonResponse(resp_data))
         fr = FeatureRequesterImpl(config)
         if secure:
             try:
                 fr.get_all_data()
             except:
-                pass # we expect this to fail because we don't have a real HTTPS proxy server
+                pass  # we expect this to fail because we don't have a real HTTPS proxy server
         else:
             result = fr.get_all_data()
             assert result == expected_data
+
     do_proxy_tests(_feature_requester_proxy_test, 'GET', monkeypatch)

--- a/ldclient/testing/impl/datasource/test_feature_requester.py
+++ b/ldclient/testing/impl/datasource/test_feature_requester.py
@@ -5,6 +5,7 @@ from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 from ldclient.testing.http_util import start_server, BasicResponse, JsonResponse
 from ldclient.testing.proxy_test_util import do_proxy_tests
 
+
 def test_get_all_data_returns_data():
     with start_server() as server:
         config = Config(sdk_key = 'sdk-key', base_uri = server.uri)
@@ -18,6 +19,7 @@ def test_get_all_data_returns_data():
 
         result = fr.get_all_data()
         assert result == expected_data
+
 
 def test_get_all_data_sends_headers():
     with start_server() as server:
@@ -35,6 +37,7 @@ def test_get_all_data_sends_headers():
         assert req.headers.get('X-LaunchDarkly-Wrapper') is None
         assert req.headers.get('X-LaunchDarkly-Tags') is None
 
+
 def test_get_all_data_sends_wrapper_header():
     with start_server() as server:
         config = Config(sdk_key = 'sdk-key', base_uri = server.uri,
@@ -47,6 +50,7 @@ def test_get_all_data_sends_wrapper_header():
         fr.get_all_data()
         req = server.require_request()
         assert req.headers.get('X-LaunchDarkly-Wrapper') == 'Flask/0.1.0'
+
 
 def test_get_all_data_sends_wrapper_header_without_version():
     with start_server() as server:
@@ -61,6 +65,7 @@ def test_get_all_data_sends_wrapper_header_without_version():
         req = server.require_request()
         assert req.headers.get('X-LaunchDarkly-Wrapper') == 'Flask'
 
+
 def test_get_all_data_sends_tags_header():
     with start_server() as server:
         config = Config(sdk_key = 'sdk-key', base_uri = server.uri,
@@ -73,6 +78,7 @@ def test_get_all_data_sends_tags_header():
         fr.get_all_data()
         req = server.require_request()
         assert req.headers.get('X-LaunchDarkly-Tags') == 'application-id/my-id application-version/my-version'
+
 
 def test_get_all_data_can_use_cached_data():
     with start_server() as server:
@@ -113,6 +119,7 @@ def test_get_all_data_can_use_cached_data():
         assert result == expected_data2
         req = server.require_request()
         assert req.headers['If-None-Match'] == etag2
+
 
 def test_http_proxy(monkeypatch):
     def _feature_requester_proxy_test(server, config, secure):

--- a/ldclient/testing/impl/datasource/test_polling_processor.py
+++ b/ldclient/testing/impl/datasource/test_polling_processor.py
@@ -27,14 +27,17 @@ def setup_function():
     store = InMemoryFeatureStore()
     ready = threading.Event()
 
+
 def teardown_function():
     if pp is not None:
         pp.stop()
+
 
 def setup_processor(config):
     global pp
     pp = PollingUpdateProcessor(config, mock_requester, store, ready)
     pp.start()
+
 
 def test_successful_request_puts_feature_data_in_store():
     flag = FlagBuilder('flagkey').build()
@@ -66,6 +69,7 @@ def test_successful_request_puts_feature_data_in_store():
 
 # Note that we have to mock Config.poll_interval because Config won't let you set a value less than 30 seconds
 
+
 @mock.patch('ldclient.config.Config.poll_interval', new_callable=mock.PropertyMock, return_value=0.1)
 def test_general_connection_error_does_not_cause_immediate_failure(ignore_mock):
     mock_requester.exception = Exception("bad")
@@ -74,23 +78,30 @@ def test_general_connection_error_does_not_cause_immediate_failure(ignore_mock):
     assert not pp.initialized()
     assert mock_requester.request_count >= 2
 
+
 def test_http_401_error_causes_immediate_failure():
     verify_unrecoverable_http_error(401)
+
 
 def test_http_403_error_causes_immediate_failure():
     verify_unrecoverable_http_error(401)
 
+
 def test_http_408_error_does_not_cause_immediate_failure():
     verify_recoverable_http_error(408)
+
 
 def test_http_429_error_does_not_cause_immediate_failure():
     verify_recoverable_http_error(429)
 
+
 def test_http_500_error_does_not_cause_immediate_failure():
     verify_recoverable_http_error(500)
 
+
 def test_http_503_error_does_not_cause_immediate_failure():
     verify_recoverable_http_error(503)
+
 
 @mock.patch('ldclient.config.Config.poll_interval', new_callable=mock.PropertyMock, return_value=0.1)
 def verify_unrecoverable_http_error(http_status_code, ignore_mock):
@@ -112,6 +123,7 @@ def verify_unrecoverable_http_error(http_status_code, ignore_mock):
     assert spy.statuses[0].state == DataSourceState.OFF
     assert spy.statuses[0].error.kind == DataSourceErrorKind.ERROR_RESPONSE
     assert spy.statuses[0].error.status_code == http_status_code
+
 
 @mock.patch('ldclient.config.Config.poll_interval', new_callable=mock.PropertyMock, return_value=0.1)
 def verify_recoverable_http_error(http_status_code, ignore_mock):

--- a/ldclient/testing/impl/datasource/test_polling_processor.py
+++ b/ldclient/testing/impl/datasource/test_polling_processor.py
@@ -42,14 +42,7 @@ def setup_processor(config):
 def test_successful_request_puts_feature_data_in_store():
     flag = FlagBuilder('flagkey').build()
     segment = SegmentBuilder('segkey').build()
-    mock_requester.all_data = {
-        FEATURES: {
-            "flagkey": flag.to_json_dict()
-        },
-        SEGMENTS: {
-            "segkey": segment.to_json_dict()
-        }
-    }
+    mock_requester.all_data = {FEATURES: {"flagkey": flag.to_json_dict()}, SEGMENTS: {"segkey": segment.to_json_dict()}}
 
     spy = SpyListener()
     listeners = Listeners()
@@ -66,6 +59,7 @@ def test_successful_request_puts_feature_data_in_store():
     assert len(spy.statuses) == 1
     assert spy.statuses[0].state == DataSourceState.VALID
     assert spy.statuses[0].error is None
+
 
 # Note that we have to mock Config.poll_interval because Config won't let you set a value less than 30 seconds
 

--- a/ldclient/testing/impl/datasource/test_polling_processor.py
+++ b/ldclient/testing/impl/datasource/test_polling_processor.py
@@ -1,5 +1,6 @@
 import threading
 import time
+
 import mock
 
 from ldclient.config import Config
@@ -8,12 +9,12 @@ from ldclient.impl.datasource.polling import PollingUpdateProcessor
 from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.util import UnsuccessfulResponseException
-from ldclient.interfaces import DataSourceStatus, DataSourceState, DataSourceErrorKind
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
+from ldclient.interfaces import (DataSourceErrorKind, DataSourceState,
+                                 DataSourceStatus)
 from ldclient.testing.builders import *
 from ldclient.testing.stub_util import MockFeatureRequester, MockResponse
 from ldclient.testing.test_util import SpyListener
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 pp = None
 mock_requester = None

--- a/ldclient/testing/impl/datasource/test_streaming.py
+++ b/ldclient/testing/impl/datasource/test_streaming.py
@@ -35,7 +35,7 @@ def test_request_properties():
 
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -54,8 +54,7 @@ def test_sends_wrapper_header():
 
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri,
-                            wrapper_name = 'Flask', wrapper_version = '0.1.0')
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, wrapper_name='Flask', wrapper_version='0.1.0')
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -70,8 +69,7 @@ def test_sends_wrapper_header_without_version():
 
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri,
-                            wrapper_name = 'Flask')
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, wrapper_name='Flask')
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -86,8 +84,7 @@ def test_sends_tag_header():
 
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri,
-                            application = {"id": "my-id", "version": "my-version"})
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, application={"id": "my-id", "version": "my-version"})
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -103,8 +100,8 @@ def test_receives_put_event():
     segment = SegmentBuilder('segkey').version(1).build()
 
     with start_server() as server:
-        with stream_content(make_put_event([ flag ], [ segment ])) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri)
+        with stream_content(make_put_event([flag], [segment])) as stream:
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -124,8 +121,8 @@ def test_receives_patch_events():
     segmentv2 = SegmentBuilder('segkey').version(2).build()
 
     with start_server() as server:
-        with stream_content(make_put_event([ flagv1 ], [ segmentv1 ])) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri)
+        with stream_content(make_put_event([flagv1], [segmentv1])) as stream:
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -149,8 +146,8 @@ def test_receives_delete_events():
     segmentv1 = SegmentBuilder('segkey').version(1).build()
 
     with start_server() as server:
-        with stream_content(make_put_event([ flagv1 ], [ segmentv1 ])) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri)
+        with stream_content(make_put_event([flagv1], [segmentv1])) as stream:
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
             server.for_path('/all', stream)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -174,9 +171,9 @@ def test_reconnects_if_stream_is_broken():
     flagv2 = FlagBuilder('flagkey').version(2).build()
 
     with start_server() as server:
-        with stream_content(make_put_event([ flagv1 ])) as stream1:
-            with stream_content(make_put_event([ flagv2 ])) as stream2:
-                config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+        with stream_content(make_put_event([flagv1])) as stream1:
+            with stream_content(make_put_event([flagv2])) as stream2:
+                config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
                 server.for_path('/all', SequentialHandler(stream1, stream2))
 
                 with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -198,7 +195,7 @@ def test_retries_on_network_error():
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
             two_errors_then_success = SequentialHandler(error_handler, error_handler, stream)
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
             server.for_path('/all', two_errors_then_success)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -209,7 +206,7 @@ def test_retries_on_network_error():
                 server.await_request
 
 
-@pytest.mark.parametrize("status", [ 400, 408, 429, 500, 503 ])
+@pytest.mark.parametrize("status", [400, 408, 429, 500, 503])
 def test_recoverable_http_error(status):
     error_handler = BasicResponse(status)
     store = InMemoryFeatureStore()
@@ -217,7 +214,7 @@ def test_recoverable_http_error(status):
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
             two_errors_then_success = SequentialHandler(error_handler, error_handler, stream)
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
             server.for_path('/all', two_errors_then_success)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -227,7 +224,7 @@ def test_recoverable_http_error(status):
                 server.should_have_requests(3)
 
 
-@pytest.mark.parametrize("status", [ 401, 403, 404 ])
+@pytest.mark.parametrize("status", [401, 403, 404])
 def test_unrecoverable_http_error(status):
     error_handler = BasicResponse(status)
     store = InMemoryFeatureStore()
@@ -235,7 +232,7 @@ def test_unrecoverable_http_error(status):
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
             error_then_success = SequentialHandler(error_handler, stream)
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
             server.for_path('/all', error_then_success)
 
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
@@ -262,6 +259,7 @@ def test_http_proxy(monkeypatch):
                     # for the stream connection to work correctly - we can only detect the request.
                     ready.wait(start_wait)
                     assert sp.initialized()
+
     do_proxy_tests(_stream_processor_proxy_test, 'GET', monkeypatch)
 
 
@@ -270,7 +268,7 @@ def test_records_diagnostic_on_stream_init_success():
     ready = Event()
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
             server.for_path('/all', stream)
             diag_accum = _DiagnosticAccumulator(1)
 
@@ -289,7 +287,7 @@ def test_records_diagnostic_on_stream_init_failure():
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
             error_then_success = SequentialHandler(BasicResponse(503), stream)
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
             server.for_path('/all', error_then_success)
             diag_accum = _DiagnosticAccumulator(1)
 
@@ -303,7 +301,7 @@ def test_records_diagnostic_on_stream_init_failure():
                 assert recorded_inits[1]['failed'] is False
 
 
-@pytest.mark.parametrize("status", [ 400, 408, 429, 500, 503 ])
+@pytest.mark.parametrize("status", [400, 408, 429, 500, 503])
 def test_status_includes_http_code(status):
     error_handler = BasicResponse(status)
     store = InMemoryFeatureStore()
@@ -311,7 +309,7 @@ def test_status_includes_http_code(status):
     with start_server() as server:
         with stream_content(make_put_event()) as stream:
             two_errors_then_success = SequentialHandler(error_handler, error_handler, stream)
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
 
             spy = SpyListener()
             listeners = Listeners()
@@ -346,7 +344,7 @@ def test_invalid_json_triggers_listener():
     ready = Event()
     with start_server() as server:
         with stream_content(make_put_event()) as valid_stream, stream_content(make_invalid_put_event()) as invalid_stream:
-            config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
 
             statuses: List[DataSourceStatus] = []
             listeners = Listeners()
@@ -355,6 +353,7 @@ def test_invalid_json_triggers_listener():
                 if len(statuses) == 0:
                     invalid_stream.close()
                 statuses.append(s)
+
             listeners.add(listener)
 
             config._data_source_update_sink = DataSourceUpdateSinkImpl(store, listeners, Listeners())
@@ -380,7 +379,7 @@ def test_failure_transitions_from_valid():
     ready = Event()
     error_handler = BasicResponse(401)
     with start_server() as server:
-        config = Config(sdk_key = 'sdk-key', stream_uri = server.uri, initial_reconnect_delay = brief_delay)
+        config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
 
         spy = SpyListener()
         listeners = Listeners()

--- a/ldclient/testing/impl/datasource/test_streaming.py
+++ b/ldclient/testing/impl/datasource/test_streaming.py
@@ -1,23 +1,28 @@
-import pytest
+import time
 from threading import Event
 from typing import List
-import time
+
+import pytest
 
 from ldclient.config import Config
 from ldclient.feature_store import InMemoryFeatureStore
+from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl
 from ldclient.impl.datasource.streaming import StreamingUpdateProcessor
 from ldclient.impl.events.diagnostics import _DiagnosticAccumulator
 from ldclient.impl.listeners import Listeners
+from ldclient.interfaces import (DataSourceErrorKind, DataSourceState,
+                                 DataSourceStatus)
+from ldclient.testing.builders import *
+from ldclient.testing.http_util import (BasicResponse, CauseNetworkError,
+                                        SequentialHandler, start_server)
+from ldclient.testing.proxy_test_util import do_proxy_tests
+from ldclient.testing.stub_util import (make_delete_event,
+                                        make_invalid_put_event,
+                                        make_patch_event, make_put_event,
+                                        stream_content)
+from ldclient.testing.test_util import SpyListener
 from ldclient.version import VERSION
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-from ldclient.interfaces import DataSourceStatus, DataSourceState, DataSourceErrorKind
-from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl
-
-from ldclient.testing.builders import *
-from ldclient.testing.http_util import start_server, BasicResponse, CauseNetworkError, SequentialHandler
-from ldclient.testing.proxy_test_util import do_proxy_tests
-from ldclient.testing.stub_util import make_delete_event, make_patch_event, make_put_event, make_invalid_put_event, stream_content
-from ldclient.testing.test_util import SpyListener
 
 brief_delay = 0.001
 

--- a/ldclient/testing/impl/datasource/test_streaming.py
+++ b/ldclient/testing/impl/datasource/test_streaming.py
@@ -28,6 +28,7 @@ brief_delay = 0.001
 start_wait = 10
 update_wait = 3
 
+
 def test_request_properties():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -46,6 +47,7 @@ def test_request_properties():
                 assert req.headers.get('X-LaunchDarkly-Wrapper') is None
                 assert req.headers.get('X-LaunchDarkly-Tags') is None
 
+
 def test_sends_wrapper_header():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -60,6 +62,7 @@ def test_sends_wrapper_header():
                 sp.start()
                 req = server.await_request()
                 assert req.headers.get('X-LaunchDarkly-Wrapper') == 'Flask/0.1.0'
+
 
 def test_sends_wrapper_header_without_version():
     store = InMemoryFeatureStore()
@@ -76,6 +79,7 @@ def test_sends_wrapper_header_without_version():
                 req = server.await_request()
                 assert req.headers.get('X-LaunchDarkly-Wrapper') == 'Flask'
 
+
 def test_sends_tag_header():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -90,6 +94,7 @@ def test_sends_tag_header():
                 sp.start()
                 req = server.await_request()
                 assert req.headers.get('X-LaunchDarkly-Tags') == 'application-id/my-id application-version/my-version'
+
 
 def test_receives_put_event():
     store = InMemoryFeatureStore()
@@ -108,6 +113,7 @@ def test_receives_put_event():
                 assert sp.initialized()
                 expect_item(store, FEATURES, flag)
                 expect_item(store, SEGMENTS, segment)
+
 
 def test_receives_patch_events():
     store = InMemoryFeatureStore()
@@ -135,6 +141,7 @@ def test_receives_patch_events():
                 stream.push(make_patch_event(SEGMENTS, segmentv2))
                 expect_update(store, SEGMENTS, segmentv2)
 
+
 def test_receives_delete_events():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -159,6 +166,7 @@ def test_receives_delete_events():
                 stream.push(make_delete_event(SEGMENTS, segmentv1['key'], 2))
                 expect_delete(store, SEGMENTS, segmentv1['key'])
 
+
 def test_reconnects_if_stream_is_broken():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -182,6 +190,7 @@ def test_reconnects_if_stream_is_broken():
                     server.await_request
                     expect_update(store, FEATURES, flagv2)
 
+
 def test_retries_on_network_error():
     error_handler = CauseNetworkError()
     store = InMemoryFeatureStore()
@@ -198,6 +207,7 @@ def test_retries_on_network_error():
                 assert sp.initialized()
                 server.await_request
                 server.await_request
+
 
 @pytest.mark.parametrize("status", [ 400, 408, 429, 500, 503 ])
 def test_recoverable_http_error(status):
@@ -216,6 +226,7 @@ def test_recoverable_http_error(status):
                 assert sp.initialized()
                 server.should_have_requests(3)
 
+
 @pytest.mark.parametrize("status", [ 401, 403, 404 ])
 def test_unrecoverable_http_error(status):
     error_handler = BasicResponse(status)
@@ -232,6 +243,7 @@ def test_unrecoverable_http_error(status):
                 ready.wait(5)
                 assert not sp.initialized()
                 server.should_have_requests(1)
+
 
 def test_http_proxy(monkeypatch):
     def _stream_processor_proxy_test(server, config, secure):
@@ -252,6 +264,7 @@ def test_http_proxy(monkeypatch):
                     assert sp.initialized()
     do_proxy_tests(_stream_processor_proxy_test, 'GET', monkeypatch)
 
+
 def test_records_diagnostic_on_stream_init_success():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -268,6 +281,7 @@ def test_records_diagnostic_on_stream_init_success():
 
                 assert len(recorded_inits) == 1
                 assert recorded_inits[0]['failed'] is False
+
 
 def test_records_diagnostic_on_stream_init_failure():
     store = InMemoryFeatureStore()
@@ -287,6 +301,8 @@ def test_records_diagnostic_on_stream_init_failure():
                 assert len(recorded_inits) == 2
                 assert recorded_inits[0]['failed'] is True
                 assert recorded_inits[1]['failed'] is False
+
+
 @pytest.mark.parametrize("status", [ 400, 408, 429, 500, 503 ])
 def test_status_includes_http_code(status):
     error_handler = BasicResponse(status)
@@ -358,6 +374,7 @@ def test_invalid_json_triggers_listener():
 
                 assert statuses[1].state == DataSourceState.VALID
 
+
 def test_failure_transitions_from_valid():
     store = InMemoryFeatureStore()
     ready = Event()
@@ -393,11 +410,14 @@ def test_failure_transitions_from_valid():
 def expect_item(store, kind, item):
     assert store.get(kind, item['key'], lambda x: x) == item
 
+
 def expect_update(store, kind, expected_item):
     await_item(store, kind, expected_item['key'], expected_item)
 
+
 def expect_delete(store, kind, key):
     await_item(store, kind, key, None)
+
 
 def await_item(store, kind, key, expected_item):
     deadline = time.time() + update_wait

--- a/ldclient/testing/impl/evaluator_util.py
+++ b/ldclient/testing/impl/evaluator_util.py
@@ -1,11 +1,11 @@
+from typing import Any, Optional, Tuple, Union
+
 from ldclient import Context
 from ldclient.evaluation import BigSegmentsStatus
 from ldclient.impl.evaluator import Evaluator, _make_big_segment_ref
 from ldclient.impl.events.types import EventFactory
 from ldclient.impl.model import *
 from ldclient.testing.builders import *
-
-from typing import Any, Optional, Tuple, Union
 
 basic_user = Context.create('user-key')
 fake_timestamp = 0

--- a/ldclient/testing/impl/evaluator_util.py
+++ b/ldclient/testing/impl/evaluator_util.py
@@ -69,7 +69,7 @@ class EvaluatorBuilder:
     def _get_big_segments_membership(self, key: str) -> Tuple[Optional[dict], str]:
         if key not in self.__big_segments:
             raise Exception("test made unexpected request for big segments for context key '%s'" % key)
-        return (self.__big_segments[key], self.__big_segments_status)
+        return self.__big_segments[key], self.__big_segments_status
 
 basic_evaluator = EvaluatorBuilder().build()
 

--- a/ldclient/testing/impl/evaluator_util.py
+++ b/ldclient/testing/impl/evaluator_util.py
@@ -20,11 +20,7 @@ class EvaluatorBuilder:
         self.__big_segments_status = BigSegmentsStatus.HEALTHY
 
     def build(self) -> Evaluator:
-        return Evaluator(
-            self._get_flag,
-            self._get_segment,
-            self._get_big_segments_membership
-        )
+        return Evaluator(self._get_flag, self._get_segment, self._get_big_segments_membership)
 
     def with_flag(self, flag: FeatureFlag) -> 'EvaluatorBuilder':
         self.__flags[flag.key] = flag
@@ -70,6 +66,7 @@ class EvaluatorBuilder:
         if key not in self.__big_segments:
             raise Exception("test made unexpected request for big segments for context key '%s'" % key)
         return self.__big_segments[key], self.__big_segments_status
+
 
 basic_evaluator = EvaluatorBuilder().build()
 

--- a/ldclient/testing/impl/events/test_diagnostics.py
+++ b/ldclient/testing/impl/events/test_diagnostics.py
@@ -4,7 +4,10 @@ import uuid
 from ldclient.config import Config, HTTPConfig
 from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
-from ldclient.impl.events.diagnostics import create_diagnostic_id, create_diagnostic_init, _DiagnosticAccumulator, _create_diagnostic_config_object
+from ldclient.impl.events.diagnostics import (_create_diagnostic_config_object,
+                                              _DiagnosticAccumulator,
+                                              create_diagnostic_id,
+                                              create_diagnostic_init)
 
 
 def test_create_diagnostic_id():

--- a/ldclient/testing/impl/events/test_diagnostics.py
+++ b/ldclient/testing/impl/events/test_diagnostics.py
@@ -6,6 +6,7 @@ from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
 from ldclient.impl.events.diagnostics import create_diagnostic_id, create_diagnostic_init, _DiagnosticAccumulator, _create_diagnostic_config_object
 
+
 def test_create_diagnostic_id():
     test_config = Config(sdk_key = "SDK_KEY", http=HTTPConfig())
     diag_id = create_diagnostic_id(test_config)
@@ -14,6 +15,7 @@ def test_create_diagnostic_id():
     # Will throw if invalid UUID4
     uuid.UUID('urn:uuid:' + uid)
     assert diag_id['sdkKeySuffix'] == 'DK_KEY'
+
 
 def test_create_diagnostic_init():
     test_config = Config(sdk_key = "SDK_KEY", wrapper_name='django', wrapper_version = '5.1.1')
@@ -38,6 +40,7 @@ def test_create_diagnostic_init():
     # Verify converts to json without failure
     json.dumps(diag_init)
 
+
 def test_create_diagnostic_config_defaults():
     test_config = Config("SDK_KEY")
     diag_config = _create_diagnostic_config_object(test_config)
@@ -59,6 +62,7 @@ def test_create_diagnostic_config_defaults():
     assert diag_config['userKeysFlushIntervalMillis'] == 300000
     assert diag_config['diagnosticRecordingIntervalMillis'] == 900000
     assert diag_config['dataStoreType'] == 'memory'
+
 
 def test_create_diagnostic_config_custom():
     test_store = CachingStoreWrapper(_TestStoreForDiagnostics(), CacheConfig.default())
@@ -87,9 +91,11 @@ def test_create_diagnostic_config_custom():
     assert diag_config['diagnosticRecordingIntervalMillis'] == 60000
     assert diag_config['dataStoreType'] == 'MyFavoriteStore'
 
+
 class _TestStoreForDiagnostics:
     def describe_configuration(self, config):
         return 'MyFavoriteStore'
+
 
 def test_diagnostic_accumulator():
     test_config = Config(sdk_key = "SDK_KEY")

--- a/ldclient/testing/impl/events/test_diagnostics.py
+++ b/ldclient/testing/impl/events/test_diagnostics.py
@@ -8,7 +8,7 @@ from ldclient.impl.events.diagnostics import create_diagnostic_id, create_diagno
 
 
 def test_create_diagnostic_id():
-    test_config = Config(sdk_key = "SDK_KEY", http=HTTPConfig())
+    test_config = Config(sdk_key="SDK_KEY", http=HTTPConfig())
     diag_id = create_diagnostic_id(test_config)
     assert len(diag_id) == 2
     uid = diag_id['diagnosticId']
@@ -18,7 +18,7 @@ def test_create_diagnostic_id():
 
 
 def test_create_diagnostic_init():
-    test_config = Config(sdk_key = "SDK_KEY", wrapper_name='django', wrapper_version = '5.1.1')
+    test_config = Config(sdk_key="SDK_KEY", wrapper_name='django', wrapper_version='5.1.1')
     diag_id = create_diagnostic_id(test_config)
     diag_init = create_diagnostic_init(100, diag_id, test_config)
     assert len(diag_init) == 6
@@ -66,11 +66,23 @@ def test_create_diagnostic_config_defaults():
 
 def test_create_diagnostic_config_custom():
     test_store = CachingStoreWrapper(_TestStoreForDiagnostics(), CacheConfig.default())
-    test_config = Config("SDK_KEY", base_uri='https://test.com', events_uri='https://test.com',
-                         events_max_pending=10, flush_interval=1, stream_uri='https://test.com',
-                         stream=False, poll_interval=60, use_ldd=True, feature_store=test_store,
-                         all_attributes_private=True, context_keys_capacity=10, context_keys_flush_interval=60,
-                         http=HTTPConfig(http_proxy = 'proxy', read_timeout=1, connect_timeout=1), diagnostic_recording_interval=60)
+    test_config = Config(
+        "SDK_KEY",
+        base_uri='https://test.com',
+        events_uri='https://test.com',
+        events_max_pending=10,
+        flush_interval=1,
+        stream_uri='https://test.com',
+        stream=False,
+        poll_interval=60,
+        use_ldd=True,
+        feature_store=test_store,
+        all_attributes_private=True,
+        context_keys_capacity=10,
+        context_keys_flush_interval=60,
+        http=HTTPConfig(http_proxy='proxy', read_timeout=1, connect_timeout=1),
+        diagnostic_recording_interval=60,
+    )
     diag_config = _create_diagnostic_config_object(test_config)
 
     assert len(diag_config) == 16
@@ -98,7 +110,7 @@ class _TestStoreForDiagnostics:
 
 
 def test_diagnostic_accumulator():
-    test_config = Config(sdk_key = "SDK_KEY")
+    test_config = Config(sdk_key="SDK_KEY")
     diag_id = create_diagnostic_id(test_config)
     diag_accum = _DiagnosticAccumulator(diag_id)
 
@@ -131,8 +143,7 @@ def test_diagnostic_accumulator():
     assert diag_event['droppedEvents'] == 10
     assert diag_event['deduplicatedUsers'] == 15
     assert diag_event['eventsInLastBatch'] == 50
-    assert diag_event['streamInits'] == [{'timestamp': 100, 'durationMillis': 100, 'failed': False},
-                                         {'timestamp': 300, 'durationMillis': 200, 'failed': True}]
+    assert diag_event['streamInits'] == [{'timestamp': 100, 'durationMillis': 100, 'failed': False}, {'timestamp': 300, 'durationMillis': 200, 'failed': True}]
     json.dumps(diag_event)
 
     reset_diag_event = diag_accum.create_event_and_reset(0, 0)

--- a/ldclient/testing/impl/events/test_event_context_formatter.py
+++ b/ldclient/testing/impl/events/test_event_context_formatter.py
@@ -11,27 +11,13 @@ def test_simple_context():
 def test_context_with_more_attributes():
     f = EventContextFormatter(False, [])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).build()
-    assert f.format_context(c) == {
-        'kind': 'user',
-        'key': 'a',
-        'name': 'b',
-        'anonymous': True,
-        'c': True,
-        'd': 2
-    }
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'name': 'b', 'anonymous': True, 'c': True, 'd': 2}
 
 
 def test_context_can_redact_anonymous_attributes():
     f = EventContextFormatter(False, [])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).build()
-    assert f.format_context_redact_anonymous(c) == {
-        'kind': 'user',
-        'key': 'a',
-        'anonymous': True,
-        '_meta': {
-            'redactedAttributes': ['name', 'c', 'd']
-        }
-    }
+    assert f.format_context_redact_anonymous(c) == {'kind': 'user', 'key': 'a', 'anonymous': True, '_meta': {'redactedAttributes': ['name', 'c', 'd']}}
 
 
 def test_multi_kind_context_can_redact_anonymous_attributes():
@@ -42,85 +28,36 @@ def test_multi_kind_context_can_redact_anonymous_attributes():
 
     assert f.format_context_redact_anonymous(multi) == {
         'kind': 'multi',
-        'user': {
-            'key': 'user-key',
-            'anonymous': True,
-            '_meta': {
-                'redactedAttributes': ['name', 'c', 'd']
-            }
-        },
-        'org': {
-            'key': 'org-key',
-            'name': 'b',
-            'c': True,
-            'd': 2
-        }
+        'user': {'key': 'user-key', 'anonymous': True, '_meta': {'redactedAttributes': ['name', 'c', 'd']}},
+        'org': {'key': 'org-key', 'name': 'b', 'c': True, 'd': 2},
     }
 
 
 def test_multi_context():
     f = EventContextFormatter(False, [])
-    c = Context.create_multi(
-        Context.create('a'),
-        Context.builder('b').kind('c').name('d').build()
-    )
-    assert f.format_context(c) == {
-        'kind': 'multi',
-        'user': {
-            'key': 'a'
-        },
-        'c': {
-            'key': 'b',
-            'name': 'd'
-        }
-    }
+    c = Context.create_multi(Context.create('a'), Context.builder('b').kind('c').name('d').build())
+    assert f.format_context(c) == {'kind': 'multi', 'user': {'key': 'a'}, 'c': {'key': 'b', 'name': 'd'}}
 
 
 def test_all_private():
     f = EventContextFormatter(True, [])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).build()
-    assert f.format_context(c) == {
-        'kind': 'user',
-        'key': 'a',
-        'anonymous': True,
-        '_meta': {'redactedAttributes': ['name', 'c', 'd']}
-    }
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'anonymous': True, '_meta': {'redactedAttributes': ['name', 'c', 'd']}}
 
 
 def test_some_private_global():
     f = EventContextFormatter(False, ['name', 'd'])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).build()
-    assert f.format_context(c) == {
-        'kind': 'user',
-        'key': 'a',
-        'anonymous': True,
-        'c': True,
-        '_meta': {'redactedAttributes': ['name', 'd']}
-    }
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'anonymous': True, 'c': True, '_meta': {'redactedAttributes': ['name', 'd']}}
 
 
 def test_some_private_per_context():
     f = EventContextFormatter(False, ['name'])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).private('d').build()
-    assert f.format_context(c) == {
-        'kind': 'user',
-        'key': 'a',
-        'anonymous': True,
-        'c': True,
-        '_meta': {'redactedAttributes': ['name', 'd']}
-    }
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'anonymous': True, 'c': True, '_meta': {'redactedAttributes': ['name', 'd']}}
 
 
 def test_private_property_in_object():
     f = EventContextFormatter(False, ['/b/prop1', '/c/prop2/sub1'])
-    c = Context.builder('a') \
-        .set('b', {'prop1': True, 'prop2': 3}) \
-        .set('c', {'prop1': {'sub1': True}, 'prop2': {'sub1': 4, 'sub2': 5}}) \
-        .build()
-    assert f.format_context(c) == {
-        'kind': 'user',
-        'key': 'a',
-        'b': {'prop2': 3},
-        'c': {'prop1': {'sub1': True}, 'prop2': {'sub2': 5}},
-        '_meta': {'redactedAttributes': ['/b/prop1', '/c/prop2/sub1']}
-    }
+    c = Context.builder('a').set('b', {'prop1': True, 'prop2': 3}).set('c', {'prop1': {'sub1': True}, 'prop2': {'sub1': 4, 'sub2': 5}}).build()
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'b': {'prop2': 3}, 'c': {'prop1': {'sub1': True}, 'prop2': {'sub2': 5}}, '_meta': {'redactedAttributes': ['/b/prop1', '/c/prop2/sub1']}}

--- a/ldclient/testing/impl/events/test_event_context_formatter.py
+++ b/ldclient/testing/impl/events/test_event_context_formatter.py
@@ -1,10 +1,12 @@
 from ldclient.context import Context
 from ldclient.impl.events.event_context_formatter import EventContextFormatter
 
+
 def test_simple_context():
     f = EventContextFormatter(False, [])
     c = Context.create('a')
     assert f.format_context(c) == {'kind': 'user', 'key': 'a'}
+
 
 def test_context_with_more_attributes():
     f = EventContextFormatter(False, [])
@@ -18,6 +20,7 @@ def test_context_with_more_attributes():
         'd': 2
     }
 
+
 def test_context_can_redact_anonymous_attributes():
     f = EventContextFormatter(False, [])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).build()
@@ -29,6 +32,7 @@ def test_context_can_redact_anonymous_attributes():
             'redactedAttributes': ['name', 'c', 'd']
         }
     }
+
 
 def test_multi_kind_context_can_redact_anonymous_attributes():
     f = EventContextFormatter(False, [])
@@ -53,6 +57,7 @@ def test_multi_kind_context_can_redact_anonymous_attributes():
         }
     }
 
+
 def test_multi_context():
     f = EventContextFormatter(False, [])
     c = Context.create_multi(
@@ -70,6 +75,7 @@ def test_multi_context():
         }
     }
 
+
 def test_all_private():
     f = EventContextFormatter(True, [])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).build()
@@ -79,6 +85,7 @@ def test_all_private():
         'anonymous': True,
         '_meta': {'redactedAttributes': ['name', 'c', 'd']}
     }
+
 
 def test_some_private_global():
     f = EventContextFormatter(False, ['name', 'd'])
@@ -91,6 +98,7 @@ def test_some_private_global():
         '_meta': {'redactedAttributes': ['name', 'd']}
     }
 
+
 def test_some_private_per_context():
     f = EventContextFormatter(False, ['name'])
     c = Context.builder('a').name('b').anonymous(True).set('c', True).set('d', 2).private('d').build()
@@ -101,6 +109,7 @@ def test_some_private_per_context():
         'c': True,
         '_meta': {'redactedAttributes': ['name', 'd']}
     }
+
 
 def test_private_property_in_object():
     f = EventContextFormatter(False, ['/b/prop1', '/c/prop2/sub1'])

--- a/ldclient/testing/impl/events/test_event_factory.py
+++ b/ldclient/testing/impl/events/test_event_factory.py
@@ -9,17 +9,11 @@ _user = Context.create('x')
 
 
 def make_basic_flag_with_rules(kind, should_track_events):
-    rule_builder = FlagRuleBuilder().rollout({
-        'variations': [
-            { 'variation': 0, 'weight': 50000 },
-            { 'variation': 1, 'weight': 50000 }
-        ]
-    })
+    rule_builder = FlagRuleBuilder().rollout({'variations': [{'variation': 0, 'weight': 50000}, {'variation': 1, 'weight': 50000}]})
     if kind == 'rulematch':
         rule_builder.track_events(should_track_events)
 
-    flag_builder = FlagBuilder('feature').on(True).fallthrough_variation(0).variations(False, True) \
-        .rules(rule_builder.build())
+    flag_builder = FlagBuilder('feature').on(True).fallthrough_variation(0).variations(False, True).rules(rule_builder.build())
     if kind == 'fallthrough':
         flag_builder.track_events_fallthrough(should_track_events)
     return flag_builder.build()

--- a/ldclient/testing/impl/events/test_event_factory.py
+++ b/ldclient/testing/impl/events/test_event_factory.py
@@ -7,6 +7,7 @@ from ldclient.testing.builders import *
 _event_factory_default = EventFactory(False)
 _user = Context.create('x')
 
+
 def make_basic_flag_with_rules(kind, should_track_events):
     rule_builder = FlagRuleBuilder().rollout({
         'variations': [
@@ -23,12 +24,14 @@ def make_basic_flag_with_rules(kind, should_track_events):
         flag_builder.track_events_fallthrough(should_track_events)
     return flag_builder.build()
 
+
 def test_fallthrough_track_event_false():
     flag = make_basic_flag_with_rules('fallthrough', False)
     detail = EvaluationDetail('b', 1, {'kind': 'FALLTHROUGH'})
 
     eval = _event_factory_default.new_eval_event(flag, _user, detail, 'b', None)
     assert eval.track_events is False
+
 
 def test_fallthrough_track_event_true():
     flag = make_basic_flag_with_rules('fallthrough', True)
@@ -37,12 +40,14 @@ def test_fallthrough_track_event_true():
     eval = _event_factory_default.new_eval_event(flag, _user, detail, 'b', None)
     assert eval.track_events is True
 
+
 def test_fallthrough_track_event_false_with_experiment():
     flag = make_basic_flag_with_rules('fallthrough', False)
     detail = EvaluationDetail('b', 1, {'kind': 'FALLTHROUGH', 'inExperiment': True})
 
     eval = _event_factory_default.new_eval_event(flag, _user, detail, 'b', None)
     assert eval.track_events is True
+
 
 def test_rulematch_track_event_false():
     flag = make_basic_flag_with_rules('rulematch', False)
@@ -51,12 +56,14 @@ def test_rulematch_track_event_false():
     eval = _event_factory_default.new_eval_event(flag, _user, detail, 'b', None)
     assert eval.track_events is False
 
+
 def test_rulematch_track_event_true():
     flag = make_basic_flag_with_rules('rulematch', True)
     detail = EvaluationDetail('b', 1, {'kind': 'RULE_MATCH', 'ruleIndex': 0})
 
     eval = _event_factory_default.new_eval_event(flag, _user, detail, 'b', None)
     assert eval.track_events is True
+
 
 def test_rulematch_track_event_false_with_experiment():
     flag = make_basic_flag_with_rules('rulematch', False)

--- a/ldclient/testing/impl/events/test_event_factory.py
+++ b/ldclient/testing/impl/events/test_event_factory.py
@@ -1,7 +1,6 @@
 from ldclient.context import Context
 from ldclient.evaluation import EvaluationDetail
 from ldclient.impl.events.types import EventFactory
-
 from ldclient.testing.builders import *
 
 _event_factory_default = EventFactory(False)

--- a/ldclient/testing/impl/events/test_event_processor.py
+++ b/ldclient/testing/impl/events/test_event_processor.py
@@ -37,9 +37,11 @@ def setup_function():
     global mock_http
     mock_http = MockHttp()
 
+
 def teardown_function():
     if ep is not None:
         ep.stop()
+
 
 def make_context_keys(context: Context) -> dict:
     ret = {}  # type: Dict[str, str]
@@ -226,6 +228,7 @@ def test_identify_event_is_queued():
         assert len(output) == 1
         check_identify_event(output[0], e)
 
+
 def test_context_is_filtered_in_identify_event():
     with DefaultTestProcessor(all_attributes_private = True) as ep:
         formatter = EventContextFormatter(True, [])
@@ -328,6 +331,7 @@ def test_exclude_can_keep_feature_event_from_summary():
         check_index_event(output[0], e)
         check_feature_event(output[1], e)
 
+
 def test_context_is_filtered_in_index_event():
     with DefaultTestProcessor(all_attributes_private = True) as ep:
         formatter = EventContextFormatter(True, [])
@@ -339,6 +343,7 @@ def test_context_is_filtered_in_index_event():
         check_index_event(output[0], e, formatter.format_context(context))
         check_feature_event(output[1], e, formatter.format_context(context))
         check_summary_event(output[2])
+
 
 def test_two_events_for_same_context_only_produce_one_index_event():
     with DefaultTestProcessor(context_keys_flush_interval = 300) as ep:
@@ -353,6 +358,7 @@ def test_two_events_for_same_context_only_produce_one_index_event():
         check_feature_event(output[1], e0)
         check_feature_event(output[2], e1)
         check_summary_event(output[3])
+
 
 def test_new_index_event_is_added_if_context_cache_has_been_cleared():
     with DefaultTestProcessor(context_keys_flush_interval = 0.1) as ep:
@@ -370,6 +376,7 @@ def test_new_index_event_is_added_if_context_cache_has_been_cleared():
         check_feature_event(output[3], e1)
         check_summary_event(output[4])
 
+
 def test_event_kind_is_debug_if_flag_is_temporarily_in_debug_mode():
     with DefaultTestProcessor() as ep:
         future_time = now() + 100000
@@ -382,6 +389,7 @@ def test_event_kind_is_debug_if_flag_is_temporarily_in_debug_mode():
         check_index_event(output[0], e)
         check_debug_event(output[1], e)
         check_summary_event(output[2])
+
 
 def test_event_can_be_both_tracked_and_debugged():
     with DefaultTestProcessor() as ep:
@@ -435,6 +443,7 @@ def test_debug_mode_does_not_expire_if_both_client_time_and_server_time_are_befo
         check_debug_event(output[1], e)
         check_summary_event(output[2])
 
+
 def test_debug_mode_expires_based_on_client_time_if_client_time_is_later_than_server_time():
     with DefaultTestProcessor() as ep:
         # Pick a server time that is somewhat behind the client time
@@ -458,6 +467,7 @@ def test_debug_mode_expires_based_on_client_time_if_client_time_is_later_than_se
         check_index_event(output[0], e)
         check_summary_event(output[1])
 
+
 def test_debug_mode_expires_based_on_server_time_if_server_time_is_later_than_client_time():
     with DefaultTestProcessor() as ep:
         # Pick a server time that is somewhat ahead of the client time
@@ -480,6 +490,7 @@ def test_debug_mode_expires_based_on_server_time_if_server_time_is_later_than_cl
         assert len(output) == 2
         check_index_event(output[0], e)
         check_summary_event(output[1])
+
 
 def test_nontracked_events_are_summarized():
     with DefaultTestProcessor() as ep:
@@ -511,6 +522,7 @@ def test_nontracked_events_are_summarized():
             }
         }
 
+
 def test_custom_event_is_queued_with_user():
     with DefaultTestProcessor() as ep:
         e = EventInputCustom(timestamp, context, 'eventkey', { 'thing': 'stuff '}, 1.5)
@@ -521,11 +533,13 @@ def test_custom_event_is_queued_with_user():
         check_index_event(output[0], e)
         check_custom_event(output[1], e)
 
+
 def test_nothing_is_sent_if_there_are_no_events():
     with DefaultTestProcessor() as ep:
         ep.flush()
         ep._wait_until_inactive()
         assert mock_http.request_data is None
+
 
 def test_sdk_key_is_sent():
     with DefaultTestProcessor(sdk_key = 'SDK_KEY') as ep:
@@ -535,6 +549,7 @@ def test_sdk_key_is_sent():
 
         assert mock_http.request_headers.get('Authorization') == 'SDK_KEY'
 
+
 def test_wrapper_header_not_sent_when_not_set():
     with DefaultTestProcessor() as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
@@ -542,6 +557,7 @@ def test_wrapper_header_not_sent_when_not_set():
         ep._wait_until_inactive()
 
         assert mock_http.request_headers.get('X-LaunchDarkly-Wrapper') is None
+
 
 def test_wrapper_header_sent_when_set():
     with DefaultTestProcessor(wrapper_name = "Flask", wrapper_version = "0.0.1") as ep:
@@ -551,6 +567,7 @@ def test_wrapper_header_sent_when_set():
 
         assert mock_http.request_headers.get('X-LaunchDarkly-Wrapper') == "Flask/0.0.1"
 
+
 def test_wrapper_header_sent_without_version():
     with DefaultTestProcessor(wrapper_name = "Flask") as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
@@ -558,6 +575,7 @@ def test_wrapper_header_sent_without_version():
         ep._wait_until_inactive()
 
         assert mock_http.request_headers.get('X-LaunchDarkly-Wrapper') == "Flask"
+
 
 def test_event_schema_set_on_event_send():
     with DefaultTestProcessor() as ep:
@@ -567,15 +585,18 @@ def test_event_schema_set_on_event_send():
 
         assert mock_http.request_headers.get('X-LaunchDarkly-Event-Schema') == "4"
 
+
 def test_sdk_key_is_sent_on_diagnostic_request():
     with DefaultTestProcessor(sdk_key = 'SDK_KEY', diagnostic_opt_out=False) as ep:
         ep._wait_until_inactive()
         assert mock_http.request_headers.get('Authorization') == 'SDK_KEY'
 
+
 def test_event_schema_not_set_on_diagnostic_send():
     with DefaultTestProcessor(diagnostic_opt_out=False) as ep:
         ep._wait_until_inactive()
         assert mock_http.request_headers.get('X-LaunchDarkly-Event-Schema') is None
+
 
 def test_init_diagnostic_event_sent():
     with DefaultTestProcessor(diagnostic_opt_out=False) as ep:
@@ -583,6 +604,7 @@ def test_init_diagnostic_event_sent():
         # Fields are tested in test_diagnostics.py
         assert len(diag_init) == 6
         assert diag_init['kind'] == 'diagnostic-init'
+
 
 def test_periodic_diagnostic_includes_events_in_batch():
     with DefaultTestProcessor(diagnostic_opt_out=False) as ep:
@@ -598,6 +620,7 @@ def test_periodic_diagnostic_includes_events_in_batch():
         assert diag_event['kind'] == 'diagnostic'
         assert diag_event['eventsInLastBatch'] == 1
         assert diag_event['deduplicatedUsers'] == 0
+
 
 def test_periodic_diagnostic_includes_deduplicated_users():
     with DefaultTestProcessor(diagnostic_opt_out=False) as ep:
@@ -617,20 +640,26 @@ def test_periodic_diagnostic_includes_deduplicated_users():
         assert diag_event['eventsInLastBatch'] == 3
         assert diag_event['deduplicatedUsers'] == 1
 
+
 def test_no_more_payloads_are_sent_after_401_error():
     verify_unrecoverable_http_error(401)
+
 
 def test_no_more_payloads_are_sent_after_403_error():
     verify_unrecoverable_http_error(403)
 
+
 def test_will_still_send_after_408_error():
     verify_recoverable_http_error(408)
+
 
 def test_will_still_send_after_429_error():
     verify_recoverable_http_error(429)
 
+
 def test_will_still_send_after_500_error():
     verify_recoverable_http_error(500)
+
 
 def test_does_not_block_on_full_inbox():
     config = Config("fake_sdk_key", events_max_pending=1)  # this sets the size of both the inbox and the outbox to 1
@@ -662,6 +691,7 @@ def test_does_not_block_on_full_inbox():
         assert message1.param == event1
         assert had_no_more
 
+
 def test_http_proxy(monkeypatch):
     def _event_processor_proxy_test(server, config, secure):
         with DefaultEventProcessor(config) as ep:
@@ -669,6 +699,7 @@ def test_http_proxy(monkeypatch):
             ep.flush()
             ep._wait_until_inactive()
     do_proxy_tests(_event_processor_proxy_test, 'POST', monkeypatch)
+
 
 def verify_unrecoverable_http_error(status):
     with DefaultTestProcessor(sdk_key = 'SDK_KEY') as ep:
@@ -683,6 +714,7 @@ def verify_unrecoverable_http_error(status):
         ep._wait_until_inactive()
         assert mock_http.request_data is None
 
+
 def verify_recoverable_http_error(status):
     with DefaultTestProcessor(sdk_key = 'SDK_KEY') as ep:
         mock_http.set_response_status(status)
@@ -696,6 +728,7 @@ def verify_recoverable_http_error(status):
         ep._wait_until_inactive()
         assert mock_http.request_data is not None
 
+
 def test_event_payload_id_is_sent():
     with DefaultEventProcessor(Config(sdk_key = 'SDK_KEY'), mock_http) as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
@@ -706,6 +739,7 @@ def test_event_payload_id_is_sent():
         assert headerVal is not None
         # Throws on invalid UUID
         uuid.UUID(headerVal)
+
 
 def test_event_payload_id_changes_between_requests():
     with DefaultEventProcessor(Config(sdk_key = 'SDK_KEY'), mock_http) as ep:
@@ -721,6 +755,7 @@ def test_event_payload_id_changes_between_requests():
         secondPayloadId = mock_http.recorded_requests[1][0].get('X-LaunchDarkly-Payload-ID')
         assert firstPayloadId != secondPayloadId
 
+
 def flush_and_get_events(ep):
     ep.flush()
     ep._wait_until_inactive()
@@ -729,15 +764,18 @@ def flush_and_get_events(ep):
     else:
         return json.loads(mock_http.request_data)
 
+
 def check_identify_event(data, source: EventInput, context_json: Optional[dict] = None):
     assert data['kind'] == 'identify'
     assert data['creationDate'] == source.timestamp
     assert data['context'] == (source.context.to_dict() if context_json is None else context_json)
 
+
 def check_index_event(data, source: EventInput, context_json: Optional[dict] = None):
     assert data['kind'] == 'index'
     assert data['creationDate'] == source.timestamp
     assert data['context'] == (source.context.to_dict() if context_json is None else context_json)
+
 
 def check_feature_event(data, source: EventInputEvaluation, context_json: Optional[dict] = None):
     assert data['kind'] == 'feature'
@@ -811,6 +849,7 @@ def check_debug_event(data, source: EventInputEvaluation, context_json: Optional
     assert data['context'] == (source.context.to_dict() if context_json is None else context_json)
     assert data.get('prereq_of') == None if source.prereq_of is None else source.prereq_of.key
 
+
 def check_custom_event(data, source: EventInputCustom):
     assert data['kind'] == 'custom'
     assert data['creationDate'] == source.timestamp
@@ -819,8 +858,10 @@ def check_custom_event(data, source: EventInputCustom):
     assert data['contextKeys'] == make_context_keys(source.context)
     assert data.get('metricValue') == source.metric_value
 
+
 def check_summary_event(data):
     assert data['kind'] == 'summary'
+
 
 def now():
     return int(time.time() * 1000)

--- a/ldclient/testing/impl/events/test_event_processor.py
+++ b/ldclient/testing/impl/events/test_event_processor.py
@@ -1,26 +1,28 @@
-import pytest
 import json
-from threading import Thread
-from typing import Set, Dict
-from datetime import timedelta
 import time
 import uuid
+from datetime import timedelta
+from threading import Thread
+from typing import Dict, Set
+
+import pytest
 
 from ldclient.config import Config
 from ldclient.context import Context
 from ldclient.evaluation import EvaluationDetail
-from ldclient.impl.events.diagnostics import create_diagnostic_id, _DiagnosticAccumulator
-from ldclient.impl.events.event_processor import DefaultEventProcessor
-from ldclient.migrations.types import Operation, Origin, Stage
-from ldclient.migrations.tracker import MigrationOpEvent
-from ldclient.impl.events.types import EventInput, EventInputCustom, EventInputEvaluation, EventInputIdentify
-from ldclient.impl.util import timedelta_millis
+from ldclient.impl.events.diagnostics import (_DiagnosticAccumulator,
+                                              create_diagnostic_id)
 from ldclient.impl.events.event_context_formatter import EventContextFormatter
-
+from ldclient.impl.events.event_processor import DefaultEventProcessor
+from ldclient.impl.events.types import (EventInput, EventInputCustom,
+                                        EventInputEvaluation,
+                                        EventInputIdentify)
+from ldclient.impl.util import timedelta_millis
+from ldclient.migrations.tracker import MigrationOpEvent
+from ldclient.migrations.types import Operation, Origin, Stage
 from ldclient.testing.builders import *
 from ldclient.testing.proxy_test_util import do_proxy_tests
 from ldclient.testing.stub_util import MockHttp
-
 
 default_config = Config("fake_sdk_key")
 context = Context.builder('userkey').name('Red').build()

--- a/ldclient/testing/impl/events/test_event_processor.py
+++ b/ldclient/testing/impl/events/test_event_processor.py
@@ -72,7 +72,6 @@ class DefaultTestProcessor(DefaultEventProcessor):
         pytest.param(Operation.READ, Stage.LIVE, id="read live"),
         pytest.param(Operation.READ, Stage.RAMPDOWN, id="read rampdown"),
         pytest.param(Operation.READ, Stage.COMPLETE, id="read complete"),
-
         pytest.param(Operation.WRITE, Stage.OFF, id="write off"),
         pytest.param(Operation.WRITE, Stage.DUALWRITE, id="write dualwrite"),
         pytest.param(Operation.WRITE, Stage.SHADOW, id="write shadow"),
@@ -100,7 +99,6 @@ def test_migration_op_event_is_queued_without_flag(operation: Operation, default
         pytest.param(Operation.READ, Stage.LIVE, {Origin.OLD, Origin.NEW}, id="read live"),
         pytest.param(Operation.READ, Stage.RAMPDOWN, {Origin.NEW}, id="read rampdown"),
         pytest.param(Operation.READ, Stage.COMPLETE, {Origin.NEW}, id="read complete"),
-
         pytest.param(Operation.WRITE, Stage.OFF, {Origin.OLD}, id="write off"),
         pytest.param(Operation.WRITE, Stage.DUALWRITE, {Origin.OLD, Origin.NEW}, id="write dualwrite"),
         pytest.param(Operation.WRITE, Stage.SHADOW, {Origin.OLD, Origin.NEW}, id="write shadow"),
@@ -128,7 +126,6 @@ def test_migration_op_event_is_queued_with_invoked(operation: Operation, default
         pytest.param(Operation.READ, Stage.LIVE, {Origin.OLD, Origin.NEW}, id="read live"),
         pytest.param(Operation.READ, Stage.RAMPDOWN, {Origin.NEW}, id="read rampdown"),
         pytest.param(Operation.READ, Stage.COMPLETE, {Origin.NEW}, id="read complete"),
-
         pytest.param(Operation.WRITE, Stage.OFF, {Origin.OLD}, id="write off"),
         pytest.param(Operation.WRITE, Stage.DUALWRITE, {Origin.OLD}, id="write dualwrite"),
         pytest.param(Operation.WRITE, Stage.SHADOW, {Origin.OLD}, id="write shadow"),
@@ -156,7 +153,6 @@ def test_migration_op_event_is_queued_with_errors(operation: Operation, default_
         pytest.param(Operation.READ, Stage.LIVE, {Origin.OLD: 100, Origin.NEW: 100}, id="read live"),
         pytest.param(Operation.READ, Stage.RAMPDOWN, {Origin.NEW: 100}, id="read rampdown"),
         pytest.param(Operation.READ, Stage.COMPLETE, {Origin.NEW: 100}, id="read complete"),
-
         pytest.param(Operation.WRITE, Stage.OFF, {Origin.OLD: 100}, id="write off"),
         pytest.param(Operation.WRITE, Stage.DUALWRITE, {Origin.OLD: 100, Origin.NEW: 100}, id="write dualwrite"),
         pytest.param(Operation.WRITE, Stage.SHADOW, {Origin.OLD: 100, Origin.NEW: 100}, id="write shadow"),
@@ -168,7 +164,9 @@ def test_migration_op_event_is_queued_with_errors(operation: Operation, default_
 def test_migration_op_event_is_queued_with_latencies(operation: Operation, default_stage: Stage, latencies: Dict[Origin, float]):
     with DefaultTestProcessor() as ep:
         delta_latencies = {origin: timedelta(milliseconds=ms) for origin, ms in latencies.items()}
-        e = MigrationOpEvent(timestamp, context, flag.key, flag, operation, default_stage, EvaluationDetail('off', 0, {'kind': 'FALLTHROUGH'}), {Origin.OLD, Origin.NEW}, None, None, set(), delta_latencies)
+        e = MigrationOpEvent(
+            timestamp, context, flag.key, flag, operation, default_stage, EvaluationDetail('off', 0, {'kind': 'FALLTHROUGH'}), {Origin.OLD, Origin.NEW}, None, None, set(), delta_latencies
+        )
         ep.send_event(e)
 
         output = flush_and_get_events(ep)
@@ -178,7 +176,20 @@ def test_migration_op_event_is_queued_with_latencies(operation: Operation, defau
 
 def test_migration_op_event_is_disabled_with_sampling_ratio():
     with DefaultTestProcessor() as ep:
-        e = MigrationOpEvent(timestamp, context, flag_with_0_sampling_ratio.key, flag_with_0_sampling_ratio, Operation.READ, Stage.OFF, EvaluationDetail('off', 0, {'kind': 'FALLTHROUGH'}), {Origin.OLD}, None, None, set(), {})
+        e = MigrationOpEvent(
+            timestamp,
+            context,
+            flag_with_0_sampling_ratio.key,
+            flag_with_0_sampling_ratio,
+            Operation.READ,
+            Stage.OFF,
+            EvaluationDetail('off', 0, {'kind': 'FALLTHROUGH'}),
+            {Origin.OLD},
+            None,
+            None,
+            set(),
+            {},
+        )
         ep.send_event(e)
 
         # NOTE: Have to send an identify event; otherwise, we will timeout waiting on no events.
@@ -199,7 +210,6 @@ def test_migration_op_event_is_disabled_with_sampling_ratio():
         pytest.param(Operation.READ, Stage.LIVE, id="read live"),
         pytest.param(Operation.READ, Stage.RAMPDOWN, id="read rampdown"),
         pytest.param(Operation.READ, Stage.COMPLETE, id="read complete"),
-
         pytest.param(Operation.WRITE, Stage.OFF, id="write off"),
         pytest.param(Operation.WRITE, Stage.DUALWRITE, id="write dualwrite"),
         pytest.param(Operation.WRITE, Stage.SHADOW, id="write shadow"),
@@ -230,7 +240,7 @@ def test_identify_event_is_queued():
 
 
 def test_context_is_filtered_in_identify_event():
-    with DefaultTestProcessor(all_attributes_private = True) as ep:
+    with DefaultTestProcessor(all_attributes_private=True) as ep:
         formatter = EventContextFormatter(True, [])
         e = EventInputIdentify(timestamp, context)
         ep.send_event(e)
@@ -333,7 +343,7 @@ def test_exclude_can_keep_feature_event_from_summary():
 
 
 def test_context_is_filtered_in_index_event():
-    with DefaultTestProcessor(all_attributes_private = True) as ep:
+    with DefaultTestProcessor(all_attributes_private=True) as ep:
         formatter = EventContextFormatter(True, [])
         e = EventInputEvaluation(timestamp, context, flag.key, flag, 1, 'value', None, 'default', None, True)
         ep.send_event(e)
@@ -346,7 +356,7 @@ def test_context_is_filtered_in_index_event():
 
 
 def test_two_events_for_same_context_only_produce_one_index_event():
-    with DefaultTestProcessor(context_keys_flush_interval = 300) as ep:
+    with DefaultTestProcessor(context_keys_flush_interval=300) as ep:
         e0 = EventInputEvaluation(timestamp, context, flag.key, flag, 1, 'value1', None, 'default', None, True)
         e1 = EventInputEvaluation(timestamp, context, flag.key, flag, 2, 'value2', None, 'default', None, True)
         ep.send_event(e0)
@@ -361,7 +371,7 @@ def test_two_events_for_same_context_only_produce_one_index_event():
 
 
 def test_new_index_event_is_added_if_context_cache_has_been_cleared():
-    with DefaultTestProcessor(context_keys_flush_interval = 0.1) as ep:
+    with DefaultTestProcessor(context_keys_flush_interval=0.1) as ep:
         e0 = EventInputEvaluation(timestamp, context, flag.key, flag, 1, 'value1', None, 'default', None, True)
         e1 = EventInputEvaluation(timestamp, context, flag.key, flag, 2, 'value2', None, 'default', None, True)
         ep.send_event(e0)
@@ -510,22 +520,14 @@ def test_nontracked_events_are_summarized():
         assert se['startDate'] == earlier_time
         assert se['endDate'] == later_time
         assert se['features'] == {
-            'flagkey1': {
-                'contextKinds': ['user'],
-                'default': 'default1',
-                'counters': [ { 'version': 11, 'variation': 1, 'value': 'value1', 'count': 1 } ]
-            },
-            'flagkey2': {
-                'contextKinds': ['user'],
-                'default': 'default2',
-                'counters': [ { 'version': 22, 'variation': 2, 'value': 'value2', 'count': 1 } ]
-            }
+            'flagkey1': {'contextKinds': ['user'], 'default': 'default1', 'counters': [{'version': 11, 'variation': 1, 'value': 'value1', 'count': 1}]},
+            'flagkey2': {'contextKinds': ['user'], 'default': 'default2', 'counters': [{'version': 22, 'variation': 2, 'value': 'value2', 'count': 1}]},
         }
 
 
 def test_custom_event_is_queued_with_user():
     with DefaultTestProcessor() as ep:
-        e = EventInputCustom(timestamp, context, 'eventkey', { 'thing': 'stuff '}, 1.5)
+        e = EventInputCustom(timestamp, context, 'eventkey', {'thing': 'stuff '}, 1.5)
         ep.send_event(e)
 
         output = flush_and_get_events(ep)
@@ -542,7 +544,7 @@ def test_nothing_is_sent_if_there_are_no_events():
 
 
 def test_sdk_key_is_sent():
-    with DefaultTestProcessor(sdk_key = 'SDK_KEY') as ep:
+    with DefaultTestProcessor(sdk_key='SDK_KEY') as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
         ep._wait_until_inactive()
@@ -560,7 +562,7 @@ def test_wrapper_header_not_sent_when_not_set():
 
 
 def test_wrapper_header_sent_when_set():
-    with DefaultTestProcessor(wrapper_name = "Flask", wrapper_version = "0.0.1") as ep:
+    with DefaultTestProcessor(wrapper_name="Flask", wrapper_version="0.0.1") as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
         ep._wait_until_inactive()
@@ -569,7 +571,7 @@ def test_wrapper_header_sent_when_set():
 
 
 def test_wrapper_header_sent_without_version():
-    with DefaultTestProcessor(wrapper_name = "Flask") as ep:
+    with DefaultTestProcessor(wrapper_name="Flask") as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
         ep._wait_until_inactive()
@@ -587,7 +589,7 @@ def test_event_schema_set_on_event_send():
 
 
 def test_sdk_key_is_sent_on_diagnostic_request():
-    with DefaultTestProcessor(sdk_key = 'SDK_KEY', diagnostic_opt_out=False) as ep:
+    with DefaultTestProcessor(sdk_key='SDK_KEY', diagnostic_opt_out=False) as ep:
         ep._wait_until_inactive()
         assert mock_http.request_headers.get('Authorization') == 'SDK_KEY'
 
@@ -663,12 +665,13 @@ def test_will_still_send_after_500_error():
 
 def test_does_not_block_on_full_inbox():
     config = Config("fake_sdk_key", events_max_pending=1)  # this sets the size of both the inbox and the outbox to 1
-    ep_inbox_holder = [ None ]
+    ep_inbox_holder = [None]
     ep_inbox = None
 
     def dispatcher_factory(inbox, config, http, diag):
         ep_inbox_holder[0] = inbox  # it's an array because otherwise it's hard for a closure to modify a variable
         return None  # the dispatcher object itself doesn't matter, we only manipulate the inbox
+
     def event_consumer():
         while True:
             message = ep_inbox.get(block=True)
@@ -698,11 +701,12 @@ def test_http_proxy(monkeypatch):
             ep.send_event(EventInputIdentify(timestamp, context))
             ep.flush()
             ep._wait_until_inactive()
+
     do_proxy_tests(_event_processor_proxy_test, 'POST', monkeypatch)
 
 
 def verify_unrecoverable_http_error(status):
-    with DefaultTestProcessor(sdk_key = 'SDK_KEY') as ep:
+    with DefaultTestProcessor(sdk_key='SDK_KEY') as ep:
         mock_http.set_response_status(status)
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
@@ -716,7 +720,7 @@ def verify_unrecoverable_http_error(status):
 
 
 def verify_recoverable_http_error(status):
-    with DefaultTestProcessor(sdk_key = 'SDK_KEY') as ep:
+    with DefaultTestProcessor(sdk_key='SDK_KEY') as ep:
         mock_http.set_response_status(status)
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
@@ -730,7 +734,7 @@ def verify_recoverable_http_error(status):
 
 
 def test_event_payload_id_is_sent():
-    with DefaultEventProcessor(Config(sdk_key = 'SDK_KEY'), mock_http) as ep:
+    with DefaultEventProcessor(Config(sdk_key='SDK_KEY'), mock_http) as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
         ep._wait_until_inactive()
@@ -742,7 +746,7 @@ def test_event_payload_id_is_sent():
 
 
 def test_event_payload_id_changes_between_requests():
-    with DefaultEventProcessor(Config(sdk_key = 'SDK_KEY'), mock_http) as ep:
+    with DefaultEventProcessor(Config(sdk_key='SDK_KEY'), mock_http) as ep:
         ep.send_event(EventInputIdentify(timestamp, context))
         ep.flush()
         ep._wait_until_inactive()

--- a/ldclient/testing/impl/events/test_event_processor.py
+++ b/ldclient/testing/impl/events/test_event_processor.py
@@ -54,9 +54,9 @@ def make_context_keys(context: Context) -> dict:
 
 class DefaultTestProcessor(DefaultEventProcessor):
     def __init__(self, **kwargs):
-        if not 'diagnostic_opt_out' in kwargs:
+        if 'diagnostic_opt_out' not in kwargs:
             kwargs['diagnostic_opt_out'] = True
-        if not 'sdk_key' in kwargs:
+        if 'sdk_key' not in kwargs:
             kwargs['sdk_key'] = 'SDK_KEY'
         config = Config(**kwargs)
         diagnostic_accumulator = _DiagnosticAccumulator(create_diagnostic_id(config))
@@ -785,12 +785,12 @@ def check_feature_event(data, source: EventInputEvaluation, context_json: Option
     assert data['kind'] == 'feature'
     assert data['creationDate'] == source.timestamp
     assert data['key'] == source.key
-    assert data.get('version') == None if source.flag is None else source.flag.version
+    assert data.get('version') is None if source.flag is None else source.flag.version
     assert data.get('variation') == source.variation
     assert data.get('value') == source.value
     assert data.get('default') == source.default_value
     assert data['context'] == (source.context.to_dict() if context_json is None else context_json)
-    assert data.get('prereq_of') == None if source.prereq_of is None else source.prereq_of.key
+    assert data.get('prereq_of') is None if source.prereq_of is None else source.prereq_of.key
 
 
 def check_migration_op_event(data, source: MigrationOpEvent):
@@ -846,12 +846,12 @@ def check_debug_event(data, source: EventInputEvaluation, context_json: Optional
     assert data['kind'] == 'debug'
     assert data['creationDate'] == source.timestamp
     assert data['key'] == source.key
-    assert data.get('version') == None if source.flag is None else source.flag.version
+    assert data.get('version') is None if source.flag is None else source.flag.version
     assert data.get('variation') == source.variation
     assert data.get('value') == source.value
     assert data.get('default') == source.default_value
     assert data['context'] == (source.context.to_dict() if context_json is None else context_json)
-    assert data.get('prereq_of') == None if source.prereq_of is None else source.prereq_of.key
+    assert data.get('prereq_of') is None if source.prereq_of is None else source.prereq_of.key
 
 
 def check_custom_event(data, source: EventInputCustom):

--- a/ldclient/testing/impl/events/test_event_summarizer.py
+++ b/ldclient/testing/impl/events/test_event_summarizer.py
@@ -11,43 +11,36 @@ flag2 = FlagBuilder('flag2').version(22).build()
 
 
 def test_summarize_event_sets_start_and_end_dates():
-	es = EventSummarizer()
-	event1 = EventInputEvaluation(2000, user, flag1.key, flag1, 0, '', None, None)
-	event2 = EventInputEvaluation(1000, user, flag1.key, flag1, 0, '', None, None)
-	event3 = EventInputEvaluation(1500, user, flag1.key, flag1, 0, '', None, None)
-	es.summarize_event(event1)
-	es.summarize_event(event2)
-	es.summarize_event(event3)
-	data = es.snapshot()
+    es = EventSummarizer()
+    event1 = EventInputEvaluation(2000, user, flag1.key, flag1, 0, '', None, None)
+    event2 = EventInputEvaluation(1000, user, flag1.key, flag1, 0, '', None, None)
+    event3 = EventInputEvaluation(1500, user, flag1.key, flag1, 0, '', None, None)
+    es.summarize_event(event1)
+    es.summarize_event(event2)
+    es.summarize_event(event3)
+    data = es.snapshot()
 
-	assert data.start_date == 1000
-	assert data.end_date == 2000
+    assert data.start_date == 1000
+    assert data.end_date == 2000
 
 
 def test_summarize_event_increments_counters():
-	es = EventSummarizer()
-	event1 = EventInputEvaluation(1000, user, flag1.key, flag1, 1, 'value1', None, 'default1')
-	event2 = EventInputEvaluation(1000, user, flag1.key, flag1, 2, 'value2', None, 'default1')
-	event3 = EventInputEvaluation(1000, user, flag2.key, flag2, 1, 'value99', None, 'default2')
-	event4 = EventInputEvaluation(1000, user, flag1.key, flag1, 1, 'value1', None, 'default1')
-	event5 = EventInputEvaluation(1000, user, 'badkey', None, None, 'default3', None, 'default3')
-	es.summarize_event(event1)
-	es.summarize_event(event2)
-	es.summarize_event(event3)
-	es.summarize_event(event4)
-	es.summarize_event(event5)
-	data = es.snapshot()
+    es = EventSummarizer()
+    event1 = EventInputEvaluation(1000, user, flag1.key, flag1, 1, 'value1', None, 'default1')
+    event2 = EventInputEvaluation(1000, user, flag1.key, flag1, 2, 'value2', None, 'default1')
+    event3 = EventInputEvaluation(1000, user, flag2.key, flag2, 1, 'value99', None, 'default2')
+    event4 = EventInputEvaluation(1000, user, flag1.key, flag1, 1, 'value1', None, 'default1')
+    event5 = EventInputEvaluation(1000, user, 'badkey', None, None, 'default3', None, 'default3')
+    es.summarize_event(event1)
+    es.summarize_event(event2)
+    es.summarize_event(event3)
+    es.summarize_event(event4)
+    es.summarize_event(event5)
+    data = es.snapshot()
 
-	expected = {
-		'flag1': EventSummaryFlag({'user'}, 'default1', {
-			(1, flag1.version): EventSummaryCounter(2, 'value1'),
-			(2, flag1.version): EventSummaryCounter(1, 'value2')
-		}),
-		'flag2': EventSummaryFlag({'user'}, 'default2', {
-			(1, flag2.version): EventSummaryCounter(1, 'value99')
-		}),
-		'badkey': EventSummaryFlag({'user'}, 'default3', {
-			(None, None): EventSummaryCounter(1, 'default3')
-		})
-	}
-	assert data.flags == expected
+    expected = {
+        'flag1': EventSummaryFlag({'user'}, 'default1', {(1, flag1.version): EventSummaryCounter(2, 'value1'), (2, flag1.version): EventSummaryCounter(1, 'value2')}),
+        'flag2': EventSummaryFlag({'user'}, 'default2', {(1, flag2.version): EventSummaryCounter(1, 'value99')}),
+        'badkey': EventSummaryFlag({'user'}, 'default3', {(None, None): EventSummaryCounter(1, 'default3')}),
+    }
+    assert data.flags == expected

--- a/ldclient/testing/impl/events/test_event_summarizer.py
+++ b/ldclient/testing/impl/events/test_event_summarizer.py
@@ -1,9 +1,9 @@
 from ldclient.context import Context
-from ldclient.impl.events.event_summarizer import EventSummarizer, EventSummaryCounter, EventSummaryFlag
+from ldclient.impl.events.event_summarizer import (EventSummarizer,
+                                                   EventSummaryCounter,
+                                                   EventSummaryFlag)
 from ldclient.impl.events.types import *
-
 from ldclient.testing.builders import *
-
 
 user = Context.create('user1')
 flag1 = FlagBuilder('flag1').version(11).build()

--- a/ldclient/testing/impl/events/test_event_summarizer.py
+++ b/ldclient/testing/impl/events/test_event_summarizer.py
@@ -23,6 +23,7 @@ def test_summarize_event_sets_start_and_end_dates():
 	assert data.start_date == 1000
 	assert data.end_date == 2000
 
+
 def test_summarize_event_increments_counters():
 	es = EventSummarizer()
 	event1 = EventInputEvaluation(1000, user, flag1.key, flag1, 1, 'value1', None, 'default1')

--- a/ldclient/testing/impl/test_attribute_ref.py
+++ b/ldclient/testing/impl/test_attribute_ref.py
@@ -1,6 +1,6 @@
-from ldclient.impl.model.attribute_ref import *
-
 import pytest
+
+from ldclient.impl.model.attribute_ref import *
 
 
 class TestAttributeRef:

--- a/ldclient/testing/impl/test_attribute_ref.py
+++ b/ldclient/testing/impl/test_attribute_ref.py
@@ -26,11 +26,7 @@ class TestAttributeRef:
         assert a.depth == 1
         assert a[0] == input
 
-    @pytest.mark.parametrize("input,unescaped", [
-        ("/name", "name"),
-        ("/0", "0"),
-        ("/name~1with~1slashes~0and~0tildes", "name/with/slashes~and~tildes")
-        ])
+    @pytest.mark.parametrize("input,unescaped", [("/name", "name"), ("/0", "0"), ("/name~1with~1slashes~0and~0tildes", "name/with/slashes~and~tildes")])
     def test_ref_simple_with_leading_slash(self, input: str, unescaped: str):
         a = AttributeRef.from_path(input)
         assert a.valid is True
@@ -38,8 +34,7 @@ class TestAttributeRef:
         assert a.depth == 1
         assert a[0] == unescaped
 
-    @pytest.mark.parametrize("input", ["name", "name/with/slashes",
-                                       "name~0~1with-what-looks-like-escape-sequences"])
+    @pytest.mark.parametrize("input", ["name", "name/with/slashes", "name~0~1with-what-looks-like-escape-sequences"])
     def test_literal(self, input: str):
         a = AttributeRef.from_literal(input)
         assert a.valid is True

--- a/ldclient/testing/impl/test_attribute_ref.py
+++ b/ldclient/testing/impl/test_attribute_ref.py
@@ -38,7 +38,8 @@ class TestAttributeRef:
         assert a.depth == 1
         assert a[0] == unescaped
 
-    @pytest.mark.parametrize("input", [("name"), ("name/with/slashes"), ("name~0~1with-what-looks-like-escape-sequences")])
+    @pytest.mark.parametrize("input", ["name", "name/with/slashes",
+                                       "name~0~1with-what-looks-like-escape-sequences"])
     def test_literal(self, input: str):
         a = AttributeRef.from_literal(input)
         assert a.valid is True

--- a/ldclient/testing/impl/test_big_segments.py
+++ b/ldclient/testing/impl/test_big_segments.py
@@ -1,11 +1,12 @@
+import time
+from queue import Queue
+
 from ldclient.config import BigSegmentsConfig
 from ldclient.evaluation import BigSegmentsStatus
-from ldclient.impl.big_segments import BigSegmentStoreManager, _hash_for_user_key
+from ldclient.impl.big_segments import (BigSegmentStoreManager,
+                                        _hash_for_user_key)
 from ldclient.interfaces import BigSegmentStoreMetadata
 from ldclient.testing.mock_components import MockBigSegmentStore
-
-from queue import Queue
-import time
 
 user_key = 'user-key'
 user_hash = _hash_for_user_key(user_key)

--- a/ldclient/testing/impl/test_big_segments.py
+++ b/ldclient/testing/impl/test_big_segments.py
@@ -23,6 +23,7 @@ def test_membership_query_uncached_result_healthy_status():
     finally:
         manager.stop()
 
+
 def test_membership_query_cached_result_healthy_status():
     expected_membership = { "key1": True, "key2": False }
     store = MockBigSegmentStore()
@@ -37,6 +38,7 @@ def test_membership_query_cached_result_healthy_status():
         manager.stop()
     assert store.membership_queries == [ user_hash ]  # only 1 query done rather than 2, due to caching
 
+
 def test_membership_query_can_cache_result_of_none():
     store = MockBigSegmentStore()
     store.setup_metadata_always_up_to_date()
@@ -49,6 +51,7 @@ def test_membership_query_can_cache_result_of_none():
     finally:
         manager.stop()
     assert store.membership_queries == [ user_hash ]  # only 1 query done rather than 2, due to caching
+
 
 def test_membership_query_cache_can_expire():
     expected_membership = { "key1": True, "key2": False }
@@ -65,6 +68,7 @@ def test_membership_query_cache_can_expire():
         manager.stop()
     assert store.membership_queries == [ user_hash, user_hash ]  # cache expired after 1st query
 
+
 def test_membership_query_stale_status():
     expected_membership = { "key1": True, "key2": False }
     store = MockBigSegmentStore()
@@ -77,6 +81,7 @@ def test_membership_query_stale_status():
     finally:
         manager.stop()
 
+
 def test_membership_query_stale_status_no_store_metadata():
     expected_membership = { "key1": True, "key2": False }
     store = MockBigSegmentStore()
@@ -88,6 +93,7 @@ def test_membership_query_stale_status_no_store_metadata():
         assert manager.get_user_membership(user_key) == expected_result
     finally:
         manager.stop()
+
 
 def test_membership_query_least_recent_context_evicted_from_cache():
     user_key_1, user_key_2, user_key_3 = 'userkey1', 'userkey2', 'userkey3'
@@ -126,6 +132,7 @@ def test_membership_query_least_recent_context_evicted_from_cache():
     finally:
         manager.stop()
 
+
 def test_status_polling_detects_store_unavailability():
     store = MockBigSegmentStore()
     store.setup_metadata_always_up_to_date()
@@ -150,6 +157,7 @@ def test_status_polling_detects_store_unavailability():
         assert status3.available == True
     finally:
         manager.stop()
+
 
 def test_status_polling_detects_stale_status():
     store = MockBigSegmentStore()

--- a/ldclient/testing/impl/test_big_segments.py
+++ b/ldclient/testing/impl/test_big_segments.py
@@ -12,7 +12,7 @@ user_hash = _hash_for_user_key(user_key)
 
 
 def test_membership_query_uncached_result_healthy_status():
-    expected_membership = { "key1": True, "key2": False }
+    expected_membership = {"key1": True, "key2": False}
     store = MockBigSegmentStore()
     store.setup_metadata_always_up_to_date()
     store.setup_membership(user_hash, expected_membership)
@@ -25,7 +25,7 @@ def test_membership_query_uncached_result_healthy_status():
 
 
 def test_membership_query_cached_result_healthy_status():
-    expected_membership = { "key1": True, "key2": False }
+    expected_membership = {"key1": True, "key2": False}
     store = MockBigSegmentStore()
     store.setup_metadata_always_up_to_date()
     store.setup_membership(user_hash, expected_membership)
@@ -36,7 +36,7 @@ def test_membership_query_cached_result_healthy_status():
         assert manager.get_user_membership(user_key) == expected_result
     finally:
         manager.stop()
-    assert store.membership_queries == [ user_hash ]  # only 1 query done rather than 2, due to caching
+    assert store.membership_queries == [user_hash]  # only 1 query done rather than 2, due to caching
 
 
 def test_membership_query_can_cache_result_of_none():
@@ -50,11 +50,11 @@ def test_membership_query_can_cache_result_of_none():
         assert manager.get_user_membership(user_key) == expected_result
     finally:
         manager.stop()
-    assert store.membership_queries == [ user_hash ]  # only 1 query done rather than 2, due to caching
+    assert store.membership_queries == [user_hash]  # only 1 query done rather than 2, due to caching
 
 
 def test_membership_query_cache_can_expire():
-    expected_membership = { "key1": True, "key2": False }
+    expected_membership = {"key1": True, "key2": False}
     store = MockBigSegmentStore()
     store.setup_metadata_always_up_to_date()
     store.setup_membership(user_hash, expected_membership)
@@ -66,11 +66,11 @@ def test_membership_query_cache_can_expire():
         assert manager.get_user_membership(user_key) == expected_result
     finally:
         manager.stop()
-    assert store.membership_queries == [ user_hash, user_hash ]  # cache expired after 1st query
+    assert store.membership_queries == [user_hash, user_hash]  # cache expired after 1st query
 
 
 def test_membership_query_stale_status():
-    expected_membership = { "key1": True, "key2": False }
+    expected_membership = {"key1": True, "key2": False}
     store = MockBigSegmentStore()
     store.setup_metadata_always_stale()
     store.setup_membership(user_hash, expected_membership)
@@ -83,7 +83,7 @@ def test_membership_query_stale_status():
 
 
 def test_membership_query_stale_status_no_store_metadata():
-    expected_membership = { "key1": True, "key2": False }
+    expected_membership = {"key1": True, "key2": False}
     store = MockBigSegmentStore()
     store.setup_metadata_none()
     store.setup_membership(user_hash, expected_membership)
@@ -97,9 +97,8 @@ def test_membership_query_stale_status_no_store_metadata():
 
 def test_membership_query_least_recent_context_evicted_from_cache():
     user_key_1, user_key_2, user_key_3 = 'userkey1', 'userkey2', 'userkey3'
-    user_hash_1, user_hash_2, user_hash_3 = _hash_for_user_key(user_key_1), \
-        _hash_for_user_key(user_key_2), _hash_for_user_key(user_key_3)
-    membership_1, membership_2, membership_3 = { 'seg1': True }, { 'seg2': True }, { 'seg3': True }
+    user_hash_1, user_hash_2, user_hash_3 = _hash_for_user_key(user_key_1), _hash_for_user_key(user_key_2), _hash_for_user_key(user_key_3)
+    membership_1, membership_2, membership_3 = {'seg1': True}, {'seg2': True}, {'seg3': True}
     store = MockBigSegmentStore()
     store.setup_metadata_always_up_to_date()
     store.setup_membership(user_hash_1, membership_1)

--- a/ldclient/testing/impl/test_big_segments.py
+++ b/ldclient/testing/impl/test_big_segments.py
@@ -143,17 +143,17 @@ def test_status_polling_detects_store_unavailability():
         manager.status_provider.add_listener(lambda status: statuses.put(status))
 
         status1 = manager.status_provider.status
-        assert status1.available == True
+        assert status1.available is True
 
         store.setup_metadata_error()
 
         status2 = statuses.get(True, 1.0)
-        assert status2.available == False
+        assert status2.available is False
 
         store.setup_metadata_always_up_to_date()
 
         status3 = statuses.get(True, 1.0)
-        assert status3.available == True
+        assert status3.available is True
     finally:
         manager.stop()
 
@@ -169,16 +169,16 @@ def test_status_polling_detects_stale_status():
         manager.status_provider.add_listener(lambda status: statuses.put(status))
 
         status1 = manager.status_provider.status
-        assert status1.stale == False
+        assert status1.stale is False
 
         store.setup_metadata_always_stale()
 
         status2 = statuses.get(True, 1.0)
-        assert status2.stale == True
+        assert status2.stale is True
 
         store.setup_metadata_always_up_to_date()
 
         status3 = statuses.get(True, 1.0)
-        assert status3.stale == False
+        assert status3.stale is False
     finally:
         manager.stop()

--- a/ldclient/testing/impl/test_data_sink.py
+++ b/ldclient/testing/impl/test_data_sink.py
@@ -17,11 +17,9 @@ from ldclient.testing.builders import FlagBuilder, FlagRuleBuilder, make_clause,
 def basic_data() -> Dict:
     flag1 = FlagBuilder('flag1').version(1).on(False).build()
     flag2 = FlagBuilder('flag2').version(1).on(False).build()
-    flag3 = FlagBuilder('flag3').version(1).rules(
-        FlagRuleBuilder().variation(0).id('rule_id').track_events(True).clauses(
-            make_clause('user', 'segmentMatch', 'segmentMatch', 'segment2')
-        ).build()
-    ).build()
+    flag3 = (
+        FlagBuilder('flag3').version(1).rules(FlagRuleBuilder().variation(0).id('rule_id').track_events(True).clauses(make_clause('user', 'segmentMatch', 'segmentMatch', 'segment2')).build()).build()
+    )
     segment1 = SegmentBuilder('segment1').version(1).build()
     segment2 = SegmentBuilder('segment2').version(1).build()
 
@@ -45,17 +43,11 @@ def prereq_data() -> Dict:
     flag3 = FlagBuilder('flag3').version(1).on(False).build()
     flag4 = FlagBuilder('flag4').version(1).on(False).build()
     flag5 = FlagBuilder('flag5').version(1).on(False).build()
-    flag6 = FlagBuilder('flag6').version(1).rules(
-        FlagRuleBuilder().variation(0).id('rule_id').track_events(True).clauses(
-            make_clause('user', 'segmentMatch', 'segmentMatch', 'segment2')
-        ).build()
-    ).build()
+    flag6 = (
+        FlagBuilder('flag6').version(1).rules(FlagRuleBuilder().variation(0).id('rule_id').track_events(True).clauses(make_clause('user', 'segmentMatch', 'segmentMatch', 'segment2')).build()).build()
+    )
     segment1 = SegmentBuilder('segment1').version(1).build()
-    segment2 = SegmentBuilder('segment2').version(1).rules(
-        SegmentRuleBuilder().clauses(
-            make_clause('user', 'segmentMatch', 'segmentMatch', 'segment1')
-        ).build()
-    ).build()
+    segment2 = SegmentBuilder('segment2').version(1).rules(SegmentRuleBuilder().clauses(make_clause('user', 'segmentMatch', 'segmentMatch', 'segment1')).build()).build()
 
     return {
         FEATURES: {
@@ -125,12 +117,14 @@ def test_is_called_once_per_flag_during_init(basic_data):
 
     spy = SpyListener()
     flag_change_listener.add(spy)
-    sink.init({
-        FEATURES: {
-            flag1.key: flag1,
-            flag4.key: flag4,
+    sink.init(
+        {
+            FEATURES: {
+                flag1.key: flag1,
+                flag4.key: flag4,
+            }
         }
-    })
+    )
 
     assert len(spy.statuses) == 4
     keys = set(s.key for s in spy.statuses)  # No guaranteed order

--- a/ldclient/testing/impl/test_data_sink.py
+++ b/ldclient/testing/impl/test_data_sink.py
@@ -1,16 +1,17 @@
-import pytest
+from typing import Callable, Dict
+
 import mock
+import pytest
 
-from typing import Dict, Callable
-
-from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl
 from ldclient.feature_store import InMemoryFeatureStore
-from ldclient.interfaces import DataSourceState, DataSourceErrorKind
+from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl
 from ldclient.impl.listeners import Listeners
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
+from ldclient.interfaces import DataSourceErrorKind, DataSourceState
+from ldclient.testing.builders import (FlagBuilder, FlagRuleBuilder,
+                                       SegmentBuilder, SegmentRuleBuilder,
+                                       make_clause)
 from ldclient.testing.test_util import SpyListener
-from ldclient.testing.builders import FlagBuilder, FlagRuleBuilder, make_clause, SegmentBuilder, SegmentRuleBuilder
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 
 @pytest.fixture

--- a/ldclient/testing/impl/test_evaluator.py
+++ b/ldclient/testing/impl/test_evaluator.py
@@ -106,7 +106,7 @@ def test_segment_match_clause_retrieves_segment_from_store():
     user = Context.create('foo')
     flag = make_boolean_flag_matching_segment(segment)
 
-    assert evaluator.evaluate(flag, user, event_factory).detail.value == True
+    assert evaluator.evaluate(flag, user, event_factory).detail.value is True
 
 
 def test_segment_match_clause_falls_through_with_no_errors_if_segment_not_found():
@@ -114,4 +114,4 @@ def test_segment_match_clause_falls_through_with_no_errors_if_segment_not_found(
     flag = make_boolean_flag_with_clauses(make_clause_matching_segment_key('segkey'))
     evaluator = EvaluatorBuilder().with_unknown_segment('segkey').build()
 
-    assert evaluator.evaluate(flag, user, event_factory).detail.value == False
+    assert evaluator.evaluate(flag, user, event_factory).detail.value is False

--- a/ldclient/testing/impl/test_evaluator.py
+++ b/ldclient/testing/impl/test_evaluator.py
@@ -10,11 +10,13 @@ def test_flag_returns_off_variation_if_flag_is_off():
     detail = EvaluationDetail('b', 1, {'kind': 'OFF'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_none_if_flag_is_off_and_off_variation_is_unspecified():
     flag = FlagBuilder('feature').on(False).variations('a', 'b', 'c').build()
     user = Context.create('x')
     detail = EvaluationDetail(None, None, {'kind': 'OFF'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
+
 
 def test_flag_returns_error_if_off_variation_is_too_high():
     flag = FlagBuilder('feature').on(False).off_variation(999).variations('a', 'b', 'c').build()
@@ -22,11 +24,13 @@ def test_flag_returns_error_if_off_variation_is_too_high():
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_error_if_off_variation_is_negative():
     flag = FlagBuilder('feature').on(False).off_variation(-1).variations('a', 'b', 'c').build()
     user = Context.create('x')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
+
 
 def test_flag_returns_error_if_fallthrough_variation_is_too_high():
     flag = FlagBuilder('feature').on(True).variations('a', 'b', 'c').fallthrough_variation(999).build()
@@ -34,11 +38,13 @@ def test_flag_returns_error_if_fallthrough_variation_is_too_high():
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_error_if_fallthrough_variation_is_negative():
     flag = FlagBuilder('feature').on(True).variations('a', 'b', 'c').fallthrough_variation(-1).build()
     user = Context.create('x')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
+
 
 def test_flag_returns_error_if_fallthrough_has_no_variation_or_rollout():
     flag = FlagBuilder('feature').on(True).variations('a', 'b', 'c').build()
@@ -46,11 +52,13 @@ def test_flag_returns_error_if_fallthrough_has_no_variation_or_rollout():
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_error_if_fallthrough_has_rollout_with_no_variations():
     flag = FlagBuilder('feature').on(True).variations('a', 'b', 'c').fallthrough_rollout({'variations': []}).build()
     user = Context.create('x')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
+
 
 def test_flag_matches_user_from_rules():
     rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': 0}
@@ -59,12 +67,14 @@ def test_flag_matches_user_from_rules():
     detail = EvaluationDetail(True, 0, {'kind': 'RULE_MATCH', 'ruleIndex': 0, 'ruleId': 'id'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_error_if_rule_variation_is_too_high():
     rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': 999}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
+
 
 def test_flag_returns_error_if_rule_variation_is_negative():
     rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': -1}
@@ -73,12 +83,14 @@ def test_flag_returns_error_if_rule_variation_is_negative():
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_error_if_rule_has_no_variation_or_rollout():
     rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}]}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
+
 
 def test_flag_returns_error_if_rule_has_rollout_with_no_variations():
     rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}],
@@ -88,6 +100,7 @@ def test_flag_returns_error_if_rule_has_rollout_with_no_variations():
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
     assert_eval_result(basic_evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_segment_match_clause_retrieves_segment_from_store():
     segment = SegmentBuilder('segkey').included('foo').build()
     evaluator = EvaluatorBuilder().with_segment(segment).build()
@@ -95,6 +108,7 @@ def test_segment_match_clause_retrieves_segment_from_store():
     flag = make_boolean_flag_matching_segment(segment)
 
     assert evaluator.evaluate(flag, user, event_factory).detail.value == True
+
 
 def test_segment_match_clause_falls_through_with_no_errors_if_segment_not_found():
     user = Context.create('foo')

--- a/ldclient/testing/impl/test_evaluator.py
+++ b/ldclient/testing/impl/test_evaluator.py
@@ -61,7 +61,7 @@ def test_flag_returns_error_if_fallthrough_has_rollout_with_no_variations():
 
 
 def test_flag_matches_user_from_rules():
-    rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': 0}
+    rule = {'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': 0}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(True, 0, {'kind': 'RULE_MATCH', 'ruleIndex': 0, 'ruleId': 'id'})
@@ -69,7 +69,7 @@ def test_flag_matches_user_from_rules():
 
 
 def test_flag_returns_error_if_rule_variation_is_too_high():
-    rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': 999}
+    rule = {'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': 999}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
@@ -77,7 +77,7 @@ def test_flag_returns_error_if_rule_variation_is_too_high():
 
 
 def test_flag_returns_error_if_rule_variation_is_negative():
-    rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': -1}
+    rule = {'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'variation': -1}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
@@ -85,7 +85,7 @@ def test_flag_returns_error_if_rule_variation_is_negative():
 
 
 def test_flag_returns_error_if_rule_has_no_variation_or_rollout():
-    rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}]}
+    rule = {'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}]}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})
@@ -93,8 +93,7 @@ def test_flag_returns_error_if_rule_has_no_variation_or_rollout():
 
 
 def test_flag_returns_error_if_rule_has_rollout_with_no_variations():
-    rule = { 'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}],
-        'rollout': {'variations': []} }
+    rule = {'id': 'id', 'clauses': [{'attribute': 'key', 'op': 'in', 'values': ['userkey']}], 'rollout': {'variations': []}}
     flag = make_boolean_flag_with_rules(rule)
     user = Context.create('userkey')
     detail = EvaluationDetail(None, None, {'kind': 'ERROR', 'errorKind': 'MALFORMED_FLAG'})

--- a/ldclient/testing/impl/test_evaluator_big_segment.py
+++ b/ldclient/testing/impl/test_evaluator_big_segment.py
@@ -17,13 +17,16 @@ def test_big_segment_with_no_generation_is_not_matched():
     assert result.detail.value == False
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.NOT_CONFIGURED
 
+
 def test_big_segment_matched_with_include_for_default_kind():
     _test_matched_with_include(False, False)
     _test_matched_with_include(False, True)
 
+
 def test_big_segment_matched_with_include_for_non_default_kind():
     _test_matched_with_include(True, False)
     _test_matched_with_include(True, True)
+
 
 def _test_matched_with_include(non_default_kind: bool, multi_kind_context: bool):
     target_key = 'contextkey'
@@ -43,6 +46,7 @@ def _test_matched_with_include(non_default_kind: bool, multi_kind_context: bool)
     assert result.detail.value == True
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
+
 def test_big_segment_matched_with_rule():
     segment = SegmentBuilder('key').version(1) \
         .unbounded(True) \
@@ -57,6 +61,7 @@ def test_big_segment_matched_with_rule():
     assert result.detail.value == True
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
+
 def test_big_segment_unmatched_by_exclude_regardless_of_rule():
     segment = SegmentBuilder('key').version(1) \
         .unbounded(True) \
@@ -70,6 +75,7 @@ def test_big_segment_unmatched_by_exclude_regardless_of_rule():
     result = evaluator.evaluate(flag, basic_user, event_factory)
     assert result.detail.value == False
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
+
 
 def test_big_segment_status_is_returned_by_provider():
     segment = SegmentBuilder('key').version(1) \

--- a/ldclient/testing/impl/test_evaluator_big_segment.py
+++ b/ldclient/testing/impl/test_evaluator_big_segment.py
@@ -11,7 +11,7 @@ def test_big_segment_with_no_generation_is_not_matched():
     evaluator = EvaluatorBuilder().with_segment(segment).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
-    assert result.detail.value == False
+    assert result.detail.value is False
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.NOT_CONFIGURED
 
 
@@ -35,7 +35,7 @@ def _test_matched_with_include(non_default_kind: bool, multi_kind_context: bool)
     evaluator = EvaluatorBuilder().with_segment(segment).with_big_segment_for_key(target_key, segment, True).build()
 
     result = evaluator.evaluate(flag, eval_context, event_factory)
-    assert result.detail.value == True
+    assert result.detail.value is True
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
 
@@ -44,7 +44,7 @@ def test_big_segment_matched_with_rule():
     evaluator = EvaluatorBuilder().with_segment(segment).with_no_big_segments_for_key(basic_user.key).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
-    assert result.detail.value == True
+    assert result.detail.value is True
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
 
@@ -53,7 +53,7 @@ def test_big_segment_unmatched_by_exclude_regardless_of_rule():
     evaluator = EvaluatorBuilder().with_segment(segment).with_big_segment_for_key(basic_user.key, segment, False).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
-    assert result.detail.value == False
+    assert result.detail.value is False
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
 
@@ -62,5 +62,5 @@ def test_big_segment_status_is_returned_by_provider():
     evaluator = EvaluatorBuilder().with_segment(segment).with_no_big_segments_for_key(basic_user.key).with_big_segments_status(BigSegmentsStatus.NOT_CONFIGURED).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
-    assert result.detail.value == False
+    assert result.detail.value is False
     assert result.detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.NOT_CONFIGURED

--- a/ldclient/testing/impl/test_evaluator_big_segment.py
+++ b/ldclient/testing/impl/test_evaluator_big_segment.py
@@ -6,10 +6,7 @@ from ldclient.testing.impl.evaluator_util import *
 
 
 def test_big_segment_with_no_generation_is_not_matched():
-    segment = SegmentBuilder('key').version(1) \
-        .included(basic_user.key) \
-        .unbounded(True) \
-        .build()
+    segment = SegmentBuilder('key').version(1).included(basic_user.key).unbounded(True).build()
     # included should be ignored for a big segment
     evaluator = EvaluatorBuilder().with_segment(segment).build()
     flag = make_boolean_flag_matching_segment(segment)
@@ -31,14 +28,9 @@ def test_big_segment_matched_with_include_for_non_default_kind():
 def _test_matched_with_include(non_default_kind: bool, multi_kind_context: bool):
     target_key = 'contextkey'
     single_kind_context = Context.create(target_key, 'kind1') if non_default_kind else Context.create(target_key)
-    eval_context = Context.create_multi(single_kind_context, Context.create('key2', 'kind2')) if multi_kind_context \
-        else single_kind_context
+    eval_context = Context.create_multi(single_kind_context, Context.create('key2', 'kind2')) if multi_kind_context else single_kind_context
 
-    segment = SegmentBuilder('key').version(1) \
-        .unbounded(True) \
-        .unbounded_context_kind('kind1' if non_default_kind else None) \
-        .generation(2) \
-        .build()
+    segment = SegmentBuilder('key').version(1).unbounded(True).unbounded_context_kind('kind1' if non_default_kind else None).generation(2).build()
     flag = make_boolean_flag_matching_segment(segment)
     evaluator = EvaluatorBuilder().with_segment(segment).with_big_segment_for_key(target_key, segment, True).build()
 
@@ -48,13 +40,7 @@ def _test_matched_with_include(non_default_kind: bool, multi_kind_context: bool)
 
 
 def test_big_segment_matched_with_rule():
-    segment = SegmentBuilder('key').version(1) \
-        .unbounded(True) \
-        .generation(2) \
-        .rules(
-            make_segment_rule_matching_context(basic_user)
-        ) \
-        .build()
+    segment = SegmentBuilder('key').version(1).unbounded(True).generation(2).rules(make_segment_rule_matching_context(basic_user)).build()
     evaluator = EvaluatorBuilder().with_segment(segment).with_no_big_segments_for_key(basic_user.key).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
@@ -63,13 +49,7 @@ def test_big_segment_matched_with_rule():
 
 
 def test_big_segment_unmatched_by_exclude_regardless_of_rule():
-    segment = SegmentBuilder('key').version(1) \
-        .unbounded(True) \
-        .generation(2) \
-        .rules(
-            make_segment_rule_matching_context(basic_user)
-        ) \
-        .build()
+    segment = SegmentBuilder('key').version(1).unbounded(True).generation(2).rules(make_segment_rule_matching_context(basic_user)).build()
     evaluator = EvaluatorBuilder().with_segment(segment).with_big_segment_for_key(basic_user.key, segment, False).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
@@ -78,12 +58,8 @@ def test_big_segment_unmatched_by_exclude_regardless_of_rule():
 
 
 def test_big_segment_status_is_returned_by_provider():
-    segment = SegmentBuilder('key').version(1) \
-        .unbounded(True) \
-        .generation(1) \
-        .build()
-    evaluator = EvaluatorBuilder().with_segment(segment).with_no_big_segments_for_key(basic_user.key). \
-        with_big_segments_status(BigSegmentsStatus.NOT_CONFIGURED).build()
+    segment = SegmentBuilder('key').version(1).unbounded(True).generation(1).build()
+    evaluator = EvaluatorBuilder().with_segment(segment).with_no_big_segments_for_key(basic_user.key).with_big_segments_status(BigSegmentsStatus.NOT_CONFIGURED).build()
     flag = make_boolean_flag_matching_segment(segment)
     result = evaluator.evaluate(flag, basic_user, event_factory)
     assert result.detail.value == False

--- a/ldclient/testing/impl/test_evaluator_bucketing.py
+++ b/ldclient/testing/impl/test_evaluator_bucketing.py
@@ -1,12 +1,13 @@
-from ldclient.client import Context
-from ldclient.impl.evaluator import _bucket_context, _variation_index_for_context
-from ldclient.impl.model import *
+import math
 
+import pytest
+
+from ldclient.client import Context
+from ldclient.impl.evaluator import (_bucket_context,
+                                     _variation_index_for_context)
+from ldclient.impl.model import *
 from ldclient.testing.builders import *
 from ldclient.testing.impl.evaluator_util import *
-
-import math
-import pytest
 
 
 def assert_match_clause(clause: dict, context: Context, should_match: bool):

--- a/ldclient/testing/impl/test_evaluator_bucketing.py
+++ b/ldclient/testing/impl/test_evaluator_bucketing.py
@@ -26,15 +26,17 @@ class TestEvaluatorBucketing:
         bad_variation_a = 0
         matched_variation = 1
         bad_variation_b = 2
-        rule = VariationOrRollout({
-            'rollout': {
-                'variations': [
-                    { 'variation': bad_variation_a, 'weight': bucket_value }, # end of bucket range is not inclusive, so it will *not* match the target value
-                    { 'variation': matched_variation, 'weight': 1 }, # size of this bucket is 1, so it only matches that specific value
-                    { 'variation': bad_variation_b, 'weight': 100000 - (bucket_value + 1) }
-                ]
+        rule = VariationOrRollout(
+            {
+                'rollout': {
+                    'variations': [
+                        {'variation': bad_variation_a, 'weight': bucket_value},  # end of bucket range is not inclusive, so it will *not* match the target value
+                        {'variation': matched_variation, 'weight': 1},  # size of this bucket is 1, so it only matches that specific value
+                        {'variation': bad_variation_b, 'weight': 100000 - (bucket_value + 1)},
+                    ]
+                }
             }
-        })
+        )
         result_variation = _variation_index_for_context(flag, rule, user)
         assert result_variation == (matched_variation, False)
 
@@ -45,13 +47,7 @@ class TestEvaluatorBucketing:
         # We'll construct a list of variations that stops right at the target bucket value
         bucket_value = math.trunc(_bucket_context(None, user, None, flag.key, flag.salt, None) * 100000)
 
-        rule = VariationOrRollout({
-            'rollout': {
-                'variations': [
-                    { 'variation': 0, 'weight': bucket_value }
-                ]
-            }
-        })
+        rule = VariationOrRollout({'rollout': {'variations': [{'variation': 0, 'weight': bucket_value}]}})
         result_variation = _variation_index_for_context(flag, rule, user)
         assert result_variation == (0, False)
 
@@ -121,11 +117,7 @@ class TestEvaluatorBucketing:
         key = 'flag-key'
         salt = 'testing123'
 
-        assert _bucket_context(seed, context1, None, key, salt, None) == \
-            _bucket_context(seed, context1, 'user', key, salt, None)
-        assert _bucket_context(seed, context1, None, key, salt, None) == \
-            _bucket_context(seed, multi, 'user', key, salt, None)
-        assert _bucket_context(seed, context2, 'kind2', key, salt, None) == \
-            _bucket_context(seed, multi, 'kind2', key, salt, None)
-        assert _bucket_context(seed, multi, 'user', key, salt, None) != \
-            _bucket_context(seed, multi, 'kind2', key, salt, None)
+        assert _bucket_context(seed, context1, None, key, salt, None) == _bucket_context(seed, context1, 'user', key, salt, None)
+        assert _bucket_context(seed, context1, None, key, salt, None) == _bucket_context(seed, multi, 'user', key, salt, None)
+        assert _bucket_context(seed, context2, 'kind2', key, salt, None) == _bucket_context(seed, multi, 'kind2', key, salt, None)
+        assert _bucket_context(seed, multi, 'user', key, salt, None) != _bucket_context(seed, multi, 'kind2', key, salt, None)

--- a/ldclient/testing/impl/test_evaluator_prerequisites.py
+++ b/ldclient/testing/impl/test_evaluator_prerequisites.py
@@ -3,7 +3,6 @@ import pytest
 from ldclient.client import Context
 from ldclient.evaluation import EvaluationDetail
 from ldclient.impl.events.types import EventInputEvaluation
-
 from ldclient.testing.builders import *
 from ldclient.testing.impl.evaluator_util import *
 

--- a/ldclient/testing/impl/test_evaluator_prerequisites.py
+++ b/ldclient/testing/impl/test_evaluator_prerequisites.py
@@ -16,6 +16,7 @@ def test_flag_returns_off_variation_if_prerequisite_not_found():
     detail = EvaluationDetail('b', 1, {'kind': 'PREREQUISITE_FAILED', 'prerequisiteKey': 'badfeature'})
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, None)
 
+
 def test_flag_returns_off_variation_and_event_if_prerequisite_is_off():
     flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1) \
         .prerequisite('feature1', 1).build()
@@ -30,6 +31,7 @@ def test_flag_returns_off_variation_and_event_if_prerequisite_is_off():
     ]
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, events_should_be)
 
+
 def test_flag_returns_off_variation_and_event_if_prerequisite_is_not_met():
     flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1) \
         .prerequisite('feature1', 1).build()
@@ -43,6 +45,7 @@ def test_flag_returns_off_variation_and_event_if_prerequisite_is_not_met():
     ]
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, events_should_be)
 
+
 def test_flag_returns_fallthrough_and_event_if_prereq_is_met_and_there_are_no_rules():
     flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(0) \
         .prerequisite('feature1', 1).build()
@@ -55,6 +58,7 @@ def test_flag_returns_fallthrough_and_event_if_prereq_is_met_and_there_are_no_ru
         EventInputEvaluation(0, user, flag1.key, flag1, 1, 'e', None, None, flag, False)
     ]
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, events_should_be)
+
 
 @pytest.mark.parametrize("depth", [1, 2, 3, 4])
 def test_prerequisite_cycle_detection(depth: int):

--- a/ldclient/testing/impl/test_evaluator_prerequisites.py
+++ b/ldclient/testing/impl/test_evaluator_prerequisites.py
@@ -9,8 +9,7 @@ from ldclient.testing.impl.evaluator_util import *
 
 
 def test_flag_returns_off_variation_if_prerequisite_not_found():
-    flag = FlagBuilder('feature').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1) \
-        .prerequisite('badfeature', 1).build()
+    flag = FlagBuilder('feature').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1).prerequisite('badfeature', 1).build()
     evaluator = EvaluatorBuilder().with_unknown_flag('badfeature').build()
     user = Context.create('x')
     detail = EvaluationDetail('b', 1, {'kind': 'PREREQUISITE_FAILED', 'prerequisiteKey': 'badfeature'})
@@ -18,45 +17,33 @@ def test_flag_returns_off_variation_if_prerequisite_not_found():
 
 
 def test_flag_returns_off_variation_and_event_if_prerequisite_is_off():
-    flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1) \
-        .prerequisite('feature1', 1).build()
-    flag1 = FlagBuilder('feature1').version(2).on(False).off_variation(1).variations('d', 'e').fallthrough_variation(1) \
-        .build()
+    flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1).prerequisite('feature1', 1).build()
+    flag1 = FlagBuilder('feature1').version(2).on(False).off_variation(1).variations('d', 'e').fallthrough_variation(1).build()
     # note that even though flag1 returns the desired variation, it is still off and therefore not a match
     evaluator = EvaluatorBuilder().with_flag(flag1).build()
     user = Context.create('x')
     detail = EvaluationDetail('b', 1, {'kind': 'PREREQUISITE_FAILED', 'prerequisiteKey': 'feature1'})
-    events_should_be = [
-        EventInputEvaluation(0, user, flag1.key, flag1, 1, 'e', None, None, flag, False)
-    ]
+    events_should_be = [EventInputEvaluation(0, user, flag1.key, flag1, 1, 'e', None, None, flag, False)]
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, events_should_be)
 
 
 def test_flag_returns_off_variation_and_event_if_prerequisite_is_not_met():
-    flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1) \
-        .prerequisite('feature1', 1).build()
-    flag1 = FlagBuilder('feature1').version(2).on(True).off_variation(1).variations('d', 'e').fallthrough_variation(0) \
-        .build()
+    flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(1).prerequisite('feature1', 1).build()
+    flag1 = FlagBuilder('feature1').version(2).on(True).off_variation(1).variations('d', 'e').fallthrough_variation(0).build()
     evaluator = EvaluatorBuilder().with_flag(flag1).build()
     user = Context.create('x')
     detail = EvaluationDetail('b', 1, {'kind': 'PREREQUISITE_FAILED', 'prerequisiteKey': 'feature1'})
-    events_should_be = [
-        EventInputEvaluation(0, user, flag1.key, flag1, 0, 'd', None, None, flag, False)
-    ]
+    events_should_be = [EventInputEvaluation(0, user, flag1.key, flag1, 0, 'd', None, None, flag, False)]
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, events_should_be)
 
 
 def test_flag_returns_fallthrough_and_event_if_prereq_is_met_and_there_are_no_rules():
-    flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(0) \
-        .prerequisite('feature1', 1).build()
-    flag1 = FlagBuilder('feature1').version(2).on(True).off_variation(1).variations('d', 'e').fallthrough_variation(1) \
-        .build()
+    flag = FlagBuilder('feature0').on(True).off_variation(1).variations('a', 'b', 'c').fallthrough_variation(0).prerequisite('feature1', 1).build()
+    flag1 = FlagBuilder('feature1').version(2).on(True).off_variation(1).variations('d', 'e').fallthrough_variation(1).build()
     evaluator = EvaluatorBuilder().with_flag(flag1).build()
     user = Context.create('x')
     detail = EvaluationDetail('a', 0, {'kind': 'FALLTHROUGH'})
-    events_should_be = [
-        EventInputEvaluation(0, user, flag1.key, flag1, 1, 'e', None, None, flag, False)
-    ]
+    events_should_be = [EventInputEvaluation(0, user, flag1.key, flag1, 1, 'e', None, None, flag, False)]
     assert_eval_result(evaluator.evaluate(flag, user, event_factory), detail, events_should_be)
 
 
@@ -65,10 +52,7 @@ def test_prerequisite_cycle_detection(depth: int):
     flag_keys = list("flagkey%d" % i for i in range(depth))
     flags = []
     for i in range(depth):
-        flags.append(
-            FlagBuilder(flag_keys[i]).on(True).variations(False, True).off_variation(0) \
-                .prerequisite(flag_keys[(i + 1) % depth], 0) \
-                .build())
+        flags.append(FlagBuilder(flag_keys[i]).on(True).variations(False, True).off_variation(0).prerequisite(flag_keys[(i + 1) % depth], 0).build())
     evaluator_builder = EvaluatorBuilder()
     for f in flags:
         evaluator_builder.with_flag(f)

--- a/ldclient/testing/impl/test_evaluator_segment.py
+++ b/ldclient/testing/impl/test_evaluator_segment.py
@@ -12,6 +12,7 @@ def _segment_matches_context(segment: Segment, context: Context) -> bool:
     result = e.evaluate(flag, context, event_factory)
     return result.detail.value
 
+
 def verify_rollout(
     eval_context: Context,
     match_context: Context,
@@ -52,6 +53,7 @@ def test_explicit_include_user():
     segment = SegmentBuilder('test').included(user.key).build()
     assert _segment_matches_context(segment, user) is True
 
+
 def test_explicit_exclude_user():
     user = Context.create('foo')
     segment = SegmentBuilder('test').excluded(user.key) \
@@ -59,10 +61,12 @@ def test_explicit_exclude_user():
         .build()
     assert _segment_matches_context(segment, user) is False
 
+
 def test_explicit_include_has_precedence():
     user = Context.create('foo')
     segment = SegmentBuilder('test').included(user.key).excluded(user.key).build()
     assert _segment_matches_context(segment, user) is True
+
 
 def test_included_key_for_context_kind():
     c1 = Context.create('key1', 'kind1')
@@ -72,6 +76,7 @@ def test_included_key_for_context_kind():
     assert _segment_matches_context(segment, c1) is True
     assert _segment_matches_context(segment, c2) is False
     assert _segment_matches_context(segment, multi) is True
+
 
 def test_excluded_key_for_context_kind():
     c1 = Context.create('key1', 'kind1')
@@ -88,6 +93,7 @@ def test_excluded_key_for_context_kind():
     assert _segment_matches_context(segment, c2) is True
     assert _segment_matches_context(segment, multi) is False
 
+
 def test_matching_rule_with_no_weight():
     context = Context.create('foo')
     segment = SegmentBuilder('test') \
@@ -96,6 +102,7 @@ def test_matching_rule_with_no_weight():
         ) \
         .build()
     assert _segment_matches_context(segment, context) is True
+
 
 def test_matching_rule_with_none_weight():
     context = Context.create('foo')
@@ -106,6 +113,7 @@ def test_matching_rule_with_none_weight():
         .build()
     assert _segment_matches_context(segment, context) is True
 
+
 def test_matching_rule_with_full_rollout():
     context = Context.create('foo')
     segment = SegmentBuilder('test') \
@@ -114,6 +122,7 @@ def test_matching_rule_with_full_rollout():
         ) \
         .build()
     assert _segment_matches_context(segment, context) is True
+
 
 def test_matching_rule_with_zero_rollout():
     context = Context.create('foo')
@@ -124,9 +133,11 @@ def test_matching_rule_with_zero_rollout():
         .build()
     assert _segment_matches_context(segment, context) is False
 
+
 def test_rollout_calculation_can_bucket_by_key():
     context = Context.builder('userkey').name('Bob').build()
     verify_rollout(context, context, 12551, 'test', 'salt', None, None)
+
 
 def test_rollout_uses_context_kind():
     context1 = Context.create('key1', 'kind1')
@@ -134,6 +145,7 @@ def test_rollout_uses_context_kind():
     multi = Context.create_multi(context1, context2)
     expected_bucket_value = int(100000 * _bucket_context(None, context2, 'kind2', 'test', 'salt', None))
     verify_rollout(multi, context2, expected_bucket_value, 'test', 'salt', None, 'kind2')
+
 
 def test_matching_rule_with_multiple_clauses():
     context = Context.builder('foo').name('bob').set('email', 'test@example.com').build()
@@ -147,6 +159,7 @@ def test_matching_rule_with_multiple_clauses():
         .build()
     assert _segment_matches_context(segment, context) is True
 
+
 def test_non_matching_rule_with_multiple_clauses():
     context = Context.builder('foo').name('bob').set('email', 'test@example.com').build()
     segment = SegmentBuilder('test') \
@@ -158,6 +171,7 @@ def test_non_matching_rule_with_multiple_clauses():
         ) \
         .build()
     assert _segment_matches_context(segment, context) is False
+
 
 @pytest.mark.parametrize("depth", [1, 2, 3, 4])
 def test_segment_cycle_detection(depth: int):

--- a/ldclient/testing/impl/test_evaluator_target.py
+++ b/ldclient/testing/impl/test_evaluator_target.py
@@ -14,8 +14,7 @@ def assert_match_clause(clause: dict, context: Context, should_match: bool):
 
 
 def base_flag_builder() -> FlagBuilder:
-    return FlagBuilder('feature').on(True).variations(*VARIATIONS) \
-        .fallthrough_variation(FALLTHROUGH_VAR).off_variation(FALLTHROUGH_VAR)
+    return FlagBuilder('feature').on(True).variations(*VARIATIONS).fallthrough_variation(FALLTHROUGH_VAR).off_variation(FALLTHROUGH_VAR)
 
 
 def expect_match(flag: FeatureFlag, context: Context, variation: int):
@@ -34,10 +33,7 @@ def expect_fallthrough(flag: FeatureFlag, context: Context):
 
 class TestEvaluatorTarget:
     def test_user_targets_only(self):
-        flag = base_flag_builder() \
-            .target(MATCH_VAR_1, 'c') \
-            .target(MATCH_VAR_2, 'b', 'a') \
-            .build()
+        flag = base_flag_builder().target(MATCH_VAR_1, 'c').target(MATCH_VAR_2, 'b', 'a').build()
 
         expect_match(flag, Context.create('a'), MATCH_VAR_2)
         expect_match(flag, Context.create('b'), MATCH_VAR_2)
@@ -45,40 +41,29 @@ class TestEvaluatorTarget:
         expect_fallthrough(flag, Context.create('z'))
 
         # in a multi-kind context, these targets match only the key for the user kind
-        expect_match(flag,
-            Context.create_multi(Context.create('b', 'dog'), Context.create('a')),
-            MATCH_VAR_2)
-        expect_match(flag,
-            Context.create_multi(Context.create('a', 'dog'), Context.create('c')),
-            MATCH_VAR_1)
-        expect_fallthrough(flag,
-            Context.create_multi(Context.create('b', 'dog'), Context.create('z')))
-        expect_fallthrough(flag,
-            Context.create_multi(Context.create('a', 'dog'), Context.create('b', 'cat')))
+        expect_match(flag, Context.create_multi(Context.create('b', 'dog'), Context.create('a')), MATCH_VAR_2)
+        expect_match(flag, Context.create_multi(Context.create('a', 'dog'), Context.create('c')), MATCH_VAR_1)
+        expect_fallthrough(flag, Context.create_multi(Context.create('b', 'dog'), Context.create('z')))
+        expect_fallthrough(flag, Context.create_multi(Context.create('a', 'dog'), Context.create('b', 'cat')))
 
     def test_user_targets_and_context_targets(self):
-        flag = base_flag_builder() \
-            .target(MATCH_VAR_1, 'c') \
-            .target(MATCH_VAR_2, 'b', 'a') \
-            .context_target('dog', MATCH_VAR_1, 'a', 'b') \
-            .context_target('dog', MATCH_VAR_2, 'c') \
-            .context_target(Context.DEFAULT_KIND, MATCH_VAR_1) \
-            .context_target(Context.DEFAULT_KIND, MATCH_VAR_2) \
+        flag = (
+            base_flag_builder()
+            .target(MATCH_VAR_1, 'c')
+            .target(MATCH_VAR_2, 'b', 'a')
+            .context_target('dog', MATCH_VAR_1, 'a', 'b')
+            .context_target('dog', MATCH_VAR_2, 'c')
+            .context_target(Context.DEFAULT_KIND, MATCH_VAR_1)
+            .context_target(Context.DEFAULT_KIND, MATCH_VAR_2)
             .build()
+        )
 
         expect_match(flag, Context.create('a'), MATCH_VAR_2)
         expect_match(flag, Context.create('b'), MATCH_VAR_2)
         expect_match(flag, Context.create('c'), MATCH_VAR_1)
         expect_fallthrough(flag, Context.create('z'))
 
-        expect_match(flag,
-            Context.create_multi(Context.create('b', 'dog'), Context.create('a')),
-            MATCH_VAR_1)  # the "dog" target takes precedence due to ordering
-        expect_match(flag,
-            Context.create_multi(Context.create('z', 'dog'), Context.create('a')),
-            MATCH_VAR_2)  # "dog" targets don't match, continue to "user" targets
-        expect_fallthrough(flag,
-            Context.create_multi(Context.create('x', 'dog'), Context.create('z')))  # nothing matches
-        expect_match(flag,
-            Context.create_multi(Context.create('a', 'dog'), Context.create('b', 'cat')),
-            MATCH_VAR_1)
+        expect_match(flag, Context.create_multi(Context.create('b', 'dog'), Context.create('a')), MATCH_VAR_1)  # the "dog" target takes precedence due to ordering
+        expect_match(flag, Context.create_multi(Context.create('z', 'dog'), Context.create('a')), MATCH_VAR_2)  # "dog" targets don't match, continue to "user" targets
+        expect_fallthrough(flag, Context.create_multi(Context.create('x', 'dog'), Context.create('z')))  # nothing matches
+        expect_match(flag, Context.create_multi(Context.create('a', 'dog'), Context.create('b', 'cat')), MATCH_VAR_1)

--- a/ldclient/testing/impl/test_evaluator_target.py
+++ b/ldclient/testing/impl/test_evaluator_target.py
@@ -2,7 +2,6 @@ from ldclient.client import Context
 from ldclient.testing.builders import *
 from ldclient.testing.impl.evaluator_util import *
 
-
 FALLTHROUGH_VAR = 0
 MATCH_VAR_1 = 1
 MATCH_VAR_2 = 2

--- a/ldclient/testing/impl/test_evaluator_target.py
+++ b/ldclient/testing/impl/test_evaluator_target.py
@@ -8,18 +8,22 @@ MATCH_VAR_1 = 1
 MATCH_VAR_2 = 2
 VARIATIONS = ['fallthrough', 'match1', 'match2']
 
+
 def assert_match_clause(clause: dict, context: Context, should_match: bool):
     assert_match(basic_evaluator, make_boolean_flag_with_clauses(clause), context, should_match)
+
 
 def base_flag_builder() -> FlagBuilder:
     return FlagBuilder('feature').on(True).variations(*VARIATIONS) \
         .fallthrough_variation(FALLTHROUGH_VAR).off_variation(FALLTHROUGH_VAR)
+
 
 def expect_match(flag: FeatureFlag, context: Context, variation: int):
     result = basic_evaluator.evaluate(flag, context, event_factory)
     assert result.detail.variation_index == variation
     assert result.detail.value == VARIATIONS[variation]
     assert result.detail.reason == {'kind': 'TARGET_MATCH'}
+
 
 def expect_fallthrough(flag: FeatureFlag, context: Context):
     result = basic_evaluator.evaluate(flag, context, event_factory)

--- a/ldclient/testing/impl/test_flag_tracker.py
+++ b/ldclient/testing/impl/test_flag_tracker.py
@@ -1,7 +1,7 @@
 from ldclient.impl.flag_tracker import FlagTrackerImpl
-from ldclient.testing.test_util import SpyListener
 from ldclient.impl.listeners import Listeners
 from ldclient.interfaces import FlagChange
+from ldclient.testing.test_util import SpyListener
 
 
 def test_can_add_and_remove_listeners():

--- a/ldclient/testing/impl/test_http.py
+++ b/ldclient/testing/impl/test_http.py
@@ -9,7 +9,6 @@ from ldclient.impl.http import _get_proxy_url
     [
         ('https://secure.example.com', '', 'https://secure.proxy:1234'),
         ('http://insecure.example.com', '', 'http://insecure.proxy:6789'),
-
         ('https://secure.example.com', 'secure.example.com', None),
         ('https://secure.example.com', 'secure.example.com:443', None),
         ('https://secure.example.com', 'secure.example.com:80', 'https://secure.proxy:1234'),
@@ -19,36 +18,31 @@ from ldclient.impl.http import _get_proxy_url
         ('https://secure.example.com:8080', 'secure.example.com:443,', 'https://secure.proxy:1234'),
         ('https://secure.example.com:8080', 'secure.example.com:443,,', 'https://secure.proxy:1234'),
         ('https://secure.example.com:8080', ':8080', 'https://secure.proxy:1234'),
-
         ('https://secure.example.com', 'example.com', None),
         ('https://secure.example.com', 'example.com:443', None),
         ('https://secure.example.com', 'example.com:80', 'https://secure.proxy:1234'),
-
         ('http://insecure.example.com', 'insecure.example.com', None),
         ('http://insecure.example.com', 'insecure.example.com:443', 'http://insecure.proxy:6789'),
         ('http://insecure.example.com', 'insecure.example.com:80', None),
         ('http://insecure.example.com', 'wrong.example.com', 'http://insecure.proxy:6789'),
         ('http://insecure.example.com:8080', 'secure.example.com', None),
         ('http://insecure.example.com:8080', 'secure.example.com:443', 'http://insecure.proxy:6789'),
-
         ('http://insecure.example.com', 'example.com', None),
         ('http://insecure.example.com', 'example.com:443', 'http://insecure.proxy:6789'),
         ('http://insecure.example.com', 'example.com:80', None),
-
         ('secure.example.com', 'secure.example.com', None),
         ('secure.example.com', 'secure.example.com:443', 'http://insecure.proxy:6789'),
         ('secure.example.com', 'secure.example.com:80', None),
         ('secure.example.com', 'wrong.example.com', 'http://insecure.proxy:6789'),
         ('secure.example.com:8080', 'secure.example.com', None),
         ('secure.example.com:8080', 'secure.example.com:80', 'http://insecure.proxy:6789'),
-
         ('https://secure.example.com', '*', None),
         ('https://secure.example.com:8080', '*', None),
         ('http://insecure.example.com', '*', None),
         ('http://insecure.example.com:8080', '*', None),
         ('secure.example.com:443', '*', None),
         ('insecure.example.com:8080', '*', None),
-    ]
+    ],
 )
 def test_honors_no_proxy(target_uri: str, no_proxy: str, expected: Optional[str], monkeypatch):
     monkeypatch.setenv('https_proxy', 'https://secure.proxy:1234')

--- a/ldclient/testing/impl/test_http.py
+++ b/ldclient/testing/impl/test_http.py
@@ -1,6 +1,7 @@
+from typing import Optional
+
 import pytest
 
-from typing import Optional
 from ldclient.impl.http import _get_proxy_url
 
 

--- a/ldclient/testing/impl/test_listeners.py
+++ b/ldclient/testing/impl/test_listeners.py
@@ -1,6 +1,6 @@
-from ldclient.impl.listeners import Listeners
-
 from queue import Queue
+
+from ldclient.impl.listeners import Listeners
 
 
 def test_notify_with_no_listeners_does_not_throw_exception():

--- a/ldclient/testing/impl/test_listeners.py
+++ b/ldclient/testing/impl/test_listeners.py
@@ -2,9 +2,11 @@ from ldclient.impl.listeners import Listeners
 
 from queue import Queue
 
+
 def test_notify_with_no_listeners_does_not_throw_exception():
     l = Listeners()
     l.notify("hi")
+
 
 def test_notify_calls_listeners():
     q1 = Queue()
@@ -17,6 +19,7 @@ def test_notify_calls_listeners():
     assert q2.get() == "hi"
     assert q1.empty() == True
     assert q2.empty() == True
+
 
 def test_remove_listener():
     q1 = Queue()
@@ -32,6 +35,7 @@ def test_remove_listener():
     assert q1.empty() == True
     assert q2.get() == "hi"
     assert q2.empty() == True
+
 
 def test_exception_from_listener_is_caught_and_other_listeners_are_still_called():
     def fail(v):

--- a/ldclient/testing/impl/test_listeners.py
+++ b/ldclient/testing/impl/test_listeners.py
@@ -4,37 +4,42 @@ from queue import Queue
 
 
 def test_notify_with_no_listeners_does_not_throw_exception():
-    l = Listeners()
-    l.notify("hi")
+    listeners = Listeners()
+    listeners.notify("hi")
 
 
 def test_notify_calls_listeners():
     q1 = Queue()
     q2 = Queue()
-    l = Listeners()
-    l.add(lambda v: q1.put(v))
-    l.add(lambda v: q2.put(v))
-    l.notify("hi")
+    listeners = Listeners()
+    listeners.add(lambda v: q1.put(v))
+    listeners.add(lambda v: q2.put(v))
+    listeners.notify("hi")
     assert q1.get() == "hi"
     assert q2.get() == "hi"
-    assert q1.empty() == True
-    assert q2.empty() == True
+    assert q1.empty() is True
+    assert q2.empty() is True
 
 
 def test_remove_listener():
     q1 = Queue()
     q2 = Queue()
-    p1 = lambda v: q1.put(v)
-    p2 = lambda v: q2.put(v)
-    l = Listeners()
-    l.add(p1)
-    l.add(p2)
-    l.remove(p1)
-    l.remove(lambda v: print(v))  # removing nonexistent listener does not throw exception
-    l.notify("hi")
-    assert q1.empty() == True
+
+    def put_into_q1(v):
+        q1.put(v)
+
+    def put_into_q2(v):
+        q2.put(v)
+
+    listeners = Listeners()
+    listeners.add(put_into_q1)
+    listeners.add(put_into_q2)
+    listeners.remove(put_into_q1)
+    listeners.remove(lambda v: print(v))  # removing nonexistent listener does not throw exception
+    listeners.notify("hi")
+    assert q1.empty() is True
     assert q2.get() == "hi"
-    assert q2.empty() == True
+    assert q2.empty() is True
 
 
 def test_exception_from_listener_is_caught_and_other_listeners_are_still_called():
@@ -42,9 +47,9 @@ def test_exception_from_listener_is_caught_and_other_listeners_are_still_called(
         raise Exception("deliberate error")
 
     q = Queue()
-    l = Listeners()
-    l.add(fail)
-    l.add(lambda v: q.put(v))
-    l.notify("hi")
+    listeners = Listeners()
+    listeners.add(fail)
+    listeners.add(lambda v: q.put(v))
+    listeners.notify("hi")
     assert q.get() == "hi"
-    assert q.empty() == True
+    assert q.empty() is True

--- a/ldclient/testing/impl/test_listeners.py
+++ b/ldclient/testing/impl/test_listeners.py
@@ -30,7 +30,7 @@ def test_remove_listener():
     l.add(p1)
     l.add(p2)
     l.remove(p1)
-    l.remove(lambda v: print(v)) # removing nonexistent listener does not throw exception
+    l.remove(lambda v: print(v))  # removing nonexistent listener does not throw exception
     l.notify("hi")
     assert q1.empty() == True
     assert q2.get() == "hi"
@@ -40,6 +40,7 @@ def test_remove_listener():
 def test_exception_from_listener_is_caught_and_other_listeners_are_still_called():
     def fail(v):
         raise Exception("deliberate error")
+
     q = Queue()
     l = Listeners()
     l.add(fail)

--- a/ldclient/testing/impl/test_lru_cache.py
+++ b/ldclient/testing/impl/test_lru_cache.py
@@ -1,5 +1,6 @@
 from ldclient.impl.lru_cache import SimpleLRUCache
 
+
 def test_retains_values_up_to_capacity():
     lru = SimpleLRUCache(3)
     assert lru.put("a", True) == False
@@ -9,6 +10,7 @@ def test_retains_values_up_to_capacity():
     assert lru.put("b", True) == True
     assert lru.put("c", True) == True
 
+
 def test_discards_oldest_value_on_overflow():
     lru = SimpleLRUCache(2)
     assert lru.put("a", True) == False
@@ -17,6 +19,7 @@ def test_discards_oldest_value_on_overflow():
     assert lru.get("a") is None
     assert lru.get("b") == True
     assert lru.get("c") == True
+
 
 def test_value_becomes_new_on_replace():
     lru = SimpleLRUCache(2)

--- a/ldclient/testing/impl/test_lru_cache.py
+++ b/ldclient/testing/impl/test_lru_cache.py
@@ -3,30 +3,30 @@ from ldclient.impl.lru_cache import SimpleLRUCache
 
 def test_retains_values_up_to_capacity():
     lru = SimpleLRUCache(3)
-    assert lru.put("a", True) == False
-    assert lru.put("b", True) == False
-    assert lru.put("c", True) == False
-    assert lru.put("a", True) == True
-    assert lru.put("b", True) == True
-    assert lru.put("c", True) == True
+    assert lru.put("a", True) is False
+    assert lru.put("b", True) is False
+    assert lru.put("c", True) is False
+    assert lru.put("a", True) is True
+    assert lru.put("b", True) is True
+    assert lru.put("c", True) is True
 
 
 def test_discards_oldest_value_on_overflow():
     lru = SimpleLRUCache(2)
-    assert lru.put("a", True) == False
-    assert lru.put("b", True) == False
-    assert lru.put("c", True) == False
+    assert lru.put("a", True) is False
+    assert lru.put("b", True) is False
+    assert lru.put("c", True) is False
     assert lru.get("a") is None
-    assert lru.get("b") == True
-    assert lru.get("c") == True
+    assert lru.get("b") is True
+    assert lru.get("c") is True
 
 
 def test_value_becomes_new_on_replace():
     lru = SimpleLRUCache(2)
-    assert lru.put("a", True) == False
-    assert lru.put("b", True) == False
-    assert lru.put("a", True) == True  # b is now oldest
-    assert lru.put("c", True) == False  # b is discarded as oldest
+    assert lru.put("a", True) is False
+    assert lru.put("b", True) is False
+    assert lru.put("a", True) is True  # b is now oldest
+    assert lru.put("c", True) is False  # b is discarded as oldest
     assert lru.get("a") is True
     assert lru.get("b") is None
     assert lru.get("c") is True

--- a/ldclient/testing/impl/test_model_decode.py
+++ b/ldclient/testing/impl/test_model_decode.py
@@ -15,6 +15,7 @@ def test_flag_targets_are_stored_as_sets():
     assert flag.targets[0].values == {"a", "b"}
     assert flag.context_targets[0].values == {"c", "d"}
 
+
 def test_segment_targets_are_stored_as_sets():
     segment = SegmentBuilder("key") \
         .included("a", "b") \
@@ -27,6 +28,7 @@ def test_segment_targets_are_stored_as_sets():
     assert segment.included_contexts[0].values == {"e", "f"}
     assert segment.excluded_contexts[0].values == {"g", "h"}
 
+
 def test_clause_values_preprocessed_with_regex_operator():
     pattern_str = "^[a-z]*$"
     pattern = re.compile(pattern_str)
@@ -34,11 +36,13 @@ def test_clause_values_preprocessed_with_regex_operator():
     assert flag.rules[0].clauses[0]._values == [pattern_str, "?", True]
     assert list(x.as_regex for x in flag.rules[0].clauses[0]._values_preprocessed) == [pattern, None, None]
 
+
 @pytest.mark.parametrize('op', ['semVerEqual', 'semVerGreaterThan', 'semVerLessThan'])
 def test_clause_values_preprocessed_with_semver_operator(op):
     flag = make_boolean_flag_with_clauses(make_clause(None, "attr", op, "1.2.3", 1, True))
     assert flag.rules[0].clauses[0]._values == ["1.2.3", 1, True]
     assert list(x.as_semver for x in flag.rules[0].clauses[0]._values_preprocessed) == [VersionInfo(1, 2, 3), None, None]
+
 
 @pytest.mark.parametrize('op', ['before', 'after'])
 def test_clause_values_preprocessed_with_time_operator(op):

--- a/ldclient/testing/impl/test_model_decode.py
+++ b/ldclient/testing/impl/test_model_decode.py
@@ -1,9 +1,9 @@
-import pytest
 import re
+
+import pytest
 from semver import VersionInfo
 
 from ldclient.impl.model import *
-
 from ldclient.testing.builders import *
 
 

--- a/ldclient/testing/impl/test_model_decode.py
+++ b/ldclient/testing/impl/test_model_decode.py
@@ -8,21 +8,13 @@ from ldclient.testing.builders import *
 
 
 def test_flag_targets_are_stored_as_sets():
-    flag = FlagBuilder("key") \
-        .target(0, "a", "b") \
-        .context_target("kind1", 0, "c", "d") \
-        .build()
+    flag = FlagBuilder("key").target(0, "a", "b").context_target("kind1", 0, "c", "d").build()
     assert flag.targets[0].values == {"a", "b"}
     assert flag.context_targets[0].values == {"c", "d"}
 
 
 def test_segment_targets_are_stored_as_sets():
-    segment = SegmentBuilder("key") \
-        .included("a", "b") \
-        .excluded("c", "d") \
-        .included_contexts("kind1", "e", "f") \
-        .excluded_contexts("kind2", "g", "h") \
-        .build()
+    segment = SegmentBuilder("key").included("a", "b").excluded("c", "d").included_contexts("kind1", "e", "f").excluded_contexts("kind2", "g", "h").build()
     assert segment.included == {"a", "b"}
     assert segment.excluded == {"c", "d"}
     assert segment.included_contexts[0].values == {"e", "f"}

--- a/ldclient/testing/impl/test_model_encoder.py
+++ b/ldclient/testing/impl/test_model_encoder.py
@@ -1,6 +1,6 @@
-from ldclient.impl.model import *
-
 import json
+
+from ldclient.impl.model import *
 
 
 class MyTestEntity(ModelEntity):

--- a/ldclient/testing/impl/test_model_encoder.py
+++ b/ldclient/testing/impl/test_model_encoder.py
@@ -6,7 +6,7 @@ import json
 class MyTestEntity(ModelEntity):
     def __init__(self, value):
         self._value = value
-    
+
     def to_json_dict(self) -> dict:
         return {'magicValue': self._value}
 

--- a/ldclient/testing/impl/test_operators.py
+++ b/ldclient/testing/impl/test_operators.py
@@ -5,90 +5,87 @@ from ldclient.impl import operators
 from ldclient.testing.builders import *
 
 
-@pytest.mark.parametrize("op,context_value,clause_value,expected", [
-    # numeric comparisons
-    [ "in",                 99,      99,      True ],
-    [ "in",                 99.0001, 99.0001, True ],
-    [ "in",                 99,      99.0001, False ],
-    [ "in",                 99.0001, 99,      False ],
-    [ "lessThan",           99,      99.0001, True ],
-    [ "lessThan",           99.0001, 99,      False ],
-    [ "lessThan",           99,      99,      False ],
-    [ "lessThanOrEqual",    99,      99.0001, True ],
-    [ "lessThanOrEqual",    99.0001, 99,      False ],
-    [ "lessThanOrEqual",    99,      99,      True ],
-    [ "greaterThan",        99.0001, 99,      True ],
-    [ "greaterThan",        99,      99.0001, False ],
-    [ "greaterThan",        99,      99,      False ],
-    [ "greaterThanOrEqual", 99.0001, 99,      True ],
-    [ "greaterThanOrEqual", 99,      99.0001, False ],
-    [ "greaterThanOrEqual", 99,      99,      True ],
-
-    # string comparisons
-    [ "in",         "x",   "x",   True ],
-    [ "in",         "x",   "xyz", False ],
-    [ "startsWith", "xyz", "x",   True ],
-    [ "startsWith", "x",   "xyz", False ],
-    [ "endsWith",   "xyz", "z",   True ],
-    [ "endsWith",   "z",   "xyz", False ],
-    [ "contains",   "xyz", "y",   True ],
-    [ "contains",   "y",   "xyz", False ],
-
-    # mixed strings and numbers
-    [ "in",                 "99", 99,   False ],
-    [ "in",                 99,   "99", False ],
-    [ "contains",           "99", 99,   False ],
-    [ "startsWith",         "99", 99,   False ],
-    [ "endsWith",           "99", 99,   False ],
-    [ "lessThanOrEqual",    "99", 99,   False ],
-    [ "lessThanOrEqual",    99,   "99", False ],
-    [ "greaterThanOrEqual", "99", 99,   False ],
-    [ "greaterThanOrEqual", 99,   "99", False ],
-
-    # regex
-    [ "matches", "hello world", "hello.*rld",     True ],
-    [ "matches", "hello world", "hello.*rl",      True ],
-    [ "matches", "hello world", "l+",             True ],
-    [ "matches", "hello world", "(world|planet)", True ],
-    [ "matches", "hello world", "aloha",          False ],
-    # [ "matches", "hello world", "***not a regex", False ],   # currently throws an exception
-
-    # dates
-    [ "before", 0, 1,                              True ],
-    [ "before", -100, 0,                           True ],
-    [ "before", "1970-01-01T00:00:00Z", 1000,      True ],
-    [ "before", "1970-01-01T00:00:00.500Z", 1000,  True ],
-    [ "before", True, 1000,                        False ],  # wrong type
-    [ "after",  "1970-01-01T00:00:02.500Z", 1000,  True ],
-    [ "after",  "1970-01-01 00:00:02.500Z", 1000,  False ],  # malformed timestamp
-    [ "after", "1970-01-01T00:00:02+01:00", None, False ],
-    [ "after", None, "1970-01-01T00:00:02+01:00", False ],
-    [ "before", "1970-01-01T00:00:02+01:00", 1000, True ],
-    [ "before", "1970-01-01T00:00:02+01:00", None, False ],
-    [ "before", None, "1970-01-01T00:00:02+01:00", False ],
-    [ "before", -1000, 1000,                       True ],
-    [ "after",  "1970-01-01T00:00:01.001Z", 1000,  True ],
-    [ "after",  "1970-01-01T00:00:00-01:00", 1000, True ],
-
-    # semver
-    [ "semVerEqual",       "2.0.1", "2.0.1",    True ],
-    [ "semVerEqual",       "2.0",   "2.0.0",    True ],
-    [ "semVerEqual",       "2",     "2.0.0",    True ],
-    [ "semVerEqual",       2,     "2.0.0",    False ],
-    [ "semVerEqual",       "2.0.0",     2,    False ],
-    [ "semVerEqual",       "2.0-rc1", "2.0.0-rc1", True ],
-    [ "semVerLessThan",    "2.0.0", "2.0.1",    True ],
-    [ "semVerLessThan",    "2.0",   "2.0.1",    True ],
-    [ "semVerLessThan",    "2.0.1", "2.0.0",    False ],
-    [ "semVerLessThan",    "2.0.1", "2.0",      False ],
-    [ "semVerGreaterThan", "2.0.1", "2.0.0",    True ],
-    [ "semVerGreaterThan", "2.0.1", "2.0",      True ],
-    [ "semVerGreaterThan", "2.0.0", "2.0.1",    False ],
-    [ "semVerGreaterThan", "2.0",   "2.0.1",    False ],
-    [ "semVerLessThan",    "2.0.1", "xbad%ver", False ],
-    [ "semVerGreaterThan", "2.0.1", "xbad%ver", False ]
-])
-
+@pytest.mark.parametrize(
+    "op,context_value,clause_value,expected",
+    [
+        # numeric comparisons
+        ["in", 99, 99, True],
+        ["in", 99.0001, 99.0001, True],
+        ["in", 99, 99.0001, False],
+        ["in", 99.0001, 99, False],
+        ["lessThan", 99, 99.0001, True],
+        ["lessThan", 99.0001, 99, False],
+        ["lessThan", 99, 99, False],
+        ["lessThanOrEqual", 99, 99.0001, True],
+        ["lessThanOrEqual", 99.0001, 99, False],
+        ["lessThanOrEqual", 99, 99, True],
+        ["greaterThan", 99.0001, 99, True],
+        ["greaterThan", 99, 99.0001, False],
+        ["greaterThan", 99, 99, False],
+        ["greaterThanOrEqual", 99.0001, 99, True],
+        ["greaterThanOrEqual", 99, 99.0001, False],
+        ["greaterThanOrEqual", 99, 99, True],
+        # string comparisons
+        ["in", "x", "x", True],
+        ["in", "x", "xyz", False],
+        ["startsWith", "xyz", "x", True],
+        ["startsWith", "x", "xyz", False],
+        ["endsWith", "xyz", "z", True],
+        ["endsWith", "z", "xyz", False],
+        ["contains", "xyz", "y", True],
+        ["contains", "y", "xyz", False],
+        # mixed strings and numbers
+        ["in", "99", 99, False],
+        ["in", 99, "99", False],
+        ["contains", "99", 99, False],
+        ["startsWith", "99", 99, False],
+        ["endsWith", "99", 99, False],
+        ["lessThanOrEqual", "99", 99, False],
+        ["lessThanOrEqual", 99, "99", False],
+        ["greaterThanOrEqual", "99", 99, False],
+        ["greaterThanOrEqual", 99, "99", False],
+        # regex
+        ["matches", "hello world", "hello.*rld", True],
+        ["matches", "hello world", "hello.*rl", True],
+        ["matches", "hello world", "l+", True],
+        ["matches", "hello world", "(world|planet)", True],
+        ["matches", "hello world", "aloha", False],
+        # [ "matches", "hello world", "***not a regex", False ],   # currently throws an exception
+        # dates
+        ["before", 0, 1, True],
+        ["before", -100, 0, True],
+        ["before", "1970-01-01T00:00:00Z", 1000, True],
+        ["before", "1970-01-01T00:00:00.500Z", 1000, True],
+        ["before", True, 1000, False],  # wrong type
+        ["after", "1970-01-01T00:00:02.500Z", 1000, True],
+        ["after", "1970-01-01 00:00:02.500Z", 1000, False],  # malformed timestamp
+        ["after", "1970-01-01T00:00:02+01:00", None, False],
+        ["after", None, "1970-01-01T00:00:02+01:00", False],
+        ["before", "1970-01-01T00:00:02+01:00", 1000, True],
+        ["before", "1970-01-01T00:00:02+01:00", None, False],
+        ["before", None, "1970-01-01T00:00:02+01:00", False],
+        ["before", -1000, 1000, True],
+        ["after", "1970-01-01T00:00:01.001Z", 1000, True],
+        ["after", "1970-01-01T00:00:00-01:00", 1000, True],
+        # semver
+        ["semVerEqual", "2.0.1", "2.0.1", True],
+        ["semVerEqual", "2.0", "2.0.0", True],
+        ["semVerEqual", "2", "2.0.0", True],
+        ["semVerEqual", 2, "2.0.0", False],
+        ["semVerEqual", "2.0.0", 2, False],
+        ["semVerEqual", "2.0-rc1", "2.0.0-rc1", True],
+        ["semVerLessThan", "2.0.0", "2.0.1", True],
+        ["semVerLessThan", "2.0", "2.0.1", True],
+        ["semVerLessThan", "2.0.1", "2.0.0", False],
+        ["semVerLessThan", "2.0.1", "2.0", False],
+        ["semVerGreaterThan", "2.0.1", "2.0.0", True],
+        ["semVerGreaterThan", "2.0.1", "2.0", True],
+        ["semVerGreaterThan", "2.0.0", "2.0.1", False],
+        ["semVerGreaterThan", "2.0", "2.0.1", False],
+        ["semVerLessThan", "2.0.1", "xbad%ver", False],
+        ["semVerGreaterThan", "2.0.1", "xbad%ver", False],
+    ],
+)
 def test_operator(op, context_value, clause_value, expected):
     flag = make_boolean_flag_with_clauses(make_clause(None, 'attr', op, clause_value))
     preprocessed = flag.rules[0].clauses[0].values_preprocessed

--- a/ldclient/testing/impl/test_operators.py
+++ b/ldclient/testing/impl/test_operators.py
@@ -1,7 +1,6 @@
 import pytest
 
 from ldclient.impl import operators
-
 from ldclient.testing.builders import *
 
 

--- a/ldclient/testing/impl/test_repeating_task.py
+++ b/ldclient/testing/impl/test_repeating_task.py
@@ -10,7 +10,7 @@ def test_task_does_not_start_when_created():
     task = RepeatingTask("ldclient.testing.set-signal", 0.01, 0, lambda: signal.set())
     try:
         signal_was_set = signal.wait(0.1)
-        assert signal_was_set == False
+        assert signal_was_set is False
     finally:
         task.stop()
 
@@ -36,7 +36,7 @@ def test_task_executes_until_stopped():
             assert t <= stopped_time
         except Empty:
             no_more_items = True
-    assert no_more_items == True
+    assert no_more_items is True
 
 
 def test_task_can_be_stopped_from_within_the_task():
@@ -54,7 +54,7 @@ def test_task_can_be_stopped_from_within_the_task():
     task = RepeatingTask("ldclient.testing.task-runner", 0.01, 0, do_task)
     try:
         task.start()
-        assert stopped.wait(0.1) == True
+        assert stopped.wait(0.1) is True
         assert counter == 2
         time.sleep(0.1)
         assert counter == 2

--- a/ldclient/testing/impl/test_repeating_task.py
+++ b/ldclient/testing/impl/test_repeating_task.py
@@ -14,6 +14,7 @@ def test_task_does_not_start_when_created():
     finally:
         task.stop()
 
+
 def test_task_executes_until_stopped():
     queue = Queue()
     task = RepeatingTask("ldclient.testing.enqueue-time", 0.1, 0, lambda: queue.put(time.time()))
@@ -37,10 +38,12 @@ def test_task_executes_until_stopped():
             no_more_items = True
     assert no_more_items == True
 
+
 def test_task_can_be_stopped_from_within_the_task():
     counter = 0
     stopped = Event()
     task = None
+
     def do_task():
         nonlocal counter
         counter += 1

--- a/ldclient/testing/impl/test_repeating_task.py
+++ b/ldclient/testing/impl/test_repeating_task.py
@@ -50,6 +50,7 @@ def test_task_can_be_stopped_from_within_the_task():
         if counter >= 2:
             task.stop()
             stopped.set()
+
     task = RepeatingTask("ldclient.testing.task-runner", 0.01, 0, do_task)
     try:
         task.start()

--- a/ldclient/testing/impl/test_repeating_task.py
+++ b/ldclient/testing/impl/test_repeating_task.py
@@ -1,8 +1,8 @@
-from ldclient.impl.repeating_task import RepeatingTask
-
+import time
 from queue import Empty, Queue
 from threading import Event
-import time
+
+from ldclient.impl.repeating_task import RepeatingTask
 
 
 def test_task_does_not_start_when_created():

--- a/ldclient/testing/impl/test_sampler.py
+++ b/ldclient/testing/impl/test_sampler.py
@@ -1,4 +1,5 @@
 from random import Random
+
 from ldclient.impl.sampler import Sampler
 
 

--- a/ldclient/testing/integrations/big_segment_store_test_base.py
+++ b/ldclient/testing/integrations/big_segment_store_test_base.py
@@ -50,11 +50,11 @@ class BigSegmentStoreTester:
 class BigSegmentStoreTestScope:
     def __init__(self, store: BigSegmentStore):
         self.__store = store
-    
+
     @property
     def store(self) -> BigSegmentStore:
         return self.__store
-    
+
     # These magic methods allow the scope to be automatically cleaned up in a "with" block
     def __enter__(self):
         return self.__store
@@ -106,17 +106,16 @@ class BigSegmentStoreTestBase:
         tester.set_segments(tester.prefix, fake_user_hash, ['key1', 'key2'], [])
         with self.store(tester) as store:
             membership = store.get_membership(fake_user_hash)
-            assert membership == { 'key1': True, 'key2': True }
+            assert membership == {'key1': True, 'key2': True}
 
     def test_get_membership_excludes_only(self, tester):
         tester.set_segments(tester.prefix, fake_user_hash, [], ['key1', 'key2'])
         with self.store(tester) as store:
             membership = store.get_membership(fake_user_hash)
-            assert membership == { 'key1': False, 'key2': False }
-    
+            assert membership == {'key1': False, 'key2': False}
+
     def test_get_membership_includes_and_excludes(self, tester):
         tester.set_segments(tester.prefix, fake_user_hash, ['key1', 'key2'], ['key2', 'key3'])
         with self.store(tester) as store:
             membership = store.get_membership(fake_user_hash)
-            assert membership == { 'key1': True, 'key2': True, 'key3': False }
-    
+            assert membership == {'key1': True, 'key2': True, 'key3': False}

--- a/ldclient/testing/integrations/big_segment_store_test_base.py
+++ b/ldclient/testing/integrations/big_segment_store_test_base.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod, abstractproperty
 from os import environ
-import pytest
 from typing import List
+
+import pytest
 
 from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 

--- a/ldclient/testing/integrations/persistent_feature_store_test_base.py
+++ b/ldclient/testing/integrations/persistent_feature_store_test_base.py
@@ -47,12 +47,7 @@ class PersistentFeatureStoreTestBase(FeatureStoreTestBase):
     def tester_class(self):
         pass
 
-    @pytest.fixture(params=[
-        (False, False),
-        (True, False),
-        (False, True),
-        (True, True)
-    ])
+    @pytest.fixture(params=[(False, False), (True, False), (False, True), (True, True)])
     def tester(self, request):
         specify_prefix, use_caching = request.param
         instance = self.tester_class()
@@ -75,17 +70,17 @@ class PersistentFeatureStoreTestBase(FeatureStoreTestBase):
         tester_b.prefix = "b"
         tester_b.clear_data(tester_b.prefix)
 
-        flag_a1 = { 'key': 'flagA1', 'version': 1 }
-        flag_a2 = { 'key': 'flagA2', 'version': 1 }
-        flag_b1 = { 'key': 'flagB1', 'version': 1 }
-        flag_b2 = { 'key': 'flagB2', 'version': 1 }
+        flag_a1 = {'key': 'flagA1', 'version': 1}
+        flag_a2 = {'key': 'flagA2', 'version': 1}
+        flag_b1 = {'key': 'flagB1', 'version': 1}
+        flag_b2 = {'key': 'flagB2', 'version': 1}
 
         with StoreTestScope(tester_a.create_feature_store()) as store_a:
             with StoreTestScope(tester_b.create_feature_store()) as store_b:
-                store_a.init({ FEATURES: { 'flagA1': flag_a1 } })
+                store_a.init({FEATURES: {'flagA1': flag_a1}})
                 store_a.upsert(FEATURES, flag_a2)
 
-                store_b.init({ FEATURES: { 'flagB1': flag_b1 } })
+                store_b.init({FEATURES: {'flagB1': flag_b1}})
                 store_b.upsert(FEATURES, flag_b2)
 
                 item = store_a.get(FEATURES, 'flagA1', lambda x: x)
@@ -93,11 +88,11 @@ class PersistentFeatureStoreTestBase(FeatureStoreTestBase):
                 item = store_a.get(FEATURES, 'flagB1', lambda x: x)
                 assert item is None
                 items = store_a.all(FEATURES, lambda x: x)
-                assert items == { 'flagA1': FEATURES.decode(flag_a1), 'flagA2': FEATURES.decode(flag_a2) }
+                assert items == {'flagA1': FEATURES.decode(flag_a1), 'flagA2': FEATURES.decode(flag_a2)}
 
                 item = store_b.get(FEATURES, 'flagB1', lambda x: x)
                 assert item == FEATURES.decode(flag_b1)
                 item = store_b.get(FEATURES, 'flagA1', lambda x: x)
                 assert item is None
                 items = store_b.all(FEATURES, lambda x: x)
-                assert items == { 'flagB1': FEATURES.decode(flag_b1), 'flagB2': FEATURES.decode(flag_b2) }
+                assert items == {'flagB1': FEATURES.decode(flag_b1), 'flagB2': FEATURES.decode(flag_b2)}

--- a/ldclient/testing/integrations/persistent_feature_store_test_base.py
+++ b/ldclient/testing/integrations/persistent_feature_store_test_base.py
@@ -1,13 +1,14 @@
 from abc import abstractmethod, abstractproperty
+
 import pytest
 
 from ldclient.feature_store import CacheConfig
 from ldclient.interfaces import FeatureStore
-from ldclient.versioned_data_kind import FEATURES
-
-from ldclient.testing.feature_store_test_base import FeatureStoreTestBase, FeatureStoreTester, StoreTestScope
+from ldclient.testing.feature_store_test_base import (FeatureStoreTestBase,
+                                                      FeatureStoreTester,
+                                                      StoreTestScope)
 from ldclient.testing.test_util import skip_database_tests
-
+from ldclient.versioned_data_kind import FEATURES
 
 # The standard test suite to be run against all persistent feature store implementations. See
 # ldclient.testing.feature_store_test_base for the basic model being used here. For each database integration,

--- a/ldclient/testing/integrations/test_consul.py
+++ b/ldclient/testing/integrations/test_consul.py
@@ -38,6 +38,7 @@ class ConsulFeatureStoreTester(PersistentFeatureStoreTester):
         for key in (keys or []):
             client.kv.delete(key)
 
+
 class TestConsulFeatureStore(PersistentFeatureStoreTestBase):
     @property
     def tester_class(self):

--- a/ldclient/testing/integrations/test_consul.py
+++ b/ldclient/testing/integrations/test_consul.py
@@ -1,8 +1,8 @@
-from ldclient.integrations import Consul
+import pytest
 
+from ldclient.integrations import Consul
 from ldclient.testing.integrations.persistent_feature_store_test_base import *
 from ldclient.testing.test_util import skip_database_tests
-import pytest
 
 have_consul = False
 try:

--- a/ldclient/testing/integrations/test_consul.py
+++ b/ldclient/testing/integrations/test_consul.py
@@ -7,6 +7,7 @@ import pytest
 have_consul = False
 try:
     import consul
+
     have_consul = True
 except ImportError:
     pass
@@ -35,7 +36,7 @@ class ConsulFeatureStoreTester(PersistentFeatureStoreTester):
     def clear_data(self, prefix):
         client = consul.Consul()
         index, keys = client.kv.get((prefix or Consul.DEFAULT_PREFIX) + "/", recurse=True, keys=True)
-        for key in (keys or []):
+        for key in keys or []:
             client.kv.delete(key)
 
 

--- a/ldclient/testing/integrations/test_dynamodb.py
+++ b/ldclient/testing/integrations/test_dynamodb.py
@@ -12,6 +12,7 @@ import time
 have_dynamodb = False
 try:
     import boto3
+
     have_dynamodb = True
 except ImportError:
     pass
@@ -21,8 +22,7 @@ pytestmark = pytest.mark.skipif(not have_dynamodb, reason="skipping DynamoDB tes
 
 @pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
 def dynamodb_defaults_to_available():
-    dynamodb = DynamoDB.new_feature_store(DynamoDBTestHelper.table_name,
-        prefix=prefix, caching=caching, dynamodb_opts=DynamoDBTestHelper.options)
+    dynamodb = DynamoDB.new_feature_store(DynamoDBTestHelper.table_name, prefix=prefix, caching=caching, dynamodb_opts=DynamoDBTestHelper.options)
     assert dynamodb.is_monitoring_enabled() is True
     assert dynamodb.is_available() is True
 
@@ -31,8 +31,7 @@ def dynamodb_defaults_to_available():
 def dynamodb_detects_nonexistent_store():
     options = DynamoDBTestHelper.options
     options['endpoint_url'] = 'http://i-mean-what-are-the-odds'
-    dynamodb = DynamoDB.new_feature_store(DynamoDBTestHelper.table_name,
-        prefix=prefix, caching=caching, dynamodb_opts=options)
+    dynamodb = DynamoDB.new_feature_store(DynamoDBTestHelper.table_name, prefix=prefix, caching=caching, dynamodb_opts=options)
     assert dynamodb.is_monitoring_enabled() is True
     assert dynamodb.is_available() is False
 
@@ -40,12 +39,7 @@ def dynamodb_detects_nonexistent_store():
 class DynamoDBTestHelper:
     table_name = 'LD_DYNAMODB_TEST_TABLE'
     table_created = False
-    options = {
-        'aws_access_key_id': 'key', # not used by local DynamoDB, but still required
-        'aws_secret_access_key': 'secret',
-        'endpoint_url': 'http://localhost:8000',
-        'region_name': 'us-east-1'
-    }
+    options = {'aws_access_key_id': 'key', 'aws_secret_access_key': 'secret', 'endpoint_url': 'http://localhost:8000', 'region_name': 'us-east-1'}  # not used by local DynamoDB, but still required
 
     @staticmethod
     def make_client():
@@ -58,14 +52,11 @@ class DynamoDBTestHelper:
             'TableName': DynamoDBTestHelper.table_name,
             'ConsistentRead': True,
             'ProjectionExpression': '#namespace, #key',
-            'ExpressionAttributeNames': {
-                '#namespace': _DynamoDBFeatureStoreCore.PARTITION_KEY,
-                '#key': _DynamoDBFeatureStoreCore.SORT_KEY
-            }
+            'ExpressionAttributeNames': {'#namespace': _DynamoDBFeatureStoreCore.PARTITION_KEY, '#key': _DynamoDBFeatureStoreCore.SORT_KEY},
         }
         for resp in client.get_paginator('scan').paginate(**req):
             for item in resp['Items']:
-                delete_requests.append({ 'DeleteRequest': { 'Key': item } })
+                delete_requests.append({'DeleteRequest': {'Key': item}})
         _DynamoDBHelpers.batch_write_requests(client, DynamoDBTestHelper.table_name, delete_requests)
 
     @staticmethod
@@ -86,25 +77,10 @@ class DynamoDBTestHelper:
                     'AttributeName': _DynamoDBFeatureStoreCore.PARTITION_KEY,
                     'KeyType': 'HASH',
                 },
-                {
-                    'AttributeName': _DynamoDBFeatureStoreCore.SORT_KEY,
-                    'KeyType': 'RANGE'
-                }
+                {'AttributeName': _DynamoDBFeatureStoreCore.SORT_KEY, 'KeyType': 'RANGE'},
             ],
-            'AttributeDefinitions': [
-                {
-                    'AttributeName': _DynamoDBFeatureStoreCore.PARTITION_KEY,
-                    'AttributeType': 'S'
-                },
-                {
-                    'AttributeName': _DynamoDBFeatureStoreCore.SORT_KEY,
-                    'AttributeType': 'S'
-                }
-            ],
-            'ProvisionedThroughput': {
-                'ReadCapacityUnits': 1,
-                'WriteCapacityUnits': 1
-            }
+            'AttributeDefinitions': [{'AttributeName': _DynamoDBFeatureStoreCore.PARTITION_KEY, 'AttributeType': 'S'}, {'AttributeName': _DynamoDBFeatureStoreCore.SORT_KEY, 'AttributeType': 'S'}],
+            'ProvisionedThroughput': {'ReadCapacityUnits': 1, 'WriteCapacityUnits': 1},
         }
         client.create_table(**req)
         while True:
@@ -121,8 +97,7 @@ class DynamoDBFeatureStoreTester(PersistentFeatureStoreTester):
         DynamoDBTestHelper.ensure_table_created()
 
     def create_persistent_feature_store(self, prefix, caching) -> FeatureStore:
-        return DynamoDB.new_feature_store(DynamoDBTestHelper.table_name,
-            prefix=prefix, caching=caching, dynamodb_opts=DynamoDBTestHelper.options)
+        return DynamoDB.new_feature_store(DynamoDBTestHelper.table_name, prefix=prefix, caching=caching, dynamodb_opts=DynamoDBTestHelper.options)
 
     def clear_data(self, prefix):
         DynamoDBTestHelper.clear_data_for_prefix(prefix)
@@ -134,8 +109,7 @@ class DynamoDBBigSegmentTester(BigSegmentStoreTester):
         DynamoDBTestHelper.ensure_table_created()
 
     def create_big_segment_store(self, prefix) -> BigSegmentStore:
-        return DynamoDB.new_big_segment_store(DynamoDBTestHelper.table_name,
-            prefix=prefix, dynamodb_opts=DynamoDBTestHelper.options)
+        return DynamoDB.new_big_segment_store(DynamoDBTestHelper.table_name, prefix=prefix, dynamodb_opts=DynamoDBTestHelper.options)
 
     def clear_data(self, prefix):
         DynamoDBTestHelper.clear_data_for_prefix(prefix)
@@ -147,31 +121,23 @@ class DynamoDBBigSegmentTester(BigSegmentStoreTester):
         client.put_item(
             TableName=DynamoDBTestHelper.table_name,
             Item={
-                _DynamoDBBigSegmentStore.PARTITION_KEY: { "S": key },
-                _DynamoDBBigSegmentStore.SORT_KEY: { "S": key },
-                _DynamoDBBigSegmentStore.ATTR_SYNC_TIME: {
-                    "N": "" if metadata.last_up_to_date is None else str(metadata.last_up_to_date)
-                }
-            }
+                _DynamoDBBigSegmentStore.PARTITION_KEY: {"S": key},
+                _DynamoDBBigSegmentStore.SORT_KEY: {"S": key},
+                _DynamoDBBigSegmentStore.ATTR_SYNC_TIME: {"N": "" if metadata.last_up_to_date is None else str(metadata.last_up_to_date)},
+            },
         )
 
     def set_segments(self, prefix: str, user_hash: str, includes: List[str], excludes: List[str]):
         client = DynamoDBTestHelper.make_client()
         actual_prefix = prefix + ":" if prefix else ""
-        sets = {
-            _DynamoDBBigSegmentStore.ATTR_INCLUDED: includes,
-            _DynamoDBBigSegmentStore.ATTR_EXCLUDED: excludes
-        }
+        sets = {_DynamoDBBigSegmentStore.ATTR_INCLUDED: includes, _DynamoDBBigSegmentStore.ATTR_EXCLUDED: excludes}
         for attr_name, values in sets.items():
             if len(values) > 0:
                 client.update_item(
                     TableName=DynamoDBTestHelper.table_name,
-                    Key={
-                        _DynamoDBBigSegmentStore.PARTITION_KEY: { "S": actual_prefix + _DynamoDBBigSegmentStore.KEY_USER_DATA },
-                        _DynamoDBBigSegmentStore.SORT_KEY: { "S": user_hash }
-                    },
-                    UpdateExpression= "ADD %s :value" % attr_name,
-                    ExpressionAttributeValues={ ":value": { "SS": values } }
+                    Key={_DynamoDBBigSegmentStore.PARTITION_KEY: {"S": actual_prefix + _DynamoDBBigSegmentStore.KEY_USER_DATA}, _DynamoDBBigSegmentStore.SORT_KEY: {"S": user_hash}},
+                    UpdateExpression="ADD %s :value" % attr_name,
+                    ExpressionAttributeValues={":value": {"SS": values}},
                 )
 
 

--- a/ldclient/testing/integrations/test_dynamodb.py
+++ b/ldclient/testing/integrations/test_dynamodb.py
@@ -1,13 +1,14 @@
-from ldclient.impl.integrations.dynamodb.dynamodb_big_segment_store import _DynamoDBBigSegmentStore
-from ldclient.impl.integrations.dynamodb.dynamodb_feature_store import _DynamoDBFeatureStoreCore, _DynamoDBHelpers
+import time
+
+from ldclient.impl.integrations.dynamodb.dynamodb_big_segment_store import \
+    _DynamoDBBigSegmentStore
+from ldclient.impl.integrations.dynamodb.dynamodb_feature_store import (
+    _DynamoDBFeatureStoreCore, _DynamoDBHelpers)
 from ldclient.integrations import DynamoDB
 from ldclient.interfaces import UpdateProcessor
-
 from ldclient.testing.integrations.big_segment_store_test_base import *
 from ldclient.testing.integrations.persistent_feature_store_test_base import *
 from ldclient.testing.test_util import skip_database_tests
-
-import time
 
 have_dynamodb = False
 try:

--- a/ldclient/testing/integrations/test_redis.py
+++ b/ldclient/testing/integrations/test_redis.py
@@ -1,13 +1,14 @@
-from ldclient.impl.integrations.redis.redis_big_segment_store import _RedisBigSegmentStore
-from ldclient.integrations import Redis
-from ldclient.versioned_data_kind import FEATURES
+import json
 
+import pytest
+
+from ldclient.impl.integrations.redis.redis_big_segment_store import \
+    _RedisBigSegmentStore
+from ldclient.integrations import Redis
 from ldclient.testing.integrations.big_segment_store_test_base import *
 from ldclient.testing.integrations.persistent_feature_store_test_base import *
 from ldclient.testing.test_util import skip_database_tests
-
-import pytest
-import json
+from ldclient.versioned_data_kind import FEATURES
 
 have_redis = False
 try:

--- a/ldclient/testing/integrations/test_redis.py
+++ b/ldclient/testing/integrations/test_redis.py
@@ -12,6 +12,7 @@ import json
 have_redis = False
 try:
     import redis
+
     have_redis = True
 except ImportError:
     pass
@@ -61,8 +62,7 @@ class RedisBigSegmentStoreTester(BigSegmentStoreTester):
 
     def set_metadata(self, prefix: str, metadata: BigSegmentStoreMetadata):
         r = RedisTestHelper.make_client()
-        r.set((prefix or Redis.DEFAULT_PREFIX) + _RedisBigSegmentStore.KEY_LAST_UP_TO_DATE,
-            "" if metadata.last_up_to_date is None else str(metadata.last_up_to_date))
+        r.set((prefix or Redis.DEFAULT_PREFIX) + _RedisBigSegmentStore.KEY_LAST_UP_TO_DATE, "" if metadata.last_up_to_date is None else str(metadata.last_up_to_date))
 
     def set_segments(self, prefix: str, user_hash: str, includes: List[str], excludes: List[str]):
         r = RedisTestHelper.make_client()
@@ -81,16 +81,18 @@ class TestRedisFeatureStore(PersistentFeatureStoreTestBase):
     def test_upsert_race_condition_against_external_client_with_higher_version(self):
         other_client = RedisTestHelper.make_client()
         store = Redis.new_feature_store()
-        store.init({ FEATURES: {} })
+        store.init({FEATURES: {}})
 
         other_version = {u'key': u'flagkey', u'version': 2}
+
         def hook(base_key, key):
             if other_version['version'] <= 4:
                 other_client.hset(base_key, key, json.dumps(other_version))
                 other_version['version'] = other_version['version'] + 1
+
         store._core.test_update_hook = hook
 
-        feature = { u'key': 'flagkey', u'version': 1 }
+        feature = {u'key': 'flagkey', u'version': 1}
 
         store.upsert(FEATURES, feature)
         result = store.get(FEATURES, 'flagkey', lambda x: x)
@@ -99,16 +101,18 @@ class TestRedisFeatureStore(PersistentFeatureStoreTestBase):
     def test_upsert_race_condition_against_external_client_with_lower_version(self):
         other_client = RedisTestHelper.make_client()
         store = Redis.new_feature_store()
-        store.init({ FEATURES: {} })
+        store.init({FEATURES: {}})
 
         other_version = {u'key': u'flagkey', u'version': 2}
+
         def hook(base_key, key):
             if other_version['version'] <= 4:
                 other_client.hset(base_key, key, json.dumps(other_version))
                 other_version['version'] = other_version['version'] + 1
+
         store._core.test_update_hook = hook
 
-        feature = { u'key': 'flagkey', u'version': 5 }
+        feature = {u'key': 'flagkey', u'version': 5}
 
         store.upsert(FEATURES, feature)
         result = store.get(FEATURES, 'flagkey', lambda x: x)

--- a/ldclient/testing/integrations/test_test_data_source.py
+++ b/ldclient/testing/integrations/test_test_data_source.py
@@ -292,6 +292,7 @@ def test_can_retrieve_flag_from_store():
 
     client.close()
 
+
 def test_updates_to_flags_are_reflected_in_store():
     td = TestData.data_source()
 
@@ -305,6 +306,7 @@ def test_updates_to_flags_are_reflected_in_store():
 
     client.close()
 
+
 def test_updates_after_client_close_have_no_affect():
     td = TestData.data_source()
 
@@ -317,6 +319,7 @@ def test_updates_after_client_close_have_no_affect():
     td.update(td.flag('some-flag'))
 
     assert store.get(FEATURES, 'some-flag') == None
+
 
 def test_can_handle_multiple_clients():
     td = TestData.data_source()
@@ -379,6 +382,7 @@ def test_flag_evaluation_with_client():
     assert eval2.value == False
     assert eval2.variation_index == 1
     assert eval2.reason['kind'] == 'FALLTHROUGH'
+
 
 def test_flag_can_evaluate_all_flags():
     td = TestData.data_source()

--- a/ldclient/testing/integrations/test_test_data_source.py
+++ b/ldclient/testing/integrations/test_test_data_source.py
@@ -1,13 +1,12 @@
-import pytest
 from typing import Callable
 
-from ldclient.client import LDClient, Context
+import pytest
+
+from ldclient.client import Context, LDClient
 from ldclient.config import Config
 from ldclient.feature_store import InMemoryFeatureStore
+from ldclient.integrations.test_data import FlagBuilder, TestData
 from ldclient.versioned_data_kind import FEATURES
-
-from ldclient.integrations.test_data import TestData, FlagBuilder
-
 
 # Test Data + Data Source
 

--- a/ldclient/testing/integrations/test_test_data_source.py
+++ b/ldclient/testing/integrations/test_test_data_source.py
@@ -11,11 +11,12 @@ from ldclient.integrations.test_data import TestData, FlagBuilder
 
 ## Test Data + Data Source
 
+
 def test_makes_valid_datasource():
     td = TestData.data_source()
     store = InMemoryFeatureStore()
 
-    client = LDClient(config=Config('SDK_KEY', update_processor_class = td, send_events = False, offline = True, feature_store = store))
+    client = LDClient(config=Config('SDK_KEY', update_processor_class=td, send_events=False, offline=True, feature_store=store))
 
     assert store.all(FEATURES, lambda x: x) == {}
 
@@ -32,7 +33,7 @@ def verify_flag_builder(desc: str, expected_props: dict, builder_actions: Callab
         'salt': '',
         'variations': [True, False],
         'offVariation': 1,
-        'fallthrough': {'variation': 0}
+        'fallthrough': {'variation': 0},
     }
     all_expected_props.update(expected_props)
 
@@ -42,240 +43,143 @@ def verify_flag_builder(desc: str, expected_props: dict, builder_actions: Callab
     assert built_flag == all_expected_props, "did not get expected flag properties for '%s' test" % desc
 
 
-@pytest.mark.parametrize('expected_props,builder_actions', [
-    pytest.param(
-        {},
-        lambda f: f,
-        id='defaults'
-    ),
-    pytest.param(
-        {},
-        lambda f: f.boolean_flag(),
-        id='changing default flag to boolean flag has no effect'
-    ),
-    pytest.param(
-        {},
-        lambda f: f.variations('a', 'b').boolean_flag(),
-        id='non-boolean flag can be changed to boolean flag',
-    ),
-    pytest.param(
-        {'on': False},
-        lambda f: f.on(False),
-        id='flag can be turned off'
-    ),
-    pytest.param(
-        {},
-        lambda f: f.on(False).on(True),
-        id='flag can be turned on',
-    ),
-    pytest.param(
-        {'fallthrough': {'variation': 1}},
-        lambda f: f.variation_for_all(False),
-        id='set false variation for all'
-    ),
-    pytest.param(
-        {'fallthrough': {'variation': 0}},
-        lambda f: f.variation_for_all(True),
-        id='set true variation for all'
-    ),
-    pytest.param(
-        {'variations': ['a', 'b', 'c'], 'fallthrough': {'variation': 2}},
-        lambda f: f.variations('a', 'b', 'c').variation_for_all(2),
-        id='set variation index for all'
-    ),
-    pytest.param(
-        {'offVariation': 0},
-        lambda f: f.off_variation(True),
-        id='set off variation boolean'
-    ),
-    pytest.param(
-        {'variations': ['a', 'b', 'c'], 'offVariation': 2},
-        lambda f: f.variations('a', 'b', 'c').off_variation(2),
-        id='set off variation index'
-    ),
-    pytest.param(
-        {
-            'targets': [
-                {'variation': 0, 'values': ['key1', 'key2']},
-            ],
-            'contextTargets': [
-                {'contextKind': 'user', 'variation': 0, 'values': []},
-                {'contextKind': 'kind1', 'variation': 0, 'values': ['key3', 'key4']},
-                {'contextKind': 'kind1', 'variation': 1, 'values': ['key5', 'key6']},
-            ]
-        },
-        lambda f: f.variation_for_key('user', 'key1', True) \
-            .variation_for_key('user', 'key2', True) \
-            .variation_for_key('kind1', 'key3', True) \
-            .variation_for_key('kind1', 'key5', False) \
-            .variation_for_key('kind1', 'key4', True) \
+@pytest.mark.parametrize(
+    'expected_props,builder_actions',
+    [
+        pytest.param({}, lambda f: f, id='defaults'),
+        pytest.param({}, lambda f: f.boolean_flag(), id='changing default flag to boolean flag has no effect'),
+        pytest.param(
+            {},
+            lambda f: f.variations('a', 'b').boolean_flag(),
+            id='non-boolean flag can be changed to boolean flag',
+        ),
+        pytest.param({'on': False}, lambda f: f.on(False), id='flag can be turned off'),
+        pytest.param(
+            {},
+            lambda f: f.on(False).on(True),
+            id='flag can be turned on',
+        ),
+        pytest.param({'fallthrough': {'variation': 1}}, lambda f: f.variation_for_all(False), id='set false variation for all'),
+        pytest.param({'fallthrough': {'variation': 0}}, lambda f: f.variation_for_all(True), id='set true variation for all'),
+        pytest.param({'variations': ['a', 'b', 'c'], 'fallthrough': {'variation': 2}}, lambda f: f.variations('a', 'b', 'c').variation_for_all(2), id='set variation index for all'),
+        pytest.param({'offVariation': 0}, lambda f: f.off_variation(True), id='set off variation boolean'),
+        pytest.param({'variations': ['a', 'b', 'c'], 'offVariation': 2}, lambda f: f.variations('a', 'b', 'c').off_variation(2), id='set off variation index'),
+        pytest.param(
+            {
+                'targets': [
+                    {'variation': 0, 'values': ['key1', 'key2']},
+                ],
+                'contextTargets': [
+                    {'contextKind': 'user', 'variation': 0, 'values': []},
+                    {'contextKind': 'kind1', 'variation': 0, 'values': ['key3', 'key4']},
+                    {'contextKind': 'kind1', 'variation': 1, 'values': ['key5', 'key6']},
+                ],
+            },
+            lambda f: f.variation_for_key('user', 'key1', True)
+            .variation_for_key('user', 'key2', True)
+            .variation_for_key('kind1', 'key3', True)
+            .variation_for_key('kind1', 'key5', False)
+            .variation_for_key('kind1', 'key4', True)
             .variation_for_key('kind1', 'key6', False),
-        id='set context targets as boolean'
-    ),
-    pytest.param(
-        {
-            'variations': ['a', 'b'],
-            'targets': [
-                {'variation': 0, 'values': ['key1', 'key2']},
-            ],
-            'contextTargets': [
-                {'contextKind': 'user', 'variation': 0, 'values': []},
-                {'contextKind': 'kind1', 'variation': 0, 'values': ['key3', 'key4']},
-                {'contextKind': 'kind1', 'variation': 1, 'values': ['key5', 'key6']},
-            ]
-        },
-        lambda f: f.variations('a', 'b') \
-            .variation_for_key('user', 'key1', 0) \
-            .variation_for_key('user', 'key2', 0) \
-            .variation_for_key('kind1', 'key3', 0) \
-            .variation_for_key('kind1', 'key5', 1) \
-            .variation_for_key('kind1', 'key4', 0) \
+            id='set context targets as boolean',
+        ),
+        pytest.param(
+            {
+                'variations': ['a', 'b'],
+                'targets': [
+                    {'variation': 0, 'values': ['key1', 'key2']},
+                ],
+                'contextTargets': [
+                    {'contextKind': 'user', 'variation': 0, 'values': []},
+                    {'contextKind': 'kind1', 'variation': 0, 'values': ['key3', 'key4']},
+                    {'contextKind': 'kind1', 'variation': 1, 'values': ['key5', 'key6']},
+                ],
+            },
+            lambda f: f.variations('a', 'b')
+            .variation_for_key('user', 'key1', 0)
+            .variation_for_key('user', 'key2', 0)
+            .variation_for_key('kind1', 'key3', 0)
+            .variation_for_key('kind1', 'key5', 1)
+            .variation_for_key('kind1', 'key4', 0)
             .variation_for_key('kind1', 'key6', 1),
-        id='set context targets as variation index'
-    ),
-    pytest.param(
-        {
-            'contextTargets': [
-                {'contextKind': 'kind1', 'variation': 0, 'values': ['key1', 'key2']},
-                {'contextKind': 'kind1', 'variation': 1, 'values': ['key3']}
-            ]
-        },
-        lambda f: f.variation_for_key('kind1', 'key1', 0) \
-            .variation_for_key('kind1', 'key2', 1) \
-            .variation_for_key('kind1', 'key3', 1) \
-            .variation_for_key('kind1', 'key2', 0),
-        id='replace existing context target key'
-    ),
-    pytest.param(
-        {
-            'variations': ['a', 'b'],
-            'contextTargets': [
-                {'contextKind': 'kind1', 'variation': 1, 'values': ['key1']},
-            ]
-        },
-        lambda f: f.variations('a', 'b') \
-            .variation_for_key('kind1', 'key1', 1) \
-            .variation_for_key('kind1', 'key2', 3),
-        id='ignore target for nonexistent variation'
-    ),
-    pytest.param(
-        {
-            'targets': [
-                {'variation': 0, 'values': ['key1']}
-            ],
-            'contextTargets': [
-                {'contextKind': 'user', 'variation': 0, 'values': []}
-            ]
-        },
-        lambda f: f.variation_for_user('key1', True),
-        id='variation_for_user is shortcut for variation_for_key'
-    ),
-    pytest.param(
-        {},
-        lambda f: f.variation_for_key('kind1', 'key1', 0) \
-            .clear_targets(),
-        id='clear targets'
-    ),
-    pytest.param(
-        {
-            'rules': [
-                {
-                    'variation': 1,
-                    'id': 'rule0',
-                    'clauses': [
-                        {'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False}
-                    ]
-                }
-            ]
-        },
-        lambda f: f.if_match_context('kind1', 'attr1', 'a', 'b').then_return(1),
-        id='if_match_context'
-    ),
-    pytest.param(
-        {
-            'rules': [
-                {
-                    'variation': 1,
-                    'id': 'rule0',
-                    'clauses': [
-                        {'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': True}
-                    ]
-                }
-            ]
-        },
-        lambda f: f.if_not_match_context('kind1', 'attr1', 'a', 'b').then_return(1),
-        id='if_not_match_context'
-    ),
-    pytest.param(
-        {
-            'rules': [
-                {
-                    'variation': 1,
-                    'id': 'rule0',
-                    'clauses': [
-                        {'contextKind': 'user', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False}
-                    ]
-                }
-            ]
-        },
-        lambda f: f.if_match('attr1', 'a', 'b').then_return(1),
-        id='if_match is shortcut for if_match_context'
-    ),
-    pytest.param(
-        {
-            'rules': [
-                {
-                    'variation': 1,
-                    'id': 'rule0',
-                    'clauses': [
-                        {'contextKind': 'user', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': True}
-                    ]
-                }
-            ]
-        },
-        lambda f: f.if_not_match('attr1', 'a', 'b').then_return(1),
-        id='if_not_match is shortcut for if_not_match_context'
-    ),
-    pytest.param(
-        {
-            'rules': [
-                {
-                    'variation': 1,
-                    'id': 'rule0',
-                    'clauses': [
-                        {'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False},
-                        {'contextKind': 'kind1', 'attribute': 'attr2', 'op': 'in', 'values': ['c', 'd'], 'negate': False}
-                    ]
-                }
-            ]
-        },
-        lambda f: f.if_match_context('kind1', 'attr1', 'a', 'b') \
-            .and_match_context('kind1', 'attr2', 'c', 'd').then_return(1),
-        id='and_match_context'
-    ),
-    pytest.param(
-        {
-            'rules': [
-                {
-                    'variation': 1,
-                    'id': 'rule0',
-                    'clauses': [
-                        {'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False},
-                        {'contextKind': 'kind1', 'attribute': 'attr2', 'op': 'in', 'values': ['c', 'd'], 'negate': True}
-                    ]
-                }
-            ]
-        },
-        lambda f: f.if_match_context('kind1', 'attr1', 'a', 'b') \
-            .and_not_match_context('kind1', 'attr2', 'c', 'd').then_return(1),
-        id='and_not_match_context'
-    ),
-    pytest.param(
-        {},
-        lambda f: f.if_match_context('kind1', 'attr1', 'a').then_return(1).clear_rules(),
-        id='clear rules'
-    )
-])
+            id='set context targets as variation index',
+        ),
+        pytest.param(
+            {'contextTargets': [{'contextKind': 'kind1', 'variation': 0, 'values': ['key1', 'key2']}, {'contextKind': 'kind1', 'variation': 1, 'values': ['key3']}]},
+            lambda f: f.variation_for_key('kind1', 'key1', 0).variation_for_key('kind1', 'key2', 1).variation_for_key('kind1', 'key3', 1).variation_for_key('kind1', 'key2', 0),
+            id='replace existing context target key',
+        ),
+        pytest.param(
+            {
+                'variations': ['a', 'b'],
+                'contextTargets': [
+                    {'contextKind': 'kind1', 'variation': 1, 'values': ['key1']},
+                ],
+            },
+            lambda f: f.variations('a', 'b').variation_for_key('kind1', 'key1', 1).variation_for_key('kind1', 'key2', 3),
+            id='ignore target for nonexistent variation',
+        ),
+        pytest.param(
+            {'targets': [{'variation': 0, 'values': ['key1']}], 'contextTargets': [{'contextKind': 'user', 'variation': 0, 'values': []}]},
+            lambda f: f.variation_for_user('key1', True),
+            id='variation_for_user is shortcut for variation_for_key',
+        ),
+        pytest.param({}, lambda f: f.variation_for_key('kind1', 'key1', 0).clear_targets(), id='clear targets'),
+        pytest.param(
+            {'rules': [{'variation': 1, 'id': 'rule0', 'clauses': [{'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False}]}]},
+            lambda f: f.if_match_context('kind1', 'attr1', 'a', 'b').then_return(1),
+            id='if_match_context',
+        ),
+        pytest.param(
+            {'rules': [{'variation': 1, 'id': 'rule0', 'clauses': [{'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': True}]}]},
+            lambda f: f.if_not_match_context('kind1', 'attr1', 'a', 'b').then_return(1),
+            id='if_not_match_context',
+        ),
+        pytest.param(
+            {'rules': [{'variation': 1, 'id': 'rule0', 'clauses': [{'contextKind': 'user', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False}]}]},
+            lambda f: f.if_match('attr1', 'a', 'b').then_return(1),
+            id='if_match is shortcut for if_match_context',
+        ),
+        pytest.param(
+            {'rules': [{'variation': 1, 'id': 'rule0', 'clauses': [{'contextKind': 'user', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': True}]}]},
+            lambda f: f.if_not_match('attr1', 'a', 'b').then_return(1),
+            id='if_not_match is shortcut for if_not_match_context',
+        ),
+        pytest.param(
+            {
+                'rules': [
+                    {
+                        'variation': 1,
+                        'id': 'rule0',
+                        'clauses': [
+                            {'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False},
+                            {'contextKind': 'kind1', 'attribute': 'attr2', 'op': 'in', 'values': ['c', 'd'], 'negate': False},
+                        ],
+                    }
+                ]
+            },
+            lambda f: f.if_match_context('kind1', 'attr1', 'a', 'b').and_match_context('kind1', 'attr2', 'c', 'd').then_return(1),
+            id='and_match_context',
+        ),
+        pytest.param(
+            {
+                'rules': [
+                    {
+                        'variation': 1,
+                        'id': 'rule0',
+                        'clauses': [
+                            {'contextKind': 'kind1', 'attribute': 'attr1', 'op': 'in', 'values': ['a', 'b'], 'negate': False},
+                            {'contextKind': 'kind1', 'attribute': 'attr2', 'op': 'in', 'values': ['c', 'd'], 'negate': True},
+                        ],
+                    }
+                ]
+            },
+            lambda f: f.if_match_context('kind1', 'attr1', 'a', 'b').and_not_match_context('kind1', 'attr2', 'c', 'd').then_return(1),
+            id='and_not_match_context',
+        ),
+        pytest.param({}, lambda f: f.if_match_context('kind1', 'attr1', 'a').then_return(1).clear_rules(), id='clear rules'),
+    ],
+)
 def test_flag_configs_parameterized(expected_props: dict, builder_actions: Callable[[FlagBuilder], FlagBuilder]):
     verify_flag_builder('x', expected_props, builder_actions)
 
@@ -286,7 +190,7 @@ def test_can_retrieve_flag_from_store():
 
     store = InMemoryFeatureStore()
 
-    client = LDClient(config=Config('SDK_KEY', update_processor_class = td, send_events = False, offline = True, feature_store = store))
+    client = LDClient(config=Config('SDK_KEY', update_processor_class=td, send_events=False, offline=True, feature_store=store))
 
     assert store.get(FEATURES, 'some-flag') == FEATURES.decode(td.flag('some-flag')._build(1))
 
@@ -298,7 +202,7 @@ def test_updates_to_flags_are_reflected_in_store():
 
     store = InMemoryFeatureStore()
 
-    client = LDClient(config=Config('SDK_KEY', update_processor_class = td, send_events = False, offline = True, feature_store = store))
+    client = LDClient(config=Config('SDK_KEY', update_processor_class=td, send_events=False, offline=True, feature_store=store))
 
     td.update(td.flag('some-flag'))
 
@@ -312,7 +216,7 @@ def test_updates_after_client_close_have_no_affect():
 
     store = InMemoryFeatureStore()
 
-    client = LDClient(config=Config('SDK_KEY', update_processor_class = td, send_events = False, offline = True, feature_store = store))
+    client = LDClient(config=Config('SDK_KEY', update_processor_class=td, send_events=False, offline=True, feature_store=store))
 
     client.close()
 
@@ -330,10 +234,10 @@ def test_can_handle_multiple_clients():
     store = InMemoryFeatureStore()
     store2 = InMemoryFeatureStore()
 
-    config = Config('SDK_KEY', update_processor_class = td, send_events = False, offline = True, feature_store = store)
+    config = Config('SDK_KEY', update_processor_class=td, send_events=False, offline=True, feature_store=store)
     client = LDClient(config=config)
 
-    config2 = Config('SDK_KEY', update_processor_class = td, send_events = False, offline = True, feature_store = store2)
+    config2 = Config('SDK_KEY', update_processor_class=td, send_events=False, offline=True, feature_store=store2)
     client2 = LDClient(config=config2)
 
     assert store.get(FEATURES, 'flag') == FEATURES.decode(built_flag)
@@ -356,19 +260,12 @@ def test_flag_evaluation_with_client():
     td = TestData.data_source()
     store = InMemoryFeatureStore()
 
-    client = LDClient(config=Config('SDK_KEY',
-                      update_processor_class = td,
-                      send_events = False,
-                      feature_store = store))
+    client = LDClient(config=Config('SDK_KEY', update_processor_class=td, send_events=False, feature_store=store))
 
-    td.update(td.flag(key='test-flag')
-                .fallthrough_variation(False)
-                .if_match('firstName', 'Mike')
-                .and_not_match('country', 'gb')
-                .then_return(True))
+    td.update(td.flag(key='test-flag').fallthrough_variation(False).if_match('firstName', 'Mike').and_not_match('country', 'gb').then_return(True))
 
     # user1 should satisfy the rule (matching firstname, not matching country)
-    user1 = Context.from_dict({ 'kind': 'user', 'key': 'user1', 'firstName': 'Mike', 'country': 'us' })
+    user1 = Context.from_dict({'kind': 'user', 'key': 'user1', 'firstName': 'Mike', 'country': 'us'})
     eval1 = client.variation_detail('test-flag', user1, default='default')
 
     assert eval1.value == True
@@ -376,7 +273,7 @@ def test_flag_evaluation_with_client():
     assert eval1.reason['kind'] == 'RULE_MATCH'
 
     # user2 should NOT satisfy the rule (not matching firstname despite not matching country)
-    user2 = Context.from_dict({ 'kind': 'user', 'key': 'user2', 'firstName': 'Joe', 'country': 'us' })
+    user2 = Context.from_dict({'kind': 'user', 'key': 'user2', 'firstName': 'Joe', 'country': 'us'})
     eval2 = client.variation_detail('test-flag', user2, default='default')
 
     assert eval2.value == False
@@ -388,18 +285,11 @@ def test_flag_can_evaluate_all_flags():
     td = TestData.data_source()
     store = InMemoryFeatureStore()
 
-    client = LDClient(config=Config('SDK_KEY',
-                      update_processor_class = td,
-                      send_events = False,
-                      feature_store = store))
+    client = LDClient(config=Config('SDK_KEY', update_processor_class=td, send_events=False, feature_store=store))
 
-    td.update(td.flag(key='test-flag')
-                .fallthrough_variation(False)
-                .if_match('firstName', 'Mike')
-                .and_not_match('country', 'gb')
-                .then_return(True))
+    td.update(td.flag(key='test-flag').fallthrough_variation(False).if_match('firstName', 'Mike').and_not_match('country', 'gb').then_return(True))
 
-    user1 = Context.from_dict({ 'kind': 'user', 'key': 'user1', 'firstName': 'Mike', 'country': 'us' })
+    user1 = Context.from_dict({'kind': 'user', 'key': 'user1', 'firstName': 'Mike', 'country': 'us'})
     flags_state = client.all_flags_state(user1, with_reasons=True)
 
     assert flags_state.valid

--- a/ldclient/testing/integrations/test_test_data_source.py
+++ b/ldclient/testing/integrations/test_test_data_source.py
@@ -9,7 +9,7 @@ from ldclient.versioned_data_kind import FEATURES
 from ldclient.integrations.test_data import TestData, FlagBuilder
 
 
-## Test Data + Data Source
+# Test Data + Data Source
 
 
 def test_makes_valid_datasource():
@@ -222,7 +222,7 @@ def test_updates_after_client_close_have_no_affect():
 
     td.update(td.flag('some-flag'))
 
-    assert store.get(FEATURES, 'some-flag') == None
+    assert store.get(FEATURES, 'some-flag') is None
 
 
 def test_can_handle_multiple_clients():
@@ -268,7 +268,7 @@ def test_flag_evaluation_with_client():
     user1 = Context.from_dict({'kind': 'user', 'key': 'user1', 'firstName': 'Mike', 'country': 'us'})
     eval1 = client.variation_detail('test-flag', user1, default='default')
 
-    assert eval1.value == True
+    assert eval1.value is True
     assert eval1.variation_index == 0
     assert eval1.reason['kind'] == 'RULE_MATCH'
 
@@ -276,7 +276,7 @@ def test_flag_evaluation_with_client():
     user2 = Context.from_dict({'kind': 'user', 'key': 'user2', 'firstName': 'Joe', 'country': 'us'})
     eval2 = client.variation_detail('test-flag', user2, default='default')
 
-    assert eval2.value == False
+    assert eval2.value is False
     assert eval2.variation_index == 1
     assert eval2.reason['kind'] == 'FALLTHROUGH'
 
@@ -297,5 +297,5 @@ def test_flag_can_evaluate_all_flags():
     value = flags_state.get_flag_value('test-flag')
     reason = flags_state.get_flag_reason('test-flag') or {}
 
-    assert value == True
+    assert value is True
     assert reason.get('kind', None) == 'RULE_MATCH'

--- a/ldclient/testing/migrations/test_migrator.py
+++ b/ldclient/testing/migrations/test_migrator.py
@@ -21,6 +21,7 @@ def success(payload) -> Result:
 
 def raises_exception(msg) -> MigratorFn:
     """Quick helper to generate a migration fn that is going to raise an exception"""
+
     def inner(payload):
         raise Exception(msg)
 
@@ -363,7 +364,6 @@ class TestTrackingConsistency:
             # SHADOW and LIVE are the only two stages that run both origins for read.
             pytest.param(Stage.SHADOW, "value", "value", True, id="shadow matches"),
             pytest.param(Stage.LIVE, "value", "value", True, id="live matches"),
-
             pytest.param(Stage.SHADOW, "old", "new", False, id="shadow does not match"),
             pytest.param(Stage.LIVE, "old", "new", False, id="live does not match"),
         ],
@@ -388,7 +388,6 @@ class TestTrackingConsistency:
             # SHADOW and LIVE are the only two stages that run both origins for read.
             pytest.param(Stage.SHADOW, "value", "value", True, id="shadow matches"),
             pytest.param(Stage.LIVE, "value", "value", True, id="live matches"),
-
             pytest.param(Stage.SHADOW, "old", "new", False, id="shadow does not match"),
             pytest.param(Stage.LIVE, "old", "new", False, id="live does not match"),
         ],

--- a/ldclient/testing/migrations/test_migrator.py
+++ b/ldclient/testing/migrations/test_migrator.py
@@ -1,18 +1,20 @@
-import pytest
 from datetime import datetime, timedelta
-from ldclient.feature_store import InMemoryFeatureStore
-from ldclient.migrations import MigratorBuilder
+from time import sleep
+from typing import List
+
+import pytest
+
 from ldclient import Result
-from ldclient.migrations.types import Stage, Origin, MigratorFn, ExecutionOrder
-from ldclient.migrations.migrator import Migrator
-from ldclient.migrations.tracker import MigrationOpEvent
-from ldclient.versioned_data_kind import FEATURES
+from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.impl.events.types import EventInputEvaluation
 from ldclient.impl.util import timedelta_millis
+from ldclient.migrations import MigratorBuilder
+from ldclient.migrations.migrator import Migrator
+from ldclient.migrations.tracker import MigrationOpEvent
+from ldclient.migrations.types import ExecutionOrder, MigratorFn, Origin, Stage
 from ldclient.testing.builders import FlagBuilder
 from ldclient.testing.test_ldclient import make_client, user
-from typing import List
-from time import sleep
+from ldclient.versioned_data_kind import FEATURES
 
 
 def success(payload) -> Result:

--- a/ldclient/testing/migrations/test_migrator_builder.py
+++ b/ldclient/testing/migrations/test_migrator_builder.py
@@ -1,7 +1,8 @@
 import pytest
-from ldclient.client import LDClient, Config
+
 from ldclient import Result
-from ldclient.migrations import MigratorBuilder, Migrator, ExecutionOrder
+from ldclient.client import Config, LDClient
+from ldclient.migrations import ExecutionOrder, Migrator, MigratorBuilder
 
 
 def test_can_build_successfully():

--- a/ldclient/testing/migrations/test_op_tracker.py
+++ b/ldclient/testing/migrations/test_op_tracker.py
@@ -1,9 +1,13 @@
-import pytest
 from datetime import timedelta
+
+import pytest
+
 from ldclient import Context
-from ldclient.migrations import OpTracker, Stage, Operation, Origin, MigrationOpEvent
 from ldclient.evaluation import EvaluationDetail
-from ldclient.testing.builders import build_off_flag_with_value, MigrationSettingsBuilder
+from ldclient.migrations import (MigrationOpEvent, Operation, OpTracker,
+                                 Origin, Stage)
+from ldclient.testing.builders import (MigrationSettingsBuilder,
+                                       build_off_flag_with_value)
 from ldclient.testing.test_ldclient import user
 
 

--- a/ldclient/testing/migrations/test_op_tracker.py
+++ b/ldclient/testing/migrations/test_op_tracker.py
@@ -88,8 +88,7 @@ class TestBuilding:
             pytest.param(Origin.NEW, Origin.OLD, id="invoked new measured old"),
         ],
     )
-    def test_latency_invoked_mismatch(
-            self, bare_tracker: OpTracker, invoked: Origin, recorded: Origin):
+    def test_latency_invoked_mismatch(self, bare_tracker: OpTracker, invoked: Origin, recorded: Origin):
         bare_tracker.operation(Operation.WRITE)
         bare_tracker.invoked(invoked)
         bare_tracker.latency(recorded, timedelta(milliseconds=20))
@@ -105,8 +104,7 @@ class TestBuilding:
             pytest.param(Origin.NEW, Origin.OLD, id="invoked new measured old"),
         ],
     )
-    def test_error_invoked_mismatch(
-            self, bare_tracker: OpTracker, invoked: Origin, recorded: Origin):
+    def test_error_invoked_mismatch(self, bare_tracker: OpTracker, invoked: Origin, recorded: Origin):
         bare_tracker.operation(Operation.WRITE)
         bare_tracker.invoked(invoked)
         bare_tracker.error(recorded)
@@ -176,8 +174,7 @@ class TestTrackInvocations:
 
 class TestTrackConsistency:
     @pytest.mark.parametrize("consistent", [True, False])
-    def test_without_check_ratio(
-            self, tracker: OpTracker, consistent: bool):
+    def test_without_check_ratio(self, tracker: OpTracker, consistent: bool):
         tracker.consistent(lambda: consistent)
         event = tracker.build()
         assert isinstance(event, MigrationOpEvent)

--- a/ldclient/testing/mock_components.py
+++ b/ldclient/testing/mock_components.py
@@ -1,7 +1,7 @@
-from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
-
 import time
 from typing import Callable
+
+from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 
 
 class MockBigSegmentStore(BigSegmentStore):

--- a/ldclient/testing/mock_components.py
+++ b/ldclient/testing/mock_components.py
@@ -3,16 +3,17 @@ from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 import time
 from typing import Callable
 
+
 class MockBigSegmentStore(BigSegmentStore):
     def __init__(self):
         self.__get_metadata = lambda: BigSegmentStoreMetadata(time.time())
         self.__memberships = {}
         self.__membership_queries = []
         self.setup_metadata_always_up_to_date()
-    
+
     def get_metadata(self) -> BigSegmentStoreMetadata:
         return self.__get_metadata()
-    
+
     def get_membership(self, user_hash: str) -> dict:
         self.__membership_queries.append(user_hash)
         return self.__memberships.get(user_hash, None)
@@ -22,13 +23,13 @@ class MockBigSegmentStore(BigSegmentStore):
 
     def setup_metadata_always_up_to_date(self):
         self.setup_metadata(lambda: BigSegmentStoreMetadata(time.time()*1000))
-    
+
     def setup_metadata_always_stale(self):
         self.setup_metadata(lambda: BigSegmentStoreMetadata(0))
-    
+
     def setup_metadata_none(self):
         self.setup_metadata(lambda: None)
-    
+
     def setup_metadata_error(self):
         self.setup_metadata(self.__fail)
 

--- a/ldclient/testing/mock_components.py
+++ b/ldclient/testing/mock_components.py
@@ -22,7 +22,7 @@ class MockBigSegmentStore(BigSegmentStore):
         self.__get_metadata = callback
 
     def setup_metadata_always_up_to_date(self):
-        self.setup_metadata(lambda: BigSegmentStoreMetadata(time.time()*1000))
+        self.setup_metadata(lambda: BigSegmentStoreMetadata(time.time() * 1000))
 
     def setup_metadata_always_stale(self):
         self.setup_metadata(lambda: BigSegmentStoreMetadata(0))

--- a/ldclient/testing/proxy_test_util.py
+++ b/ldclient/testing/proxy_test_util.py
@@ -11,30 +11,14 @@ def do_proxy_tests(action, action_method, monkeypatch):
     # We'll test each permutation of use_env_vars, secure, and use_auth, except that if secure is
     # true then we'll only test with use_auth=false because we don't have a way to test proxy
     # authorization over HTTPS (even though we believe it works).
-    for (use_env_vars, secure, use_auth) in [
-        (False, False, False),
-        (False, False, True),
-        (False, True, False),
-        (True, False, False),
-        (True, False, True),
-        (True, True, False)
-    ]:
-        test_desc = "%s, %s, %s" % (
-            "using env vars" if use_env_vars else "using Config",
-            "secure" if secure else "insecure",
-            "with auth" if use_auth else "no auth")
+    for use_env_vars, secure, use_auth in [(False, False, False), (False, False, True), (False, True, False), (True, False, False), (True, False, True), (True, True, False)]:
+        test_desc = "%s, %s, %s" % ("using env vars" if use_env_vars else "using Config", "secure" if secure else "insecure", "with auth" if use_auth else "no auth")
         with start_server() as server:
             proxy_uri = server.uri.replace('http://', 'http://user:pass@') if use_auth else server.uri
             target_uri = 'https://not-real' if secure else 'http://not-real'
             if use_env_vars:
                 monkeypatch.setenv('https_proxy' if secure else 'http_proxy', proxy_uri)
-            config = Config(
-                sdk_key='sdk_key',
-                base_uri=target_uri,
-                events_uri=target_uri,
-                stream_uri=target_uri,
-                http=HTTPConfig(http_proxy=proxy_uri),
-                diagnostic_opt_out=True)
+            config = Config(sdk_key='sdk_key', base_uri=target_uri, events_uri=target_uri, stream_uri=target_uri, http=HTTPConfig(http_proxy=proxy_uri), diagnostic_opt_out=True)
             try:
                 action(server, config, secure)
             except Exception:

--- a/ldclient/testing/stub_util.py
+++ b/ldclient/testing/stub_util.py
@@ -11,15 +11,15 @@ def item_as_json(item):
     return item.to_json_dict() if isinstance(item, ModelEntity) else item
 
 
-def make_items_map(items = []):
+def make_items_map(items=[]):
     ret = {}
     for item in items:
         ret[item['key']] = item_as_json(item)
     return ret
 
 
-def make_put_event(flags = [], segments = []):
-    data = { "data": { "flags": make_items_map(flags), "segments": make_items_map(segments) } }
+def make_put_event(flags=[], segments=[]):
+    data = {"data": {"flags": make_items_map(flags), "segments": make_items_map(segments)}}
     return 'event:put\ndata: %s\n\n' % json.dumps(data)
 
 
@@ -29,25 +29,25 @@ def make_invalid_put_event():
 
 def make_patch_event(kind, item):
     path = '%s%s' % (kind.stream_api_path, item['key'])
-    data = { "path": path, "data": item_as_json(item) }
+    data = {"path": path, "data": item_as_json(item)}
     return 'event:patch\ndata: %s\n\n' % json.dumps(data)
 
 
 def make_delete_event(kind, key, version):
     path = '%s%s' % (kind.stream_api_path, key)
-    data = { "path": path, "version": version }
+    data = {"path": path, "version": version}
     return 'event:delete\ndata: %s\n\n' % json.dumps(data)
 
 
-def stream_content(event = None):
-    stream = ChunkedResponse({ 'Content-Type': 'text/event-stream' })
+def stream_content(event=None):
+    stream = ChunkedResponse({'Content-Type': 'text/event-stream'})
     if event:
         stream.push(event)
     return stream
 
 
-def poll_content(flags = [], segments = []):
-    data = { "flags": make_items_map(flags), "segments": make_items_map(segments) }
+def poll_content(flags=[], segments=[]):
+    data = {"flags": make_items_map(flags), "segments": make_items_map(segments)}
     return JsonResponse(data)
 
 

--- a/ldclient/testing/stub_util.py
+++ b/ldclient/testing/stub_util.py
@@ -1,9 +1,9 @@
-from email.utils import formatdate
 import json
+from email.utils import formatdate
 
 from ldclient.impl.model import ModelEntity
-from ldclient.interfaces import EventProcessor, FeatureRequester, FeatureStore, UpdateProcessor
-
+from ldclient.interfaces import (EventProcessor, FeatureRequester,
+                                 FeatureStore, UpdateProcessor)
 from ldclient.testing.http_util import ChunkedResponse, JsonResponse
 
 

--- a/ldclient/testing/stub_util.py
+++ b/ldclient/testing/stub_util.py
@@ -10,28 +10,34 @@ from ldclient.testing.http_util import ChunkedResponse, JsonResponse
 def item_as_json(item):
     return item.to_json_dict() if isinstance(item, ModelEntity) else item
 
+
 def make_items_map(items = []):
     ret = {}
     for item in items:
         ret[item['key']] = item_as_json(item)
     return ret
 
+
 def make_put_event(flags = [], segments = []):
     data = { "data": { "flags": make_items_map(flags), "segments": make_items_map(segments) } }
     return 'event:put\ndata: %s\n\n' % json.dumps(data)
 
+
 def make_invalid_put_event():
     return 'event:put\ndata: {"data": {\n\n'
+
 
 def make_patch_event(kind, item):
     path = '%s%s' % (kind.stream_api_path, item['key'])
     data = { "path": path, "data": item_as_json(item) }
     return 'event:patch\ndata: %s\n\n' % json.dumps(data)
 
+
 def make_delete_event(kind, key, version):
     path = '%s%s' % (kind.stream_api_path, key)
     data = { "path": path, "version": version }
     return 'event:delete\ndata: %s\n\n' % json.dumps(data)
+
 
 def stream_content(event = None):
     stream = ChunkedResponse({ 'Content-Type': 'text/event-stream' })
@@ -39,9 +45,11 @@ def stream_content(event = None):
         stream.push(event)
     return stream
 
+
 def poll_content(flags = [], segments = []):
     data = { "flags": make_items_map(flags), "segments": make_items_map(segments) }
     return JsonResponse(data)
+
 
 class MockEventProcessor(EventProcessor):
     def __init__(self, *_):
@@ -62,6 +70,7 @@ class MockEventProcessor(EventProcessor):
 
     def flush(self):
         pass
+
 
 class MockFeatureRequester(FeatureRequester):
     def __init__(self):
@@ -145,6 +154,7 @@ class MockHttp:
     def reset(self):
         self._recorded_requests = []
 
+
 class MockUpdateProcessor(UpdateProcessor):
     def __init__(self, config, store, ready):
         ready.set()
@@ -160,6 +170,7 @@ class MockUpdateProcessor(UpdateProcessor):
 
     def initialized(self):
         return True
+
 
 class CapturingFeatureStore(FeatureStore):
     def init(self, all_data):

--- a/ldclient/testing/sync_util.py
+++ b/ldclient/testing/sync_util.py
@@ -9,7 +9,6 @@ def wait_until(condition, timeout=5):
         if result:
             return result
         elif time.time() > end_time:
-            raise Exception("Timeout waiting for {0}".format(
-                condition.__name__))  # pragma: no cover
+            raise Exception("Timeout waiting for {0}".format(condition.__name__))  # pragma: no cover
         else:
-            time.sleep(.1)
+            time.sleep(0.1)

--- a/ldclient/testing/test_config.py
+++ b/ldclient/testing/test_config.py
@@ -15,21 +15,26 @@ def test_copy_config():
     assert new_config.sdk_key is new_sdk_key
     assert new_config.stream is False
 
+
 def test_can_set_valid_poll_interval():
     config = Config(sdk_key = "SDK_KEY", poll_interval = 31)
     assert config.poll_interval == 31
+
 
 def test_minimum_poll_interval_is_enforced():
     config = Config(sdk_key = "SDK_KEY", poll_interval = 29)
     assert config.poll_interval == 30
 
+
 def test_can_set_valid_diagnostic_interval():
     config = Config(sdk_key = "SDK_KEY", diagnostic_recording_interval=61)
     assert config.diagnostic_recording_interval == 61
 
+
 def test_minimum_diagnostic_interval_is_enforced():
     config = Config(sdk_key = "SDK_KEY", diagnostic_recording_interval=59)
     assert config.diagnostic_recording_interval == 60
+
 
 def test_trims_trailing_slashes_on_uris():
     config = Config(
@@ -42,20 +47,24 @@ def test_trims_trailing_slashes_on_uris():
     assert config.events_uri == "https://docs.launchdarkly.com/bulk"
     assert config.stream_base_uri == "https://blog.launchdarkly.com"
 
+
 def application_can_be_set_and_read():
     application = {"id": "my-id", "version": "abcdef"}
     config = Config(sdk_key = "SDK_KEY", application = application)
     assert config.application == {"id": "my-id", "version": "abcdef"}
+
 
 def application_can_handle_non_string_values():
     application = {"id": 1, "version": 2}
     config = Config(sdk_key = "SDK_KEY", application = application)
     assert config.application == {"id": "1", "version": "2"}
 
+
 def application_will_ignore_invalid_keys():
     application = {"invalid": 1, "key": 2}
     config = Config(sdk_key = "SDK_KEY", application = application)
     assert config.application == {"id": "", "version": ""}
+
 
 @pytest.fixture(params = [
     " ",
@@ -65,6 +74,7 @@ def application_will_ignore_invalid_keys():
 ])
 def invalid_application_tags(request):
     return request.param
+
 
 def test_application_will_drop_invalid_values(invalid_application_tags):
     application = {"id": invalid_application_tags, "version": invalid_application_tags}

--- a/ldclient/testing/test_config.py
+++ b/ldclient/testing/test_config.py
@@ -1,5 +1,6 @@
-from ldclient.config import Config
 import pytest
+
+from ldclient.config import Config
 
 
 def test_copy_config():

--- a/ldclient/testing/test_config.py
+++ b/ldclient/testing/test_config.py
@@ -17,31 +17,27 @@ def test_copy_config():
 
 
 def test_can_set_valid_poll_interval():
-    config = Config(sdk_key = "SDK_KEY", poll_interval = 31)
+    config = Config(sdk_key="SDK_KEY", poll_interval=31)
     assert config.poll_interval == 31
 
 
 def test_minimum_poll_interval_is_enforced():
-    config = Config(sdk_key = "SDK_KEY", poll_interval = 29)
+    config = Config(sdk_key="SDK_KEY", poll_interval=29)
     assert config.poll_interval == 30
 
 
 def test_can_set_valid_diagnostic_interval():
-    config = Config(sdk_key = "SDK_KEY", diagnostic_recording_interval=61)
+    config = Config(sdk_key="SDK_KEY", diagnostic_recording_interval=61)
     assert config.diagnostic_recording_interval == 61
 
 
 def test_minimum_diagnostic_interval_is_enforced():
-    config = Config(sdk_key = "SDK_KEY", diagnostic_recording_interval=59)
+    config = Config(sdk_key="SDK_KEY", diagnostic_recording_interval=59)
     assert config.diagnostic_recording_interval == 60
 
 
 def test_trims_trailing_slashes_on_uris():
-    config = Config(
-        sdk_key = "SDK_KEY",
-        base_uri = "https://launchdarkly.com/",
-        events_uri = "https://docs.launchdarkly.com/",
-        stream_uri = "https://blog.launchdarkly.com/")
+    config = Config(sdk_key="SDK_KEY", base_uri="https://launchdarkly.com/", events_uri="https://docs.launchdarkly.com/", stream_uri="https://blog.launchdarkly.com/")
 
     assert config.base_uri == "https://launchdarkly.com"
     assert config.events_uri == "https://docs.launchdarkly.com/bulk"
@@ -50,33 +46,28 @@ def test_trims_trailing_slashes_on_uris():
 
 def application_can_be_set_and_read():
     application = {"id": "my-id", "version": "abcdef"}
-    config = Config(sdk_key = "SDK_KEY", application = application)
+    config = Config(sdk_key="SDK_KEY", application=application)
     assert config.application == {"id": "my-id", "version": "abcdef"}
 
 
 def application_can_handle_non_string_values():
     application = {"id": 1, "version": 2}
-    config = Config(sdk_key = "SDK_KEY", application = application)
+    config = Config(sdk_key="SDK_KEY", application=application)
     assert config.application == {"id": "1", "version": "2"}
 
 
 def application_will_ignore_invalid_keys():
     application = {"invalid": 1, "key": 2}
-    config = Config(sdk_key = "SDK_KEY", application = application)
+    config = Config(sdk_key="SDK_KEY", application=application)
     assert config.application == {"id": "", "version": ""}
 
 
-@pytest.fixture(params = [
-    " ",
-    "@",
-    ":",
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-a"
-])
+@pytest.fixture(params=[" ", "@", ":", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-a"])
 def invalid_application_tags(request):
     return request.param
 
 
 def test_application_will_drop_invalid_values(invalid_application_tags):
     application = {"id": invalid_application_tags, "version": invalid_application_tags}
-    config = Config(sdk_key = "SDK_KEY", application = application)
+    config = Config(sdk_key="SDK_KEY", application=application)
     assert config.application == {"id": "", "version": ""}

--- a/ldclient/testing/test_context.py
+++ b/ldclient/testing/test_context.py
@@ -8,6 +8,7 @@ def assert_context_valid(c):
     assert c.valid is True
     assert c.error is None
 
+
 def assert_context_invalid(c):
     assert c.valid is False
     assert c.error is not None

--- a/ldclient/testing/test_context.py
+++ b/ldclient/testing/test_context.py
@@ -141,64 +141,53 @@ class TestContext:
         def _assert_contexts_from_factory_equal(fn):
             c1, c2 = fn(), fn()
             assert c1 == c2
+
         _assert_contexts_from_factory_equal(lambda: Context.create('a'))
         _assert_contexts_from_factory_equal(lambda: Context.create('a', 'kind1'))
         _assert_contexts_from_factory_equal(lambda: Context.builder('a').name('b').build())
         _assert_contexts_from_factory_equal(lambda: Context.builder('a').anonymous(True).build())
         _assert_contexts_from_factory_equal(lambda: Context.builder('a').set('b', True).set('c', 3).build())
-        assert Context.builder('a').set('b', True).set('c', 3).build() == \
-            Context.builder('a').set('c', 3).set('b', True).build()  # order doesn't matter
+        assert Context.builder('a').set('b', True).set('c', 3).build() == Context.builder('a').set('c', 3).set('b', True).build()  # order doesn't matter
 
         assert Context.create('a', 'kind1') != Context.create('b', 'kind1')
         assert Context.create('a', 'kind1') != Context.create('a', 'kind2')
         assert Context.builder('a').name('b').build() != Context.builder('a').name('c').build()
         assert Context.builder('a').anonymous(True).build() != Context.builder('a').build()
         assert Context.builder('a').set('b', True).build() != Context.builder('a').set('b', False).build()
-        assert Context.builder('a').set('b', True).build() != \
-            Context.builder('a').set('b', True).set('c', False).build()
+        assert Context.builder('a').set('b', True).build() != Context.builder('a').set('b', True).set('c', False).build()
 
-        _assert_contexts_from_factory_equal(lambda: \
-            Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')))
-        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')) == \
-            Context.create_multi(Context.create('b', 'kind2'), Context.create('a', 'kind1'))  # order doesn't matter
+        _assert_contexts_from_factory_equal(lambda: Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')))
+        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')) == Context.create_multi(
+            Context.create('b', 'kind2'), Context.create('a', 'kind1')
+        )  # order doesn't matter
 
-        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')) != \
-            Context.create_multi(Context.create('a', 'kind1'), Context.create('c', 'kind2'))
-        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2'), Context.create('c', 'kind3')) != \
-            Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2'))
-        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')) != \
-            Context.create('a', 'kind1')
+        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')) != Context.create_multi(Context.create('a', 'kind1'), Context.create('c', 'kind2'))
+        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2'), Context.create('c', 'kind3')) != Context.create_multi(
+            Context.create('a', 'kind1'), Context.create('b', 'kind2')
+        )
+        assert Context.create_multi(Context.create('a', 'kind1'), Context.create('b', 'kind2')) != Context.create('a', 'kind1')
 
         _assert_contexts_from_factory_equal(lambda: Context.create('invalid', 'kind'))
         assert Context.create('invalid', 'kind') != Context.create_multi()  # different errors
 
     def test_json_encoding(self):
         assert Context.create('a', 'kind1').to_dict() == {'kind': 'kind1', 'key': 'a'}
-        assert Context.builder('a').kind('kind1').name('b').build().to_dict() == \
-            {'kind': 'kind1', 'key': 'a', 'name': 'b'}
-        assert Context.builder('a').kind('kind1').anonymous(True).build().to_dict() == \
-            {'kind': 'kind1', 'key': 'a', 'anonymous': True}
-        assert Context.builder('a').kind('kind1').set('b', True).set('c', 3).build().to_dict() == \
-            {'kind': 'kind1', 'key': 'a', 'b': True, 'c': 3}
-        assert Context.builder('a').kind('kind1').private('b').build().to_dict() == \
-            {'kind': 'kind1', 'key': 'a', '_meta': {'privateAttributes': ['b']}}
+        assert Context.builder('a').kind('kind1').name('b').build().to_dict() == {'kind': 'kind1', 'key': 'a', 'name': 'b'}
+        assert Context.builder('a').kind('kind1').anonymous(True).build().to_dict() == {'kind': 'kind1', 'key': 'a', 'anonymous': True}
+        assert Context.builder('a').kind('kind1').set('b', True).set('c', 3).build().to_dict() == {'kind': 'kind1', 'key': 'a', 'b': True, 'c': 3}
+        assert Context.builder('a').kind('kind1').private('b').build().to_dict() == {'kind': 'kind1', 'key': 'a', '_meta': {'privateAttributes': ['b']}}
 
-        assert Context.create_multi(Context.create('key1', 'kind1'), Context.create('key2', 'kind2')).to_dict() == \
-            {'kind': 'multi', 'kind1': {'key': 'key1'}, 'kind2': {'key': 'key2'}}
+        assert Context.create_multi(Context.create('key1', 'kind1'), Context.create('key2', 'kind2')).to_dict() == {'kind': 'multi', 'kind1': {'key': 'key1'}, 'kind2': {'key': 'key2'}}
 
         assert json.loads(Context.create('a', 'kind1').to_json_string()) == {'kind': 'kind1', 'key': 'a'}
 
     def test_json_decoding(self):
         assert Context.from_dict({'kind': 'kind1', 'key': 'key1'}) == Context.create('key1', 'kind1')
-        assert Context.from_dict({'kind': 'kind1', 'key': 'key1', 'name': 'a'}) == \
-            Context.builder('key1').kind('kind1').name('a').build()
-        assert Context.from_dict({'kind': 'kind1', 'key': 'key1', 'anonymous': True}) == \
-            Context.builder('key1').kind('kind1').anonymous(True).build()
-        assert Context.from_dict({'kind': 'kind1', 'key': 'key1', '_meta': {'privateAttributes': ['b']}}) == \
-            Context.builder('key1').kind('kind1').private('b').build()
+        assert Context.from_dict({'kind': 'kind1', 'key': 'key1', 'name': 'a'}) == Context.builder('key1').kind('kind1').name('a').build()
+        assert Context.from_dict({'kind': 'kind1', 'key': 'key1', 'anonymous': True}) == Context.builder('key1').kind('kind1').anonymous(True).build()
+        assert Context.from_dict({'kind': 'kind1', 'key': 'key1', '_meta': {'privateAttributes': ['b']}}) == Context.builder('key1').kind('kind1').private('b').build()
 
-        assert Context.from_dict({'kind': 'multi', 'kind1': {'key': 'key1'}, 'kind2': {'key': 'key2'}}) == \
-            Context.create_multi(Context.create('key1', 'kind1'), Context.create('key2', 'kind2'))
+        assert Context.from_dict({'kind': 'multi', 'kind1': {'key': 'key1'}, 'kind2': {'key': 'key2'}}) == Context.create_multi(Context.create('key1', 'kind1'), Context.create('key2', 'kind2'))
 
         assert_context_invalid(Context.from_dict({'kind': 'kind1'}))
         assert_context_invalid(Context.from_dict({'kind': 'kind1', 'key': 3}))

--- a/ldclient/testing/test_context.py
+++ b/ldclient/testing/test_context.py
@@ -1,7 +1,8 @@
-from ldclient.context import Context
-
 import json
+
 import pytest
+
+from ldclient.context import Context
 
 
 def assert_context_valid(c):

--- a/ldclient/testing/test_feature_store_client_wrapper.py
+++ b/ldclient/testing/test_feature_store_client_wrapper.py
@@ -1,10 +1,10 @@
-from unittest.mock import Mock
-from typing import Callable, List
 from threading import Event
+from typing import Callable, List
+from unittest.mock import Mock
 
 from ldclient.client import _FeatureStoreClientWrapper
-from ldclient.impl.listeners import Listeners
 from ldclient.impl.datastore.status import DataStoreUpdateSinkImpl
+from ldclient.impl.listeners import Listeners
 
 
 class CallbackListener:

--- a/ldclient/testing/test_feature_store_helpers.py
+++ b/ldclient/testing/test_feature_store_helpers.py
@@ -1,6 +1,7 @@
-import pytest
 from time import sleep
 from unittest.mock import Mock
+
+import pytest
 
 from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper

--- a/ldclient/testing/test_feature_store_helpers.py
+++ b/ldclient/testing/test_feature_store_helpers.py
@@ -6,8 +6,8 @@ from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
 from ldclient.versioned_data_kind import VersionedDataKind
 
-THINGS = VersionedDataKind(namespace = "things", request_api_path = "", stream_api_path = "")
-WRONG_THINGS = VersionedDataKind(namespace = "wrong", request_api_path = "", stream_api_path = "")
+THINGS = VersionedDataKind(namespace="things", request_api_path="", stream_api_path="")
+WRONG_THINGS = VersionedDataKind(namespace="wrong", request_api_path="", stream_api_path="")
 
 
 def make_wrapper(core, cached):
@@ -96,8 +96,8 @@ class TestCachingStoreWrapper:
         core = MockCore()
         wrapper = make_wrapper(core, cached)
         key = "flag"
-        itemv1 = { "key": key, "version": 1 }
-        itemv2 = { "key": key, "version": 2 }
+        itemv1 = {"key": key, "version": 1}
+        itemv2 = {"key": key, "version": 2}
 
         core.force_set(THINGS, itemv1)
         assert wrapper.get(THINGS, key) == itemv1
@@ -110,11 +110,11 @@ class TestCachingStoreWrapper:
         core = MockCore()
         wrapper = make_wrapper(core, cached)
         key = "flag"
-        itemv1 = { "key": key, "version": 1, "deleted": True }
-        itemv2 = { "key": key, "version": 2 }
+        itemv1 = {"key": key, "version": 1, "deleted": True}
+        itemv2 = {"key": key, "version": 2}
 
         core.force_set(THINGS, itemv1)
-        assert wrapper.get(THINGS, key) is None   # item is filtered out because deleted is true
+        assert wrapper.get(THINGS, key) is None  # item is filtered out because deleted is true
 
         core.force_set(THINGS, itemv2)
         assert wrapper.get(THINGS, key) == (None if cached else itemv2)  # if cached, we will not see the new underlying value yet
@@ -123,8 +123,8 @@ class TestCachingStoreWrapper:
     def test_get_missing_item(self, cached):
         core = MockCore()
         wrapper = make_wrapper(core, cached)
-        key =  "flag"
-        item = { "key": key, "version": 1 }
+        key = "flag"
+        item = {"key": key, "version": 1}
 
         assert wrapper.get(THINGS, key) is None
 
@@ -136,8 +136,8 @@ class TestCachingStoreWrapper:
         core = MockCore()
         wrapper = make_wrapper(core, cached)
         key = "flag"
-        item = { "key": key, "version": 1 }
-        modified_item = { "key": key, "version": 99 }
+        item = {"key": key, "version": 1}
+        modified_item = {"key": key, "version": 99}
 
         core.force_set(THINGS, item)
         assert wrapper.get(THINGS, key, lambda x: modified_item) == modified_item
@@ -145,10 +145,10 @@ class TestCachingStoreWrapper:
     def test_cached_get_uses_values_from_init(self):
         core = MockCore()
         wrapper = make_wrapper(core, True)
-        item1 = { "key": "flag1", "version": 1 }
-        item2 = { "key": "flag2", "version": 1 }
+        item1 = {"key": "flag1", "version": 1}
+        item2 = {"key": "flag2", "version": 1}
 
-        wrapper.init({ THINGS: { item1["key"]: item1, item2["key"]: item2 } })
+        wrapper.init({THINGS: {item1["key"]: item1, item2["key"]: item2}})
         core.force_remove(THINGS, item1["key"])
         assert wrapper.get(THINGS, item1["key"]) == item1
 
@@ -164,29 +164,29 @@ class TestCachingStoreWrapper:
     def test_get_all(self, cached):
         core = MockCore()
         wrapper = make_wrapper(core, cached)
-        item1 = { "key": "flag1", "version": 1 }
-        item2 = { "key": "flag2", "version": 1 }
+        item1 = {"key": "flag1", "version": 1}
+        item2 = {"key": "flag2", "version": 1}
 
         core.force_set(THINGS, item1)
         core.force_set(THINGS, item2)
-        assert wrapper.all(THINGS) == { item1["key"]: item1, item2["key"]: item2 }
+        assert wrapper.all(THINGS) == {item1["key"]: item1, item2["key"]: item2}
 
         core.force_remove(THINGS, item2["key"])
         if cached:
-            assert wrapper.all(THINGS) == { item1["key"]: item1, item2["key"]: item2 }
+            assert wrapper.all(THINGS) == {item1["key"]: item1, item2["key"]: item2}
         else:
-            assert wrapper.all(THINGS) == { item1["key"]: item1 }
+            assert wrapper.all(THINGS) == {item1["key"]: item1}
 
     @pytest.mark.parametrize("cached", [False, True])
     def test_get_all_removes_deleted_items(self, cached):
         core = MockCore()
         wrapper = make_wrapper(core, cached)
-        item1 = { "key": "flag1", "version": 1 }
-        item2 = { "key": "flag2", "version": 1, "deleted": True }
+        item1 = {"key": "flag1", "version": 1}
+        item2 = {"key": "flag2", "version": 1, "deleted": True}
 
         core.force_set(THINGS, item1)
         core.force_set(THINGS, item2)
-        assert wrapper.all(THINGS) == { item1["key"]: item1 }
+        assert wrapper.all(THINGS) == {item1["key"]: item1}
 
     @pytest.mark.parametrize("cached", [False, True])
     def test_get_all_changes_None_to_empty_dict(self, cached):
@@ -199,23 +199,21 @@ class TestCachingStoreWrapper:
     def test_get_all_iwith_lambda(self, cached):
         core = MockCore()
         wrapper = make_wrapper(core, cached)
-        extra = { "extra": True }
-        item1 = { "key": "flag1", "version": 1 }
-        item2 = { "key": "flag2", "version": 1 }
+        extra = {"extra": True}
+        item1 = {"key": "flag1", "version": 1}
+        item2 = {"key": "flag2", "version": 1}
         core.force_set(THINGS, item1)
         core.force_set(THINGS, item2)
-        assert wrapper.all(THINGS, lambda x: dict(x, **extra)) == {
-            item1["key"]: item1, item2["key"]: item2, "extra": True
-        }
+        assert wrapper.all(THINGS, lambda x: dict(x, **extra)) == {item1["key"]: item1, item2["key"]: item2, "extra": True}
 
     def test_cached_get_all_uses_values_from_init(self):
         core = MockCore()
         wrapper = make_wrapper(core, True)
-        item1 = { "key": "flag1", "version": 1 }
-        item2 = { "key": "flag2", "version": 1 }
-        both = { item1["key"]: item1, item2["key"]: item2 }
+        item1 = {"key": "flag1", "version": 1}
+        item2 = {"key": "flag2", "version": 1}
+        both = {item1["key"]: item1, item2["key"]: item2}
 
-        wrapper.init({ THINGS: both })
+        wrapper.init({THINGS: both})
         core.force_remove(THINGS, item1["key"])
         assert wrapper.all(THINGS) == both
 
@@ -232,8 +230,8 @@ class TestCachingStoreWrapper:
         core = MockCore()
         wrapper = make_wrapper(core, cached)
         key = "flag"
-        itemv1 = { "key": key, "version": 1 }
-        itemv2 = { "key": key, "version": 2 }
+        itemv1 = {"key": key, "version": 1}
+        itemv2 = {"key": key, "version": 2}
 
         wrapper.upsert(THINGS, itemv1)
         assert core.data[THINGS][key] == itemv1
@@ -244,7 +242,7 @@ class TestCachingStoreWrapper:
         # if we have a cache, verify that the new item is now cached by writing a different value
         # to the underlying data - Get should still return the cached item
         if cached:
-            itemv3 = { "key": key, "version": 3 }
+            itemv3 = {"key": key, "version": 3}
             core.force_set(THINGS, itemv3)
 
         assert wrapper.get(THINGS, key) == itemv2
@@ -257,8 +255,8 @@ class TestCachingStoreWrapper:
         core = MockCore()
         wrapper = make_wrapper(core, True)
         key = "flag"
-        itemv1 = { "key": key, "version": 1 }
-        itemv2 = { "key": key, "version": 2 }
+        itemv1 = {"key": key, "version": 1}
+        itemv2 = {"key": key, "version": 2}
 
         wrapper.upsert(THINGS, itemv2)
         assert core.data[THINGS][key] == itemv2
@@ -266,7 +264,7 @@ class TestCachingStoreWrapper:
         wrapper.upsert(THINGS, itemv1)
         assert core.data[THINGS][key] == itemv2  # value in store remains the same
 
-        itemv3 = { "key": key, "version": 3 }
+        itemv3 = {"key": key, "version": 3}
         core.force_set(THINGS, itemv3)  # bypasses cache so we can verify that itemv2 is in the cache
         assert wrapper.get(THINGS, key) == itemv2
 
@@ -276,16 +274,16 @@ class TestCachingStoreWrapper:
         wrapper = make_wrapper(core, cached)
         core.error = CustomError()
         with pytest.raises(CustomError):
-            wrapper.upsert(THINGS, { "key": "x", "version": 1 })
+            wrapper.upsert(THINGS, {"key": "x", "version": 1})
 
     @pytest.mark.parametrize("cached", [False, True])
     def test_delete(self, cached):
         core = MockCore()
         wrapper = make_wrapper(core, cached)
         key = "flag"
-        itemv1 = { "key": key, "version": 1 }
-        itemv2 = { "key": key, "version": 2, "deleted": True }
-        itemv3 = { "key": key, "version": 3 }
+        itemv1 = {"key": key, "version": 1}
+        itemv2 = {"key": key, "version": 2, "deleted": True}
+        itemv3 = {"key": key, "version": 3}
 
         core.force_set(THINGS, itemv1)
         assert wrapper.get(THINGS, key) == itemv1

--- a/ldclient/testing/test_file_data_source.py
+++ b/ldclient/testing/test_file_data_source.py
@@ -1,22 +1,22 @@
 import json
 import os
-from typing import List
-
-import pytest
 import tempfile
 import threading
 import time
+from typing import List
 
-from ldclient.client import LDClient, Context
+import pytest
+
+from ldclient.client import Context, LDClient
 from ldclient.config import Config
 from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.impl.datasource.status import DataSourceUpdateSinkImpl
 from ldclient.impl.listeners import Listeners
 from ldclient.integrations import Files
-from ldclient.interfaces import DataSourceStatus, DataSourceState, DataSourceErrorKind
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
+from ldclient.interfaces import (DataSourceErrorKind, DataSourceState,
+                                 DataSourceStatus)
 from ldclient.testing.test_util import SpyListener
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 have_yaml = False
 try:

--- a/ldclient/testing/test_file_data_source.py
+++ b/ldclient/testing/test_file_data_source.py
@@ -327,4 +327,4 @@ def test_does_not_allow_unsafe_yaml():
         os.remove(path)
         if client is not None:
             client.close()
-    assert unsafe_yaml_caused_method_to_be_called == False
+    assert unsafe_yaml_caused_method_to_be_called is False

--- a/ldclient/testing/test_file_data_source.py
+++ b/ldclient/testing/test_file_data_source.py
@@ -21,12 +21,13 @@ from ldclient.testing.test_util import SpyListener
 have_yaml = False
 try:
     import yaml
+
     have_yaml = True
 except ImportError:
     pass
 
 
-all_flag_keys = [ 'flag1', 'flag2' ]
+all_flag_keys = ['flag1', 'flag2']
 all_properties_json = '''
   {
     "flags": {
@@ -128,7 +129,7 @@ def replace_file(path, content):
 def test_does_not_load_data_prior_to_start():
     path = make_temp_file('{"flagValues":{"key":"value"}}')
     try:
-        source = make_data_source(Config("SDK_KEY"), paths = path)
+        source = make_data_source(Config("SDK_KEY"), paths=path)
         assert ready.is_set() is False
         assert source.initialized() is False
         assert store.initialized is False
@@ -145,7 +146,7 @@ def test_loads_flags_on_start_from_json():
     try:
         config = Config("SDK_KEY")
         config._data_source_update_sink = DataSourceUpdateSinkImpl(store, listeners, Listeners())
-        source = make_data_source(config, paths = path)
+        source = make_data_source(config, paths=path)
         source.start()
         assert store.initialized is True
         assert sorted(list(store.all(FEATURES, lambda x: x).keys())) == all_flag_keys
@@ -166,7 +167,7 @@ def test_handles_invalid_format_correctly():
     try:
         config = Config("SDK_KEY")
         config._data_source_update_sink = DataSourceUpdateSinkImpl(store, listeners, Listeners())
-        source = make_data_source(config, paths = path)
+        source = make_data_source(config, paths=path)
         source.start()
         assert store.initialized is False
 
@@ -182,7 +183,7 @@ def test_loads_flags_on_start_from_yaml():
         pytest.skip("skipping file source test with YAML because pyyaml isn't available")
     path = make_temp_file(all_properties_yaml)
     try:
-        source = make_data_source(Config("SDK_KEY"), paths = path)
+        source = make_data_source(Config("SDK_KEY"), paths=path)
         source.start()
         assert store.initialized is True
         assert sorted(list(store.all(FEATURES, lambda x: x).keys())) == all_flag_keys
@@ -193,7 +194,7 @@ def test_loads_flags_on_start_from_yaml():
 def test_sets_ready_event_and_initialized_on_successful_load():
     path = make_temp_file(all_properties_json)
     try:
-        source = make_data_source(Config("SDK_KEY"), paths = path)
+        source = make_data_source(Config("SDK_KEY"), paths=path)
         source.start()
         assert source.initialized() is True
         assert ready.is_set() is True
@@ -203,7 +204,7 @@ def test_sets_ready_event_and_initialized_on_successful_load():
 
 def test_sets_ready_event_and_does_not_set_initialized_on_unsuccessful_load():
     bad_file_path = 'no-such-file'
-    source = make_data_source(Config("SDK_KEY"), paths = bad_file_path)
+    source = make_data_source(Config("SDK_KEY"), paths=bad_file_path)
     source.start()
     assert source.initialized() is False
     assert ready.is_set() is True
@@ -213,7 +214,7 @@ def test_can_load_multiple_files():
     path1 = make_temp_file(flag_only_json)
     path2 = make_temp_file(segment_only_json)
     try:
-        source = make_data_source(Config("SDK_KEY"), paths = [ path1, path2 ])
+        source = make_data_source(Config("SDK_KEY"), paths=[path1, path2])
         source.start()
         assert len(store.all(FEATURES, lambda x: x)) == 1
         assert len(store.all(SEGMENTS, lambda x: x)) == 1
@@ -226,7 +227,7 @@ def test_does_not_allow_duplicate_keys():
     path1 = make_temp_file(flag_only_json)
     path2 = make_temp_file(flag_only_json)
     try:
-        source = make_data_source(Config("SDK_KEY"), paths = [ path1, path2 ])
+        source = make_data_source(Config("SDK_KEY"), paths=[path1, path2])
         source.start()
         assert len(store.all(FEATURES, lambda x: x)) == 0
     finally:
@@ -237,7 +238,7 @@ def test_does_not_allow_duplicate_keys():
 def test_does_not_reload_modified_file_if_auto_update_is_off():
     path = make_temp_file(flag_only_json)
     try:
-        source = make_data_source(Config("SDK_KEY"), paths = path)
+        source = make_data_source(Config("SDK_KEY"), paths=path)
         source.start()
         assert len(store.all(SEGMENTS, lambda x: x)) == 0
         time.sleep(0.5)
@@ -268,18 +269,18 @@ def do_auto_update_test(options):
 
 
 def test_reloads_modified_file_if_auto_update_is_on():
-    do_auto_update_test({ 'auto_update': True })
+    do_auto_update_test({'auto_update': True})
 
 
 def test_reloads_modified_file_in_polling_mode():
-    do_auto_update_test({ 'auto_update': True, 'force_polling': True, 'poll_interval': 0.1 })
+    do_auto_update_test({'auto_update': True, 'force_polling': True, 'poll_interval': 0.1})
 
 
 def test_evaluates_full_flag_with_client_as_expected():
     path = make_temp_file(all_properties_json)
     try:
-        factory = Files.new_data_source(paths = path)
-        client = LDClient(config=Config('SDK_KEY', update_processor_class = factory, send_events = False))
+        factory = Files.new_data_source(paths=path)
+        client = LDClient(config=Config('SDK_KEY', update_processor_class=factory, send_events=False))
         value = client.variation('flag1', Context.from_dict({'key': 'user', 'kind': 'user'}), '')
         assert value == 'on'
     finally:
@@ -291,14 +292,15 @@ def test_evaluates_full_flag_with_client_as_expected():
 def test_evaluates_simplified_flag_with_client_as_expected():
     path = make_temp_file(all_properties_json)
     try:
-        factory = Files.new_data_source(paths = path)
-        client = LDClient(config=Config('SDK_KEY', update_processor_class = factory, send_events = False))
+        factory = Files.new_data_source(paths=path)
+        client = LDClient(config=Config('SDK_KEY', update_processor_class=factory, send_events=False))
         value = client.variation('flag2', Context.from_dict({'key': 'user', 'kind': 'user'}), '')
         assert value == 'value2'
     finally:
         os.remove(path)
         if client is not None:
             client.close()
+
 
 unsafe_yaml_caused_method_to_be_called = False
 
@@ -319,8 +321,8 @@ def test_does_not_allow_unsafe_yaml():
 '''
     path = make_temp_file(unsafe_yaml)
     try:
-        factory = Files.new_data_source(paths = path)
-        client = LDClient(config=Config('SDK_KEY', update_processor_class = factory, send_events = False))
+        factory = Files.new_data_source(paths=path)
+        client = LDClient(config=Config('SDK_KEY', update_processor_class=factory, send_events=False))
     finally:
         os.remove(path)
         if client is not None:

--- a/ldclient/testing/test_file_data_source.py
+++ b/ldclient/testing/test_file_data_source.py
@@ -101,14 +101,17 @@ def setup_function():
     store = InMemoryFeatureStore()
     ready = threading.Event()
 
+
 def teardown_function():
     if data_source is not None:
         data_source.stop()
+
 
 def make_data_source(config, **kwargs):
     global data_source
     data_source = Files.new_data_source(**kwargs)(config, store, ready)
     return data_source
+
 
 def make_temp_file(content):
     f, path = tempfile.mkstemp()
@@ -116,9 +119,11 @@ def make_temp_file(content):
     os.close(f)
     return path
 
+
 def replace_file(path, content):
     with open(path, 'w') as f:
         f.write(content)
+
 
 def test_does_not_load_data_prior_to_start():
     path = make_temp_file('{"flagValues":{"key":"value"}}')
@@ -129,6 +134,7 @@ def test_does_not_load_data_prior_to_start():
         assert store.initialized is False
     finally:
         os.remove(path)
+
 
 def test_loads_flags_on_start_from_json():
     path = make_temp_file(all_properties_json)
@@ -150,6 +156,7 @@ def test_loads_flags_on_start_from_json():
     finally:
         os.remove(path)
 
+
 def test_handles_invalid_format_correctly():
     path = make_temp_file('{"flagValues":{')
     spy = SpyListener()
@@ -169,6 +176,7 @@ def test_handles_invalid_format_correctly():
     finally:
         os.remove(path)
 
+
 def test_loads_flags_on_start_from_yaml():
     if not have_yaml:
         pytest.skip("skipping file source test with YAML because pyyaml isn't available")
@@ -181,6 +189,7 @@ def test_loads_flags_on_start_from_yaml():
     finally:
         os.remove(path)
 
+
 def test_sets_ready_event_and_initialized_on_successful_load():
     path = make_temp_file(all_properties_json)
     try:
@@ -191,12 +200,14 @@ def test_sets_ready_event_and_initialized_on_successful_load():
     finally:
         os.remove(path)
 
+
 def test_sets_ready_event_and_does_not_set_initialized_on_unsuccessful_load():
     bad_file_path = 'no-such-file'
     source = make_data_source(Config("SDK_KEY"), paths = bad_file_path)
     source.start()
     assert source.initialized() is False
     assert ready.is_set() is True
+
 
 def test_can_load_multiple_files():
     path1 = make_temp_file(flag_only_json)
@@ -210,6 +221,7 @@ def test_can_load_multiple_files():
         os.remove(path1)
         os.remove(path2)
 
+
 def test_does_not_allow_duplicate_keys():
     path1 = make_temp_file(flag_only_json)
     path2 = make_temp_file(flag_only_json)
@@ -220,6 +232,7 @@ def test_does_not_allow_duplicate_keys():
     finally:
         os.remove(path1)
         os.remove(path2)
+
 
 def test_does_not_reload_modified_file_if_auto_update_is_off():
     path = make_temp_file(flag_only_json)
@@ -233,6 +246,7 @@ def test_does_not_reload_modified_file_if_auto_update_is_off():
         assert len(store.all(SEGMENTS, lambda x: x)) == 0
     finally:
         os.remove(path)
+
 
 def do_auto_update_test(options):
     path = make_temp_file(flag_only_json)
@@ -252,11 +266,14 @@ def do_auto_update_test(options):
     finally:
         os.remove(path)
 
+
 def test_reloads_modified_file_if_auto_update_is_on():
     do_auto_update_test({ 'auto_update': True })
 
+
 def test_reloads_modified_file_in_polling_mode():
     do_auto_update_test({ 'auto_update': True, 'force_polling': True, 'poll_interval': 0.1 })
+
 
 def test_evaluates_full_flag_with_client_as_expected():
     path = make_temp_file(all_properties_json)
@@ -269,6 +286,7 @@ def test_evaluates_full_flag_with_client_as_expected():
         os.remove(path)
         if client is not None:
             client.close()
+
 
 def test_evaluates_simplified_flag_with_client_as_expected():
     path = make_temp_file(all_properties_json)
@@ -284,9 +302,11 @@ def test_evaluates_simplified_flag_with_client_as_expected():
 
 unsafe_yaml_caused_method_to_be_called = False
 
+
 def arbitrary_method_called_from_yaml(x):
     global unsafe_yaml_caused_method_to_be_called
     unsafe_yaml_caused_method_to_be_called = True
+
 
 def test_does_not_allow_unsafe_yaml():
     if not have_yaml:

--- a/ldclient/testing/test_flags_state.py
+++ b/ldclient/testing/test_flags_state.py
@@ -3,15 +3,18 @@ import json
 import jsonpickle
 from ldclient.evaluation import FeatureFlagsState
 
+
 def test_can_get_flag_value():
     state = FeatureFlagsState(True)
     flag_state = { 'key': 'key', 'version': 100, 'value': 'value', 'variation': 1, 'reason': None }
     state.add_flag(flag_state, False, False)
     assert state.get_flag_value('key') == 'value'
 
+
 def test_returns_none_for_unknown_flag():
     state = FeatureFlagsState(True)
     assert state.get_flag_value('key') is None
+
 
 def test_can_convert_to_values_map():
     state = FeatureFlagsState(True)
@@ -20,6 +23,7 @@ def test_can_convert_to_values_map():
     state.add_flag(flag_state1, False, False)
     state.add_flag(flag_state2, False, False)
     assert state.to_values_map() == { 'key1': 'value1', 'key2': 'value2' }
+
 
 def test_can_convert_to_json_dict():
     state = FeatureFlagsState(True)
@@ -47,6 +51,7 @@ def test_can_convert_to_json_dict():
         '$valid': True
     }
 
+
 def test_can_convert_to_json_string():
     state = FeatureFlagsState(True)
     flag_state1 = { 'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None }
@@ -57,6 +62,7 @@ def test_can_convert_to_json_string():
     obj = state.to_json_dict()
     str = state.to_json_string()
     assert json.loads(str) == obj
+
 
 # We don't actually use jsonpickle in the SDK, but FeatureFlagsState has a magic method that makes it
 # behave correctly in case the application uses jsonpickle to serialize it.

--- a/ldclient/testing/test_flags_state.py
+++ b/ldclient/testing/test_flags_state.py
@@ -1,6 +1,8 @@
-import pytest
 import json
+
 import jsonpickle
+import pytest
+
 from ldclient.evaluation import FeatureFlagsState
 
 

--- a/ldclient/testing/test_flags_state.py
+++ b/ldclient/testing/test_flags_state.py
@@ -6,7 +6,7 @@ from ldclient.evaluation import FeatureFlagsState
 
 def test_can_get_flag_value():
     state = FeatureFlagsState(True)
-    flag_state = { 'key': 'key', 'version': 100, 'value': 'value', 'variation': 1, 'reason': None }
+    flag_state = {'key': 'key', 'version': 100, 'value': 'value', 'variation': 1, 'reason': None}
     state.add_flag(flag_state, False, False)
     assert state.get_flag_value('key') == 'value'
 
@@ -18,17 +18,17 @@ def test_returns_none_for_unknown_flag():
 
 def test_can_convert_to_values_map():
     state = FeatureFlagsState(True)
-    flag_state1 = { 'key': 'key1', 'version': 100, 'value': 'value1', 'variation': 0, 'reason': None }
-    flag_state2 = { 'key': 'key2', 'version': 200, 'value': 'value2', 'variation': 1, 'reason': None }
+    flag_state1 = {'key': 'key1', 'version': 100, 'value': 'value1', 'variation': 0, 'reason': None}
+    flag_state2 = {'key': 'key2', 'version': 200, 'value': 'value2', 'variation': 1, 'reason': None}
     state.add_flag(flag_state1, False, False)
     state.add_flag(flag_state2, False, False)
-    assert state.to_values_map() == { 'key1': 'value1', 'key2': 'value2' }
+    assert state.to_values_map() == {'key1': 'value1', 'key2': 'value2'}
 
 
 def test_can_convert_to_json_dict():
     state = FeatureFlagsState(True)
-    flag_state1 = { 'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None }
-    flag_state2 = { 'key': 'key2', 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'value': 'value2', 'variation': 1, 'reason': None }
+    flag_state1 = {'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None}
+    flag_state2 = {'key': 'key2', 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'value': 'value2', 'variation': 1, 'reason': None}
     state.add_flag(flag_state1, False, False)
     state.add_flag(flag_state2, False, False)
 
@@ -36,26 +36,15 @@ def test_can_convert_to_json_dict():
     assert result == {
         'key1': 'value1',
         'key2': 'value2',
-        '$flagsState': {
-            'key1': {
-                'variation': 0,
-                'version': 100
-            },
-            'key2': {
-                'variation': 1,
-                'version': 200,
-                'trackEvents': True,
-                'debugEventsUntilDate': 1000
-            }
-        },
-        '$valid': True
+        '$flagsState': {'key1': {'variation': 0, 'version': 100}, 'key2': {'variation': 1, 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000}},
+        '$valid': True,
     }
 
 
 def test_can_convert_to_json_string():
     state = FeatureFlagsState(True)
-    flag_state1 = { 'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None }
-    flag_state2 = { 'key': 'key2', 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'value': 'value2', 'variation': 1, 'reason': None }
+    flag_state1 = {'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None}
+    flag_state2 = {'key': 'key2', 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'value': 'value2', 'variation': 1, 'reason': None}
     state.add_flag(flag_state1, False, False)
     state.add_flag(flag_state2, False, False)
 
@@ -68,8 +57,8 @@ def test_can_convert_to_json_string():
 # behave correctly in case the application uses jsonpickle to serialize it.
 def test_can_serialize_with_jsonpickle():
     state = FeatureFlagsState(True)
-    flag_state1 = { 'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None }
-    flag_state2 = { 'key': 'key2', 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'value': 'value2', 'variation': 1, 'reason': None }
+    flag_state1 = {'key': 'key1', 'version': 100, 'trackEvents': False, 'value': 'value1', 'variation': 0, 'reason': None}
+    flag_state2 = {'key': 'key2', 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'value': 'value2', 'variation': 1, 'reason': None}
     state.add_flag(flag_state1, False, False)
     state.add_flag(flag_state2, False, False)
 

--- a/ldclient/testing/test_in_memory_feature_store.py
+++ b/ldclient/testing/test_in_memory_feature_store.py
@@ -5,6 +5,7 @@ from ldclient.interfaces import FeatureStore
 
 from ldclient.testing.feature_store_test_base import FeatureStoreTestBase, FeatureStoreTester
 
+
 def test_in_memory_status_checks():
     store = InMemoryFeatureStore()
 

--- a/ldclient/testing/test_in_memory_feature_store.py
+++ b/ldclient/testing/test_in_memory_feature_store.py
@@ -2,8 +2,8 @@ import pytest
 
 from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.interfaces import FeatureStore
-
-from ldclient.testing.feature_store_test_base import FeatureStoreTestBase, FeatureStoreTester
+from ldclient.testing.feature_store_test_base import (FeatureStoreTestBase,
+                                                      FeatureStoreTester)
 
 
 def test_in_memory_status_checks():

--- a/ldclient/testing/test_init.py
+++ b/ldclient/testing/test_init.py
@@ -1,5 +1,6 @@
 import logging
 from pprint import pprint
+
 import ldclient
 from ldclient import Config
 

--- a/ldclient/testing/test_init.py
+++ b/ldclient/testing/test_init.py
@@ -25,4 +25,3 @@ def test_set_config():
     # illustrates bad behavior- assigning value of ldclient.get() means
     # the old_client didn't get updated when we called set_config()
     assert old_client.get_sdk_key() == old_sdk_key
-

--- a/ldclient/testing/test_ldclient.py
+++ b/ldclient/testing/test_ldclient.py
@@ -11,47 +11,35 @@ from ldclient.testing.builders import *
 from ldclient.testing.stub_util import CapturingFeatureStore, MockEventProcessor, MockUpdateProcessor
 
 
-unreachable_uri="http://fake"
+unreachable_uri = "http://fake"
 
 
 context = Context.builder('xyz').set('bizzle', 'def').build()
-user = Context.from_dict({
-    u'key': u'xyz',
-    u'kind': u'user',
-    u'bizzle': u'def'
-})
+user = Context.from_dict({u'key': u'xyz', u'kind': u'user', u'bizzle': u'def'})
 
-anonymous_user = Context.from_dict({
-    u'key': u'abc',
-    u'kind': u'user',
-    u'anonymous': True
-})
+anonymous_user = Context.from_dict({u'key': u'abc', u'kind': u'user', u'anonymous': True})
 
 
-def make_client(store = InMemoryFeatureStore()):
-    return LDClient(config=Config(sdk_key = 'SDK_KEY',
-                                  base_uri=unreachable_uri,
-                                  events_uri=unreachable_uri,
-                                  stream_uri=unreachable_uri,
-                                  event_processor_class=MockEventProcessor,
-                                  update_processor_class=MockUpdateProcessor,
-                                  feature_store=store))
+def make_client(store=InMemoryFeatureStore()):
+    return LDClient(
+        config=Config(
+            sdk_key='SDK_KEY',
+            base_uri=unreachable_uri,
+            events_uri=unreachable_uri,
+            stream_uri=unreachable_uri,
+            event_processor_class=MockEventProcessor,
+            update_processor_class=MockUpdateProcessor,
+            feature_store=store,
+        )
+    )
 
 
 def make_offline_client():
-    return LDClient(config=Config(sdk_key="secret",
-                                  offline=True,
-                                  base_uri=unreachable_uri,
-                                  events_uri=unreachable_uri,
-                                  stream_uri=unreachable_uri))
+    return LDClient(config=Config(sdk_key="secret", offline=True, base_uri=unreachable_uri, events_uri=unreachable_uri, stream_uri=unreachable_uri))
 
 
 def make_ldd_client():
-    return LDClient(config=Config(sdk_key="secret",
-                                  use_ldd=True,
-                                  base_uri=unreachable_uri,
-                                  events_uri=unreachable_uri,
-                                  stream_uri=unreachable_uri))
+    return LDClient(config=Config(sdk_key="secret", use_ldd=True, base_uri=unreachable_uri, events_uri=unreachable_uri, stream_uri=unreachable_uri))
 
 
 def get_first_event(c):
@@ -94,29 +82,29 @@ def test_toggle_offline():
 
 
 def test_defaults():
-    config=Config("SDK_KEY", base_uri="http://localhost:3000", defaults={"foo": "bar"}, offline=True)
+    config = Config("SDK_KEY", base_uri="http://localhost:3000", defaults={"foo": "bar"}, offline=True)
     with LDClient(config=config) as client:
         assert "bar" == client.variation('foo', user, default=None)
 
 
 def test_defaults_and_online():
     expected = "bar"
-    my_client = LDClient(config=Config("SDK_KEY",
-                                       base_uri="http://localhost:3000",
-                                       defaults={"foo": expected},
-                                       event_processor_class=MockEventProcessor,
-                                       update_processor_class=MockUpdateProcessor,
-                                       feature_store=InMemoryFeatureStore()))
+    my_client = LDClient(
+        config=Config(
+            "SDK_KEY",
+            base_uri="http://localhost:3000",
+            defaults={"foo": expected},
+            event_processor_class=MockEventProcessor,
+            update_processor_class=MockUpdateProcessor,
+            feature_store=InMemoryFeatureStore(),
+        )
+    )
     actual = my_client.variation('foo', user, default="originalDefault")
     assert actual == expected
 
 
 def test_defaults_and_online_no_default():
-    my_client = LDClient(config=Config("SDK_KEY",
-                                       base_uri="http://localhost:3000",
-                                       defaults={"foo": "bar"},
-                                       event_processor_class=MockEventProcessor,
-                                       update_processor_class=MockUpdateProcessor))
+    my_client = LDClient(config=Config("SDK_KEY", base_uri="http://localhost:3000", defaults={"foo": "bar"}, event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor))
     assert "jim" == my_client.variation('baz', user, default="jim")
 
 
@@ -136,16 +124,14 @@ def test_secure_mode_hash():
 
 dependency_ordering_test_data = {
     FEATURES: {
-        "a": { "key": "a", "prerequisites": [ { "key": "b" }, { "key": "c" } ] },
-        "b": { "key": "b", "prerequisites": [ { "key": "c" }, { "key": "e" } ] },
-        "c": { "key": "c" },
-        "d": { "key": "d" },
-        "e": { "key": "e" },
-        "f": { "key": "f" }
+        "a": {"key": "a", "prerequisites": [{"key": "b"}, {"key": "c"}]},
+        "b": {"key": "b", "prerequisites": [{"key": "c"}, {"key": "e"}]},
+        "c": {"key": "c"},
+        "d": {"key": "d"},
+        "e": {"key": "e"},
+        "f": {"key": "f"},
     },
-    SEGMENTS: {
-        "o": { "key": "o" }
-    }
+    SEGMENTS: {"o": {"key": "o"}},
 }
 
 
@@ -163,8 +149,7 @@ class DependencyOrderingDataUpdateProcessor(UpdateProcessor):
 
 def test_store_data_set_ordering():
     store = CapturingFeatureStore()
-    config = Config(sdk_key = 'SDK_KEY', send_events=False, feature_store=store,
-                    update_processor_class=DependencyOrderingDataUpdateProcessor)
+    config = Config(sdk_key='SDK_KEY', send_events=False, feature_store=store, update_processor_class=DependencyOrderingDataUpdateProcessor)
     LDClient(config=config)
 
     data = store.received_data
@@ -186,5 +171,4 @@ def test_store_data_set_ordering():
             prereq_index = flags_list.index(prereq_item)
             if prereq_index > item_index:
                 all_keys = (f["key"] for f in flags_list)
-                raise Exception("%s depends on %s, but %s was listed first; keys in order are [%s]" %
-                    (item["key"], prereq["key"], item["key"], ", ".join(all_keys)))
+                raise Exception("%s depends on %s, but %s was listed first; keys in order are [%s]" % (item["key"], prereq["key"], item["key"], ", ".join(all_keys)))

--- a/ldclient/testing/test_ldclient.py
+++ b/ldclient/testing/test_ldclient.py
@@ -1,15 +1,16 @@
-from ldclient.client import LDClient, Config, Context
+import pytest
+
+from ldclient.client import Config, Context, LDClient
 from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.impl.datasource.polling import PollingUpdateProcessor
 from ldclient.impl.datasource.streaming import StreamingUpdateProcessor
 from ldclient.impl.stubs import NullUpdateProcessor
 from ldclient.interfaces import UpdateProcessor
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
-import pytest
 from ldclient.testing.builders import *
-from ldclient.testing.stub_util import CapturingFeatureStore, MockEventProcessor, MockUpdateProcessor
-
+from ldclient.testing.stub_util import (CapturingFeatureStore,
+                                        MockEventProcessor,
+                                        MockUpdateProcessor)
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 unreachable_uri = "http://fake"
 

--- a/ldclient/testing/test_ldclient.py
+++ b/ldclient/testing/test_ldclient.py
@@ -27,6 +27,7 @@ anonymous_user = Context.from_dict({
     u'anonymous': True
 })
 
+
 def make_client(store = InMemoryFeatureStore()):
     return LDClient(config=Config(sdk_key = 'SDK_KEY',
                                   base_uri=unreachable_uri,
@@ -146,6 +147,7 @@ dependency_ordering_test_data = {
         "o": { "key": "o" }
     }
 }
+
 
 class DependencyOrderingDataUpdateProcessor(UpdateProcessor):
     def __init__(self, config, store, ready):

--- a/ldclient/testing/test_ldclient_end_to_end.py
+++ b/ldclient/testing/test_ldclient_end_to_end.py
@@ -1,11 +1,14 @@
-from ldclient.client import LDClient, Context
-from ldclient.config import Config, HTTPConfig
-from ldclient.testing.http_util import BasicResponse, SequentialHandler, start_secure_server, start_server
-from ldclient.testing.stub_util import make_put_event, poll_content, stream_content
-
 import json
-import pytest
 import sys
+
+import pytest
+
+from ldclient.client import Context, LDClient
+from ldclient.config import Config, HTTPConfig
+from ldclient.testing.http_util import (BasicResponse, SequentialHandler,
+                                        start_secure_server, start_server)
+from ldclient.testing.stub_util import (make_put_event, poll_content,
+                                        stream_content)
 
 sdk_key = 'sdk-key'
 user = Context.from_dict({'key': 'userkey', 'kind': 'user'})

--- a/ldclient/testing/test_ldclient_end_to_end.py
+++ b/ldclient/testing/test_ldclient_end_to_end.py
@@ -8,17 +8,17 @@ import pytest
 import sys
 
 sdk_key = 'sdk-key'
-user = Context.from_dict({ 'key': 'userkey', 'kind': 'user' })
-always_true_flag = { 'key': 'flagkey', 'version': 1, 'on': False, 'offVariation': 1, 'variations': [ False, True ] }
+user = Context.from_dict({'key': 'userkey', 'kind': 'user'})
+always_true_flag = {'key': 'flagkey', 'version': 1, 'on': False, 'offVariation': 1, 'variations': [False, True]}
 
 
 def test_client_starts_in_streaming_mode():
     with start_server() as stream_server:
-        with stream_content(make_put_event([ always_true_flag ])) as stream_handler:
+        with stream_content(make_put_event([always_true_flag])) as stream_handler:
             stream_server.for_path('/all', stream_handler)
-            config = Config(sdk_key = sdk_key, stream_uri = stream_server.uri, send_events = False)
+            config = Config(sdk_key=sdk_key, stream_uri=stream_server.uri, send_events=False)
 
-            with LDClient(config = config) as client:
+            with LDClient(config=config) as client:
                 assert client.is_initialized()
                 assert client.variation(always_true_flag['key'], user, False) == True
 
@@ -29,21 +29,21 @@ def test_client_starts_in_streaming_mode():
 def test_client_fails_to_start_in_streaming_mode_with_401_error():
     with start_server() as stream_server:
         stream_server.for_path('/all', BasicResponse(401))
-        config = Config(sdk_key = sdk_key, stream_uri = stream_server.uri, send_events = False)
+        config = Config(sdk_key=sdk_key, stream_uri=stream_server.uri, send_events=False)
 
-        with LDClient(config = config) as client:
+        with LDClient(config=config) as client:
             assert not client.is_initialized()
             assert client.variation(always_true_flag['key'], user, False) == False
 
 
 def test_client_retries_connection_in_streaming_mode_with_non_fatal_error():
     with start_server() as stream_server:
-        with stream_content(make_put_event([ always_true_flag ])) as stream_handler:
+        with stream_content(make_put_event([always_true_flag])) as stream_handler:
             error_then_success = SequentialHandler(BasicResponse(503), stream_handler)
             stream_server.for_path('/all', error_then_success)
-            config = Config(sdk_key = sdk_key, stream_uri = stream_server.uri, initial_reconnect_delay = 0.001, send_events = False)
+            config = Config(sdk_key=sdk_key, stream_uri=stream_server.uri, initial_reconnect_delay=0.001, send_events=False)
 
-            with LDClient(config = config) as client:
+            with LDClient(config=config) as client:
                 assert client.is_initialized()
                 assert client.variation(always_true_flag['key'], user, False) == True
 
@@ -53,10 +53,10 @@ def test_client_retries_connection_in_streaming_mode_with_non_fatal_error():
 
 def test_client_starts_in_polling_mode():
     with start_server() as poll_server:
-        poll_server.for_path('/sdk/latest-all', poll_content([ always_true_flag ]))
-        config = Config(sdk_key = sdk_key, base_uri = poll_server.uri, stream = False, send_events = False)
+        poll_server.for_path('/sdk/latest-all', poll_content([always_true_flag]))
+        config = Config(sdk_key=sdk_key, base_uri=poll_server.uri, stream=False, send_events=False)
 
-        with LDClient(config = config) as client:
+        with LDClient(config=config) as client:
             assert client.is_initialized()
             assert client.variation(always_true_flag['key'], user, False) == True
 
@@ -67,9 +67,9 @@ def test_client_starts_in_polling_mode():
 def test_client_fails_to_start_in_polling_mode_with_401_error():
     with start_server() as poll_server:
         poll_server.for_path('/sdk/latest-all', BasicResponse(401))
-        config = Config(sdk_key = sdk_key, base_uri = poll_server.uri, stream = False, send_events = False)
+        config = Config(sdk_key=sdk_key, base_uri=poll_server.uri, stream=False, send_events=False)
 
-        with LDClient(config = config) as client:
+        with LDClient(config=config) as client:
             assert not client.is_initialized()
             assert client.variation(always_true_flag['key'], user, False) == False
 
@@ -77,12 +77,11 @@ def test_client_fails_to_start_in_polling_mode_with_401_error():
 def test_client_sends_event_without_diagnostics():
     with start_server() as poll_server:
         with start_server() as events_server:
-            poll_server.for_path('/sdk/latest-all', poll_content([ always_true_flag ]))
+            poll_server.for_path('/sdk/latest-all', poll_content([always_true_flag]))
             events_server.for_path('/bulk', BasicResponse(202))
 
-            config = Config(sdk_key = sdk_key, base_uri = poll_server.uri, events_uri = events_server.uri, stream = False,
-                diagnostic_opt_out = True)
-            with LDClient(config = config) as client:
+            config = Config(sdk_key=sdk_key, base_uri=poll_server.uri, events_uri=events_server.uri, stream=False, diagnostic_opt_out=True)
+            with LDClient(config=config) as client:
                 assert client.is_initialized()
                 client.identify(user)
                 client.flush()
@@ -97,11 +96,11 @@ def test_client_sends_event_without_diagnostics():
 def test_client_sends_diagnostics():
     with start_server() as poll_server:
         with start_server() as events_server:
-            poll_server.for_path('/sdk/latest-all', poll_content([ always_true_flag ]))
+            poll_server.for_path('/sdk/latest-all', poll_content([always_true_flag]))
             events_server.for_path('/diagnostic', BasicResponse(202))
 
-            config = Config(sdk_key = sdk_key, base_uri = poll_server.uri, events_uri = events_server.uri, stream = False)
-            with LDClient(config = config) as client:
+            config = Config(sdk_key=sdk_key, base_uri=poll_server.uri, events_uri=events_server.uri, stream=False)
+            with LDClient(config=config) as client:
                 assert client.is_initialized()
 
                 r = events_server.await_request()
@@ -113,53 +112,30 @@ def test_client_sends_diagnostics():
 def test_cannot_connect_with_selfsigned_cert_by_default():
     with start_secure_server() as server:
         server.for_path('/sdk/latest-all', poll_content())
-        config = Config(
-            sdk_key = 'sdk_key',
-            base_uri = server.uri,
-            stream = False,
-            send_events = False
-        )
-        with LDClient(config = config, start_wait = 1.5) as client:
+        config = Config(sdk_key='sdk_key', base_uri=server.uri, stream=False, send_events=False)
+        with LDClient(config=config, start_wait=1.5) as client:
             assert not client.is_initialized()
 
 
 def test_can_connect_with_selfsigned_cert_if_ssl_verify_is_false():
     with start_secure_server() as server:
         server.for_path('/sdk/latest-all', poll_content())
-        config = Config(
-            sdk_key = 'sdk_key',
-            base_uri = server.uri,
-            stream = False,
-            send_events = False,
-            http = HTTPConfig(disable_ssl_verification=True)
-        )
-        with LDClient(config = config) as client:
+        config = Config(sdk_key='sdk_key', base_uri=server.uri, stream=False, send_events=False, http=HTTPConfig(disable_ssl_verification=True))
+        with LDClient(config=config) as client:
             assert client.is_initialized()
 
 
 def test_can_connect_with_selfsigned_cert_if_disable_ssl_verification_is_true():
     with start_secure_server() as server:
         server.for_path('/sdk/latest-all', poll_content())
-        config = Config(
-            sdk_key = 'sdk_key',
-            base_uri = server.uri,
-            stream = False,
-            send_events = False,
-            http = HTTPConfig(disable_ssl_verification = True)
-        )
-        with LDClient(config = config) as client:
+        config = Config(sdk_key='sdk_key', base_uri=server.uri, stream=False, send_events=False, http=HTTPConfig(disable_ssl_verification=True))
+        with LDClient(config=config) as client:
             assert client.is_initialized()
 
 
 def test_can_connect_with_selfsigned_cert_by_setting_ca_certs():
     with start_secure_server() as server:
         server.for_path('/sdk/latest-all', poll_content())
-        config = Config(
-            sdk_key = 'sdk_key',
-            base_uri = server.uri,
-            stream = False,
-            send_events = False,
-            http = HTTPConfig(ca_certs = './ldclient/testing/selfsigned.pem')
-        )
-        with LDClient(config = config) as client:
+        config = Config(sdk_key='sdk_key', base_uri=server.uri, stream=False, send_events=False, http=HTTPConfig(ca_certs='./ldclient/testing/selfsigned.pem'))
+        with LDClient(config=config) as client:
             assert client.is_initialized()

--- a/ldclient/testing/test_ldclient_end_to_end.py
+++ b/ldclient/testing/test_ldclient_end_to_end.py
@@ -11,6 +11,7 @@ sdk_key = 'sdk-key'
 user = Context.from_dict({ 'key': 'userkey', 'kind': 'user' })
 always_true_flag = { 'key': 'flagkey', 'version': 1, 'on': False, 'offVariation': 1, 'variations': [ False, True ] }
 
+
 def test_client_starts_in_streaming_mode():
     with start_server() as stream_server:
         with stream_content(make_put_event([ always_true_flag ])) as stream_handler:
@@ -24,6 +25,7 @@ def test_client_starts_in_streaming_mode():
                 r = stream_server.await_request()
                 assert r.headers['Authorization'] == sdk_key
 
+
 def test_client_fails_to_start_in_streaming_mode_with_401_error():
     with start_server() as stream_server:
         stream_server.for_path('/all', BasicResponse(401))
@@ -32,6 +34,7 @@ def test_client_fails_to_start_in_streaming_mode_with_401_error():
         with LDClient(config = config) as client:
             assert not client.is_initialized()
             assert client.variation(always_true_flag['key'], user, False) == False
+
 
 def test_client_retries_connection_in_streaming_mode_with_non_fatal_error():
     with start_server() as stream_server:
@@ -47,6 +50,7 @@ def test_client_retries_connection_in_streaming_mode_with_non_fatal_error():
                 r = stream_server.await_request()
                 assert r.headers['Authorization'] == sdk_key
 
+
 def test_client_starts_in_polling_mode():
     with start_server() as poll_server:
         poll_server.for_path('/sdk/latest-all', poll_content([ always_true_flag ]))
@@ -59,6 +63,7 @@ def test_client_starts_in_polling_mode():
             r = poll_server.await_request()
             assert r.headers['Authorization'] == sdk_key
 
+
 def test_client_fails_to_start_in_polling_mode_with_401_error():
     with start_server() as poll_server:
         poll_server.for_path('/sdk/latest-all', BasicResponse(401))
@@ -67,6 +72,7 @@ def test_client_fails_to_start_in_polling_mode_with_401_error():
         with LDClient(config = config) as client:
             assert not client.is_initialized()
             assert client.variation(always_true_flag['key'], user, False) == False
+
 
 def test_client_sends_event_without_diagnostics():
     with start_server() as poll_server:
@@ -87,6 +93,7 @@ def test_client_sends_event_without_diagnostics():
                 assert len(data) == 1
                 assert data[0]['kind'] == 'identify'
 
+
 def test_client_sends_diagnostics():
     with start_server() as poll_server:
         with start_server() as events_server:
@@ -102,6 +109,7 @@ def test_client_sends_diagnostics():
                 data = json.loads(r.body)
                 assert data['kind'] == 'diagnostic-init'
 
+
 def test_cannot_connect_with_selfsigned_cert_by_default():
     with start_secure_server() as server:
         server.for_path('/sdk/latest-all', poll_content())
@@ -113,6 +121,7 @@ def test_cannot_connect_with_selfsigned_cert_by_default():
         )
         with LDClient(config = config, start_wait = 1.5) as client:
             assert not client.is_initialized()
+
 
 def test_can_connect_with_selfsigned_cert_if_ssl_verify_is_false():
     with start_secure_server() as server:
@@ -127,6 +136,7 @@ def test_can_connect_with_selfsigned_cert_if_ssl_verify_is_false():
         with LDClient(config = config) as client:
             assert client.is_initialized()
 
+
 def test_can_connect_with_selfsigned_cert_if_disable_ssl_verification_is_true():
     with start_secure_server() as server:
         server.for_path('/sdk/latest-all', poll_content())
@@ -139,6 +149,7 @@ def test_can_connect_with_selfsigned_cert_if_disable_ssl_verification_is_true():
         )
         with LDClient(config = config) as client:
             assert client.is_initialized()
+
 
 def test_can_connect_with_selfsigned_cert_by_setting_ca_certs():
     with start_secure_server() as server:

--- a/ldclient/testing/test_ldclient_end_to_end.py
+++ b/ldclient/testing/test_ldclient_end_to_end.py
@@ -20,7 +20,7 @@ def test_client_starts_in_streaming_mode():
 
             with LDClient(config=config) as client:
                 assert client.is_initialized()
-                assert client.variation(always_true_flag['key'], user, False) == True
+                assert client.variation(always_true_flag['key'], user, False) is True
 
                 r = stream_server.await_request()
                 assert r.headers['Authorization'] == sdk_key
@@ -33,7 +33,7 @@ def test_client_fails_to_start_in_streaming_mode_with_401_error():
 
         with LDClient(config=config) as client:
             assert not client.is_initialized()
-            assert client.variation(always_true_flag['key'], user, False) == False
+            assert client.variation(always_true_flag['key'], user, False) is False
 
 
 def test_client_retries_connection_in_streaming_mode_with_non_fatal_error():
@@ -45,7 +45,7 @@ def test_client_retries_connection_in_streaming_mode_with_non_fatal_error():
 
             with LDClient(config=config) as client:
                 assert client.is_initialized()
-                assert client.variation(always_true_flag['key'], user, False) == True
+                assert client.variation(always_true_flag['key'], user, False) is True
 
                 r = stream_server.await_request()
                 assert r.headers['Authorization'] == sdk_key
@@ -58,7 +58,7 @@ def test_client_starts_in_polling_mode():
 
         with LDClient(config=config) as client:
             assert client.is_initialized()
-            assert client.variation(always_true_flag['key'], user, False) == True
+            assert client.variation(always_true_flag['key'], user, False) is True
 
             r = poll_server.await_request()
             assert r.headers['Authorization'] == sdk_key
@@ -71,7 +71,7 @@ def test_client_fails_to_start_in_polling_mode_with_401_error():
 
         with LDClient(config=config) as client:
             assert not client.is_initialized()
-            assert client.variation(always_true_flag['key'], user, False) == False
+            assert client.variation(always_true_flag['key'], user, False) is False
 
 
 def test_client_sends_event_without_diagnostics():

--- a/ldclient/testing/test_ldclient_evaluation.py
+++ b/ldclient/testing/test_ldclient_evaluation.py
@@ -32,6 +32,7 @@ flag2 = {
     'debugEventsUntilDate': 1000
 }
 
+
 class ErroringFeatureStore(FeatureStore):
     def get(self, kind, key, callback=lambda x: x):
         raise NotImplementedError()
@@ -52,6 +53,7 @@ class ErroringFeatureStore(FeatureStore):
     def initialized(self):
         return True
 
+
 def get_log_lines(caplog, level):
     loglines = caplog.records
     if callable(loglines):
@@ -67,6 +69,7 @@ def test_variation_for_existing_feature():
     client = make_client(store)
     assert 'value' == client.variation('feature.key', user, default='default')
 
+
 def test_variation_passes_context_to_evaluator():
     c = Context.create('userkey')
     feature =  FlagBuilder('feature.key').on(True).variations('wrong', 'right').target(1, 'userkey').build()
@@ -75,10 +78,12 @@ def test_variation_passes_context_to_evaluator():
     client = make_client(store)
     assert 'right' == client.variation('feature.key', c, default='default')
 
+
 def test_variation_for_unknown_feature():
     store = InMemoryFeatureStore()
     client = make_client(store)
     assert 'default' == client.variation('feature.key', user, default='default')
+
 
 def test_variation_when_user_has_no_key():
     feature = build_off_flag_with_value('feature.key', 'value').build()
@@ -86,6 +91,7 @@ def test_variation_when_user_has_no_key():
     store.init({FEATURES: {'feature.key': feature}})
     client = make_client(store)
     assert 'default' == client.variation('feature.key', Context.from_dict({}), default='default')
+
 
 def test_variation_for_invalid_context():
     c = Context.create('')
@@ -95,12 +101,14 @@ def test_variation_for_invalid_context():
     client = make_client(store)
     assert 'default' == client.variation('feature.key', c, default='default')
 
+
 def test_variation_for_flag_that_evaluates_to_none():
     empty_flag = FlagBuilder('feature.key').on(False).build()
     store = InMemoryFeatureStore()
     store.init({FEATURES: {'feature.key': empty_flag}})
     client = make_client(store)
     assert 'default' == client.variation('feature.key', user, default='default')
+
 
 def test_variation_detail_for_existing_feature():
     feature = build_off_flag_with_value('feature.key', 'value').build()
@@ -110,11 +118,13 @@ def test_variation_detail_for_existing_feature():
     expected = EvaluationDetail('value', 0, {'kind': 'OFF'})
     assert expected == client.variation_detail('feature.key', user, default='default')
 
+
 def test_variation_detail_for_unknown_feature():
     store = InMemoryFeatureStore()
     client = make_client(store)
     expected = EvaluationDetail('default', None, {'kind': 'ERROR', 'errorKind': 'FLAG_NOT_FOUND'})
     assert expected == client.variation_detail('feature.key', user, default='default')
+
 
 def test_variation_detail_when_user_has_no_key():
     feature = build_off_flag_with_value('feature.key', 'value').build()
@@ -123,6 +133,7 @@ def test_variation_detail_when_user_has_no_key():
     client = make_client(store)
     expected = EvaluationDetail('default', None, {'kind': 'ERROR', 'errorKind': 'USER_NOT_SPECIFIED'})
     assert expected == client.variation_detail('feature.key', Context.from_dict({}), default='default')
+
 
 def test_variation_detail_for_flag_that_evaluates_to_none():
     empty_flag = FlagBuilder('feature.key').on(False).build()
@@ -134,12 +145,14 @@ def test_variation_detail_for_flag_that_evaluates_to_none():
     assert expected == actual
     assert actual.is_default_value() == True
 
+
 def test_variation_when_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
     assert client.variation('feature.key', Context.from_dict({ "key": "user", "kind": "user" }), default='default') == 'default'
     errlog = get_log_lines(caplog, 'ERROR')
     assert errlog == [ 'Unexpected error while retrieving feature flag "feature.key": NotImplementedError()' ]
+
 
 def test_variation_detail_when_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
@@ -150,6 +163,7 @@ def test_variation_detail_when_feature_store_throws_error(caplog):
     assert actual.is_default_value() == True
     errlog = get_log_lines(caplog, 'ERROR')
     assert errlog == [ 'Unexpected error while retrieving feature flag "feature.key": NotImplementedError()' ]
+
 
 def test_flag_using_big_segment():
     segment = SegmentBuilder('segkey').unbounded(True).generation(1).build()
@@ -171,12 +185,14 @@ def test_flag_using_big_segment():
         assert detail.value == True
         assert detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
+
 def test_all_flags_returns_values():
     store = InMemoryFeatureStore()
     store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
     client = make_client(store)
     result = client.all_flags_state(user).to_values_map()
     assert result == { 'key1': 'value1', 'key2': 'value2' }
+
 
 def test_all_flags_returns_none_if_user_has_no_key():
     store = InMemoryFeatureStore()
@@ -185,12 +201,14 @@ def test_all_flags_returns_none_if_user_has_no_key():
     result = client.all_flags_state(Context.from_dict({}))
     assert not result.valid
 
+
 def test_all_flags_returns_none_if_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
     assert not client.all_flags_state(Context.from_dict({ "key": "user", "kind": "user" })).valid
     errlog = get_log_lines(caplog, 'ERROR')
     assert errlog == [ 'Unable to read flags for all_flag_state: NotImplementedError()' ]
+
 
 def test_all_flags_state_returns_state():
     store = InMemoryFeatureStore()
@@ -324,6 +342,7 @@ def test_all_flags_state_returns_state_with_reasons():
         '$valid': True
     }
 
+
 def test_all_flags_state_can_be_filtered_for_client_side_flags():
     flag1 = {
         'key': 'server-side-1',
@@ -371,6 +390,7 @@ def test_all_flags_state_can_be_filtered_for_client_side_flags():
     assert state.valid
     values = state.to_values_map()
     assert values == { 'client-side-1': 'value1', 'client-side-2': 'value2' }
+
 
 def test_all_flags_state_can_omit_details_for_untracked_flags():
     future_time = (time.time() * 1000) + 100000
@@ -429,12 +449,14 @@ def test_all_flags_state_can_omit_details_for_untracked_flags():
         '$valid': True
     }
 
+
 def test_all_flags_state_returns_empty_state_if_user_has_no_key():
     store = InMemoryFeatureStore()
     store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
     client = make_client(store)
     state = client.all_flags_state(Context.from_dict({}))
     assert state.valid == False
+
 
 def test_all_flags_returns_empty_state_if_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()

--- a/ldclient/testing/test_ldclient_evaluation.py
+++ b/ldclient/testing/test_ldclient_evaluation.py
@@ -1,18 +1,17 @@
 import time
-from ldclient.client import LDClient, Config, Context
+
+from ldclient.client import Config, Context, LDClient
 from ldclient.config import BigSegmentsConfig
 from ldclient.evaluation import BigSegmentsStatus, EvaluationDetail
 from ldclient.feature_store import InMemoryFeatureStore
 from ldclient.impl.big_segments import _hash_for_user_key
 from ldclient.impl.evaluator import _make_big_segment_ref
 from ldclient.interfaces import FeatureStore
-from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
 from ldclient.testing.builders import *
 from ldclient.testing.mock_components import MockBigSegmentStore
 from ldclient.testing.stub_util import MockEventProcessor, MockUpdateProcessor
 from ldclient.testing.test_ldclient import make_client, user
-
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 flag1 = {'key': 'key1', 'version': 100, 'on': False, 'offVariation': 0, 'variations': ['value1'], 'trackEvents': False}
 flag2 = {'key': 'key2', 'version': 200, 'on': False, 'offVariation': 1, 'variations': ['x', 'value2'], 'trackEvents': True, 'debugEventsUntilDate': 1000}

--- a/ldclient/testing/test_ldclient_evaluation.py
+++ b/ldclient/testing/test_ldclient_evaluation.py
@@ -128,7 +128,7 @@ def test_variation_detail_for_flag_that_evaluates_to_none():
     expected = EvaluationDetail('default', None, {'kind': 'OFF'})
     actual = client.variation_detail('feature.key', user, default='default')
     assert expected == actual
-    assert actual.is_default_value() == True
+    assert actual.is_default_value() is True
 
 
 def test_variation_when_feature_store_throws_error(caplog):
@@ -145,7 +145,7 @@ def test_variation_detail_when_feature_store_throws_error(caplog):
     expected = EvaluationDetail('default', None, {'kind': 'ERROR', 'errorKind': 'EXCEPTION'})
     actual = client.variation_detail('feature.key', Context.from_dict({"key": "user", "kind": "user"}), default='default')
     assert expected == actual
-    assert actual.is_default_value() == True
+    assert actual.is_default_value() is True
     errlog = get_log_lines(caplog, 'ERROR')
     assert errlog == ['Unexpected error while retrieving feature flag "feature.key": NotImplementedError()']
 
@@ -161,7 +161,7 @@ def test_flag_using_big_segment():
     config = Config(sdk_key='SDK_KEY', feature_store=store, big_segments=BigSegmentsConfig(store=segstore), event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor)
     with LDClient(config) as client:
         detail = client.variation_detail(flag['key'], user, False)
-        assert detail.value == True
+        assert detail.value is True
         assert detail.reason['bigSegmentsStatus'] == BigSegmentsStatus.HEALTHY
 
 
@@ -333,13 +333,13 @@ def test_all_flags_state_returns_empty_state_if_user_has_no_key():
     store.init({FEATURES: {'key1': flag1, 'key2': flag2}})
     client = make_client(store)
     state = client.all_flags_state(Context.from_dict({}))
-    assert state.valid == False
+    assert state.valid is False
 
 
 def test_all_flags_returns_empty_state_if_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
     state = client.all_flags_state(Context.from_dict({"key": "user", "kind": "user"}))
-    assert state.valid == False
+    assert state.valid is False
     errlog = get_log_lines(caplog, 'ERROR')
     assert errlog == ['Unable to read flags for all_flag_state: NotImplementedError()']

--- a/ldclient/testing/test_ldclient_evaluation.py
+++ b/ldclient/testing/test_ldclient_evaluation.py
@@ -14,23 +14,8 @@ from ldclient.testing.stub_util import MockEventProcessor, MockUpdateProcessor
 from ldclient.testing.test_ldclient import make_client, user
 
 
-flag1 = {
-    'key': 'key1',
-    'version': 100,
-    'on': False,
-    'offVariation': 0,
-    'variations': [ 'value1' ],
-    'trackEvents': False
-}
-flag2 = {
-    'key': 'key2',
-    'version': 200,
-    'on': False,
-    'offVariation': 1,
-    'variations': [ 'x', 'value2' ],
-    'trackEvents': True,
-    'debugEventsUntilDate': 1000
-}
+flag1 = {'key': 'key1', 'version': 100, 'on': False, 'offVariation': 0, 'variations': ['value1'], 'trackEvents': False}
+flag2 = {'key': 'key2', 'version': 200, 'on': False, 'offVariation': 1, 'variations': ['x', 'value2'], 'trackEvents': True, 'debugEventsUntilDate': 1000}
 
 
 class ErroringFeatureStore(FeatureStore):
@@ -72,7 +57,7 @@ def test_variation_for_existing_feature():
 
 def test_variation_passes_context_to_evaluator():
     c = Context.create('userkey')
-    feature =  FlagBuilder('feature.key').on(True).variations('wrong', 'right').target(1, 'userkey').build()
+    feature = FlagBuilder('feature.key').on(True).variations('wrong', 'right').target(1, 'userkey').build()
     store = InMemoryFeatureStore()
     store.init({FEATURES: {'feature.key': feature}})
     client = make_client(store)
@@ -149,37 +134,31 @@ def test_variation_detail_for_flag_that_evaluates_to_none():
 def test_variation_when_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
-    assert client.variation('feature.key', Context.from_dict({ "key": "user", "kind": "user" }), default='default') == 'default'
+    assert client.variation('feature.key', Context.from_dict({"key": "user", "kind": "user"}), default='default') == 'default'
     errlog = get_log_lines(caplog, 'ERROR')
-    assert errlog == [ 'Unexpected error while retrieving feature flag "feature.key": NotImplementedError()' ]
+    assert errlog == ['Unexpected error while retrieving feature flag "feature.key": NotImplementedError()']
 
 
 def test_variation_detail_when_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
     expected = EvaluationDetail('default', None, {'kind': 'ERROR', 'errorKind': 'EXCEPTION'})
-    actual = client.variation_detail('feature.key', Context.from_dict({ "key": "user", "kind": "user" }), default='default')
+    actual = client.variation_detail('feature.key', Context.from_dict({"key": "user", "kind": "user"}), default='default')
     assert expected == actual
     assert actual.is_default_value() == True
     errlog = get_log_lines(caplog, 'ERROR')
-    assert errlog == [ 'Unexpected error while retrieving feature flag "feature.key": NotImplementedError()' ]
+    assert errlog == ['Unexpected error while retrieving feature flag "feature.key": NotImplementedError()']
 
 
 def test_flag_using_big_segment():
     segment = SegmentBuilder('segkey').unbounded(True).generation(1).build()
     flag = make_boolean_flag_matching_segment(segment)
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { flag['key']: flag }, SEGMENTS: { segment['key']: segment } })
+    store.init({FEATURES: {flag['key']: flag}, SEGMENTS: {segment['key']: segment}})
     segstore = MockBigSegmentStore()
     segstore.setup_metadata_always_up_to_date()
-    segstore.setup_membership(_hash_for_user_key(user['key']), { _make_big_segment_ref(segment): True })
-    config=Config(
-        sdk_key='SDK_KEY',
-        feature_store=store,
-        big_segments=BigSegmentsConfig(store=segstore),
-        event_processor_class=MockEventProcessor,
-        update_processor_class=MockUpdateProcessor
-    )
+    segstore.setup_membership(_hash_for_user_key(user['key']), {_make_big_segment_ref(segment): True})
+    config = Config(sdk_key='SDK_KEY', feature_store=store, big_segments=BigSegmentsConfig(store=segstore), event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor)
     with LDClient(config) as client:
         detail = client.variation_detail(flag['key'], user, False)
         assert detail.value == True
@@ -188,15 +167,15 @@ def test_flag_using_big_segment():
 
 def test_all_flags_returns_values():
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
+    store.init({FEATURES: {'key1': flag1, 'key2': flag2}})
     client = make_client(store)
     result = client.all_flags_state(user).to_values_map()
-    assert result == { 'key1': 'value1', 'key2': 'value2' }
+    assert result == {'key1': 'value1', 'key2': 'value2'}
 
 
 def test_all_flags_returns_none_if_user_has_no_key():
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
+    store.init({FEATURES: {'key1': flag1, 'key2': flag2}})
     client = make_client(store)
     result = client.all_flags_state(Context.from_dict({}))
     assert not result.valid
@@ -205,14 +184,14 @@ def test_all_flags_returns_none_if_user_has_no_key():
 def test_all_flags_returns_none_if_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
-    assert not client.all_flags_state(Context.from_dict({ "key": "user", "kind": "user" })).valid
+    assert not client.all_flags_state(Context.from_dict({"key": "user", "kind": "user"})).valid
     errlog = get_log_lines(caplog, 'ERROR')
-    assert errlog == [ 'Unable to read flags for all_flag_state: NotImplementedError()' ]
+    assert errlog == ['Unable to read flags for all_flag_state: NotImplementedError()']
 
 
 def test_all_flags_state_returns_state():
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
+    store.init({FEATURES: {'key1': flag1, 'key2': flag2}})
     client = make_client(store)
     state = client.all_flags_state(user)
     assert state.valid
@@ -220,19 +199,8 @@ def test_all_flags_state_returns_state():
     assert result == {
         'key1': 'value1',
         'key2': 'value2',
-        '$flagsState': {
-            'key1': {
-                'variation': 0,
-                'version': 100
-            },
-            'key2': {
-                'variation': 1,
-                'version': 200,
-                'trackEvents': True,
-                'debugEventsUntilDate': 1000
-            }
-        },
-        '$valid': True
+        '$flagsState': {'key1': {'variation': 0, 'version': 100}, 'key2': {'variation': 1, 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000}},
+        '$valid': True,
     }
 
 
@@ -247,10 +215,7 @@ def test_all_flags_state_only_includes_top_level_prereqs():
                     'on': True,
                     'fallthrough': {'variation': 0},
                     'variations': ['value'],
-                    'prerequisites': [
-                        {'key': 'prereq1', 'variation': 0},
-                        {'key': 'prereq2', 'variation': 0}
-                    ],
+                    'prerequisites': [{'key': 'prereq1', 'variation': 0}, {'key': 'prereq2', 'variation': 0}],
                 },
                 'top-level-has-prereqs-2': {
                     'key': 'top-level-has-prereqs-2',
@@ -258,9 +223,7 @@ def test_all_flags_state_only_includes_top_level_prereqs():
                     'on': True,
                     'fallthrough': {'variation': 0},
                     'variations': ['value'],
-                    'prerequisites': [
-                        {'key': 'prereq3', 'variation': 0}
-                    ],
+                    'prerequisites': [{'key': 'prereq3', 'variation': 0}],
                 },
                 'prereq1': {
                     'key': 'prereq1',
@@ -297,27 +260,19 @@ def test_all_flags_state_only_includes_top_level_prereqs():
         'prereq2': 'value',
         'prereq3': 'value',
         '$flagsState': {
-            'top-level-has-prereqs-1': {
-                'variation': 0,
-                'version': 100,
-                'prerequisites': ['prereq1', 'prereq2']
-            },
-            'top-level-has-prereqs-2': {
-                'variation': 0,
-                'version': 100,
-                'prerequisites': ['prereq3']
-            },
+            'top-level-has-prereqs-1': {'variation': 0, 'version': 100, 'prerequisites': ['prereq1', 'prereq2']},
+            'top-level-has-prereqs-2': {'variation': 0, 'version': 100, 'prerequisites': ['prereq3']},
             'prereq1': {'variation': 0, 'version': 200},
             'prereq2': {'variation': 0, 'version': 200},
             'prereq3': {'variation': 0, 'version': 200},
         },
-        '$valid': True
+        '$valid': True,
     }
 
 
 def test_all_flags_state_returns_state_with_reasons():
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
+    store.init({FEATURES: {'key1': flag1, 'key2': flag2}})
     client = make_client(store)
     state = client.all_flags_state(user, with_reasons=True)
     assert state.valid
@@ -326,101 +281,36 @@ def test_all_flags_state_returns_state_with_reasons():
         'key1': 'value1',
         'key2': 'value2',
         '$flagsState': {
-            'key1': {
-                'variation': 0,
-                'version': 100,
-                'reason': {'kind': 'OFF'}
-            },
-            'key2': {
-                'variation': 1,
-                'version': 200,
-                'trackEvents': True,
-                'debugEventsUntilDate': 1000,
-                'reason': {'kind': 'OFF'}
-            }
+            'key1': {'variation': 0, 'version': 100, 'reason': {'kind': 'OFF'}},
+            'key2': {'variation': 1, 'version': 200, 'trackEvents': True, 'debugEventsUntilDate': 1000, 'reason': {'kind': 'OFF'}},
         },
-        '$valid': True
+        '$valid': True,
     }
 
 
 def test_all_flags_state_can_be_filtered_for_client_side_flags():
-    flag1 = {
-        'key': 'server-side-1',
-        'on': False,
-        'offVariation': 0,
-        'variations': [ 'a' ],
-        'clientSide': False,
-        'version': 100,
-        'trackEvents': False
-    }
-    flag2 = {
-        'key': 'server-side-2',
-        'on': False,
-        'offVariation': 0,
-        'variations': [ 'b' ],
-        'clientSide': False,
-        'version': 200,
-        'trackEvents': False
-    }
-    flag3 = {
-        'key': 'client-side-1',
-        'on': False,
-        'offVariation': 0,
-        'variations': [ 'value1' ],
-        'trackEvents': False,
-        'clientSide': True,
-        'version': 300,
-        'trackEvents': False
-    }
-    flag4 = {
-        'key': 'client-side-2',
-        'on': False,
-        'offVariation': 0,
-        'variations': [ 'value2' ],
-        'clientSide': True,
-        'version': 400,
-        'trackEvents': False
-    }
+    flag1 = {'key': 'server-side-1', 'on': False, 'offVariation': 0, 'variations': ['a'], 'clientSide': False, 'version': 100, 'trackEvents': False}
+    flag2 = {'key': 'server-side-2', 'on': False, 'offVariation': 0, 'variations': ['b'], 'clientSide': False, 'version': 200, 'trackEvents': False}
+    flag3 = {'key': 'client-side-1', 'on': False, 'offVariation': 0, 'variations': ['value1'], 'trackEvents': False, 'clientSide': True, 'version': 300, 'trackEvents': False}
+    flag4 = {'key': 'client-side-2', 'on': False, 'offVariation': 0, 'variations': ['value2'], 'clientSide': True, 'version': 400, 'trackEvents': False}
 
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { flag1['key']: flag1, flag2['key']: flag2, flag3['key']: flag3, flag4['key']: flag4 } })
+    store.init({FEATURES: {flag1['key']: flag1, flag2['key']: flag2, flag3['key']: flag3, flag4['key']: flag4}})
     client = make_client(store)
 
     state = client.all_flags_state(user, client_side_only=True)
     assert state.valid
     values = state.to_values_map()
-    assert values == { 'client-side-1': 'value1', 'client-side-2': 'value2' }
+    assert values == {'client-side-1': 'value1', 'client-side-2': 'value2'}
 
 
 def test_all_flags_state_can_omit_details_for_untracked_flags():
     future_time = (time.time() * 1000) + 100000
-    flag1 = {
-        'key': 'key1',
-        'version': 100,
-        'on': False,
-        'offVariation': 0,
-        'variations': [ 'value1' ],
-        'trackEvents': False
-    }
-    flag2 = {
-        'key': 'key2',
-        'version': 200,
-        'on': False,
-        'offVariation': 1,
-        'variations': [ 'x', 'value2' ],
-        'trackEvents': True
-    }
-    flag3 = {
-        'key': 'key3',
-        'version': 300,
-        'on': False,
-        'offVariation': 1,
-        'variations': [ 'x', 'value3' ],
-        'trackEvents': False,
-        'debugEventsUntilDate': future_time
-    }
+    flag1 = {'key': 'key1', 'version': 100, 'on': False, 'offVariation': 0, 'variations': ['value1'], 'trackEvents': False}
+    flag2 = {'key': 'key2', 'version': 200, 'on': False, 'offVariation': 1, 'variations': ['x', 'value2'], 'trackEvents': True}
+    flag3 = {'key': 'key3', 'version': 300, 'on': False, 'offVariation': 1, 'variations': ['x', 'value3'], 'trackEvents': False, 'debugEventsUntilDate': future_time}
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { 'key1': flag1, 'key2': flag2, 'key3': flag3 } })
+    store.init({FEATURES: {'key1': flag1, 'key2': flag2, 'key3': flag3}})
     client = make_client(store)
     state = client.all_flags_state(user, with_reasons=True, details_only_for_tracked_flags=True)
     assert state.valid is True
@@ -430,29 +320,17 @@ def test_all_flags_state_can_omit_details_for_untracked_flags():
         'key2': 'value2',
         'key3': 'value3',
         '$flagsState': {
-            'key1': {
-                'variation': 0
-            },
-            'key2': {
-                'variation': 1,
-                'version': 200,
-                'trackEvents': True,
-                'reason': {'kind': 'OFF'}
-            },
-            'key3': {
-                'variation': 1,
-                'version': 300,
-                'debugEventsUntilDate': future_time,
-                'reason': {'kind': 'OFF'}
-            }
+            'key1': {'variation': 0},
+            'key2': {'variation': 1, 'version': 200, 'trackEvents': True, 'reason': {'kind': 'OFF'}},
+            'key3': {'variation': 1, 'version': 300, 'debugEventsUntilDate': future_time, 'reason': {'kind': 'OFF'}},
         },
-        '$valid': True
+        '$valid': True,
     }
 
 
 def test_all_flags_state_returns_empty_state_if_user_has_no_key():
     store = InMemoryFeatureStore()
-    store.init({ FEATURES: { 'key1': flag1, 'key2': flag2 } })
+    store.init({FEATURES: {'key1': flag1, 'key2': flag2}})
     client = make_client(store)
     state = client.all_flags_state(Context.from_dict({}))
     assert state.valid == False
@@ -461,7 +339,7 @@ def test_all_flags_state_returns_empty_state_if_user_has_no_key():
 def test_all_flags_returns_empty_state_if_feature_store_throws_error(caplog):
     store = ErroringFeatureStore()
     client = make_client(store)
-    state = client.all_flags_state(Context.from_dict({ "key": "user", "kind": "user" }))
+    state = client.all_flags_state(Context.from_dict({"key": "user", "kind": "user"}))
     assert state.valid == False
     errlog = get_log_lines(caplog, 'ERROR')
-    assert errlog == [ 'Unable to read flags for all_flag_state: NotImplementedError()' ]
+    assert errlog == ['Unable to read flags for all_flag_state: NotImplementedError()']

--- a/ldclient/testing/test_ldclient_events.py
+++ b/ldclient/testing/test_ldclient_events.py
@@ -1,16 +1,19 @@
-from ldclient.client import LDClient, Config, Context
+from ldclient.client import Config, Context, LDClient
 from ldclient.evaluation import EvaluationDetail
-from ldclient.impl.events.event_processor import DefaultEventProcessor
 from ldclient.feature_store import InMemoryFeatureStore
-from ldclient.impl.events.types import EventInputCustom, EventInputEvaluation, EventInputIdentify
-from ldclient.migrations.tracker import MigrationOpEvent
+from ldclient.impl.events.event_processor import DefaultEventProcessor
+from ldclient.impl.events.types import (EventInputCustom, EventInputEvaluation,
+                                        EventInputIdentify)
 from ldclient.impl.stubs import NullEventProcessor
-from ldclient.versioned_data_kind import FEATURES
-from ldclient.migrations import OpTracker, Stage, Operation, Origin
-
+from ldclient.migrations import Operation, OpTracker, Origin, Stage
+from ldclient.migrations.tracker import MigrationOpEvent
 from ldclient.testing.builders import *
 from ldclient.testing.stub_util import MockUpdateProcessor
-from ldclient.testing.test_ldclient import context, make_client, make_ldd_client, make_offline_client, unreachable_uri, user
+from ldclient.testing.test_ldclient import (context, make_client,
+                                            make_ldd_client,
+                                            make_offline_client,
+                                            unreachable_uri, user)
+from ldclient.versioned_data_kind import FEATURES
 
 
 def get_first_event(c):

--- a/ldclient/testing/test_ldclient_events.py
+++ b/ldclient/testing/test_ldclient_events.py
@@ -31,8 +31,7 @@ def test_client_has_null_event_processor_if_offline():
 
 
 def test_client_has_null_event_processor_if_send_events_off():
-    config = Config(sdk_key="secret", base_uri=unreachable_uri,
-                    update_processor_class = MockUpdateProcessor, send_events=False)
+    config = Config(sdk_key="secret", base_uri=unreachable_uri, update_processor_class=MockUpdateProcessor, send_events=False)
     with LDClient(config=config) as client:
         assert isinstance(client._event_processor, NullEventProcessor)
 
@@ -60,7 +59,7 @@ def test_identify_with_user_dict():
 
 def test_identify_no_user_key():
     with make_client() as client:
-        client.identify(Context.from_dict({ 'kind': 'user', 'name': 'nokey' }))
+        client.identify(Context.from_dict({'kind': 'user', 'name': 'nokey'}))
         assert count_events(client) == 0
 
 
@@ -95,8 +94,7 @@ def test_does_not_send_bad_event():
 
     with make_client() as client:
         client.track_migration_op(tracker)
-        client.identify(context) # Emit this to ensure events are working
-
+        client.identify(context)  # Emit this to ensure events are working
 
         # This is only identify if the op tracker fails to build
         e = get_first_event(client)
@@ -161,14 +159,16 @@ def test_event_for_existing_feature():
         assert 'value' == client.variation(feature.key, context, default='default')
         e = get_first_event(client)
         assert isinstance(e, EventInputEvaluation)
-        assert (e.key == feature.key and
-            e.flag == feature and
-            e.context == context and
-            e.value == 'value' and
-            e.variation == 0 and
-            e.reason is None and
-            e.default_value == 'default' and
-            e.track_events is True)
+        assert (
+            e.key == feature.key
+            and e.flag == feature
+            and e.context == context
+            and e.value == 'value'
+            and e.variation == 0
+            and e.reason is None
+            and e.default_value == 'default'
+            and e.track_events is True
+        )
 
 
 def test_event_for_existing_feature_with_reason():
@@ -179,88 +179,89 @@ def test_event_for_existing_feature_with_reason():
         assert 'value' == client.variation_detail(feature.key, context, default='default').value
         e = get_first_event(client)
         assert isinstance(e, EventInputEvaluation)
-        assert (e.key == feature.key and
-            e.flag == feature and
-            e.context == context and
-            e.value == 'value' and
-            e.variation == 0 and
-            e.reason == {'kind': 'OFF'} and
-            e.default_value == 'default' and
-            e.track_events is True)
+        assert (
+            e.key == feature.key
+            and e.flag == feature
+            and e.context == context
+            and e.value == 'value'
+            and e.variation == 0
+            and e.reason == {'kind': 'OFF'}
+            and e.default_value == 'default'
+            and e.track_events is True
+        )
 
 
 def test_event_for_existing_feature_with_tracked_rule():
-    feature = FlagBuilder('feature.key').version(100).on(True).variations('value') \
-        .rules(
-            FlagRuleBuilder().variation(0).id('rule_id').track_events(True) \
-                .clauses(make_clause(None, 'key', 'in', user['key'])) \
-                .build()
-        ) \
+    feature = (
+        FlagBuilder('feature.key')
+        .version(100)
+        .on(True)
+        .variations('value')
+        .rules(FlagRuleBuilder().variation(0).id('rule_id').track_events(True).clauses(make_clause(None, 'key', 'in', user['key'])).build())
         .build()
+    )
     store = InMemoryFeatureStore()
     store.init({FEATURES: {feature.key: feature.to_json_dict()}})
     client = make_client(store)
     assert 'value' == client.variation(feature.key, context, default='default')
     e = get_first_event(client)
     assert isinstance(e, EventInputEvaluation)
-    assert (e.key == feature.key and
-        e.flag == feature and
-        e.context == context and
-        e.value == 'value' and
-        e.variation == 0 and
-        e.reason == { 'kind': 'RULE_MATCH', 'ruleIndex': 0, 'ruleId': 'rule_id' } and
-        e.default_value == 'default' and
-        e.track_events is True)
+    assert (
+        e.key == feature.key
+        and e.flag == feature
+        and e.context == context
+        and e.value == 'value'
+        and e.variation == 0
+        and e.reason == {'kind': 'RULE_MATCH', 'ruleIndex': 0, 'ruleId': 'rule_id'}
+        and e.default_value == 'default'
+        and e.track_events is True
+    )
 
 
 def test_event_for_existing_feature_with_untracked_rule():
-    feature = FlagBuilder('feature.key').version(100).on(True).variations('value') \
-        .rules(
-            FlagRuleBuilder().variation(0).id('rule_id') \
-                .clauses(make_clause(None, 'key', 'in', user['key'])) \
-                .build()
-        ) \
-        .build()
+    feature = (
+        FlagBuilder('feature.key').version(100).on(True).variations('value').rules(FlagRuleBuilder().variation(0).id('rule_id').clauses(make_clause(None, 'key', 'in', user['key'])).build()).build()
+    )
     store = InMemoryFeatureStore()
     store.init({FEATURES: {feature.key: feature.to_json_dict()}})
     client = make_client(store)
     assert 'value' == client.variation(feature.key, context, default='default')
     e = get_first_event(client)
     assert isinstance(e, EventInputEvaluation)
-    assert (e.key == feature.key and
-        e.flag == feature and
-        e.context == context and
-        e.value == 'value' and
-        e.variation == 0 and
-        e.reason is None and
-        e.default_value == 'default' and
-        e.track_events is False)
+    assert (
+        e.key == feature.key
+        and e.flag == feature
+        and e.context == context
+        and e.value == 'value'
+        and e.variation == 0
+        and e.reason is None
+        and e.default_value == 'default'
+        and e.track_events is False
+    )
 
 
 def test_event_for_existing_feature_with_tracked_fallthrough():
-    feature = FlagBuilder('feature.key').version(100).on(True).variations('value') \
-        .fallthrough_variation(0).track_events_fallthrough(True) \
-        .build()
+    feature = FlagBuilder('feature.key').version(100).on(True).variations('value').fallthrough_variation(0).track_events_fallthrough(True).build()
     store = InMemoryFeatureStore()
     store.init({FEATURES: {feature.key: feature.to_json_dict()}})
     client = make_client(store)
     assert 'value' == client.variation(feature.key, context, default='default')
     e = get_first_event(client)
     assert isinstance(e, EventInputEvaluation)
-    assert (e.key == feature.key and
-        e.flag == feature and
-        e.context == context and
-        e.value == 'value' and
-        e.variation == 0 and
-        e.reason == { 'kind': 'FALLTHROUGH' } and
-        e.default_value == 'default' and
-        e.track_events is True)
+    assert (
+        e.key == feature.key
+        and e.flag == feature
+        and e.context == context
+        and e.value == 'value'
+        and e.variation == 0
+        and e.reason == {'kind': 'FALLTHROUGH'}
+        and e.default_value == 'default'
+        and e.track_events is True
+    )
 
 
 def test_event_for_existing_feature_with_untracked_fallthrough():
-    feature = FlagBuilder('feature.key').version(100).on(True).variations('value') \
-        .fallthrough_variation(0) \
-        .build()
+    feature = FlagBuilder('feature.key').version(100).on(True).variations('value').fallthrough_variation(0).build()
     store = InMemoryFeatureStore()
     store.init({FEATURES: {feature.key: feature.to_json_dict()}})
     client = make_client(store)
@@ -268,14 +269,16 @@ def test_event_for_existing_feature_with_untracked_fallthrough():
     assert 'value' == detail.value
     e = get_first_event(client)
     assert isinstance(e, EventInputEvaluation)
-    assert (e.key == feature.key and
-        e.flag == feature and
-        e.context == context and
-        e.value == 'value' and
-        e.variation == 0 and
-        e.reason == { 'kind': 'FALLTHROUGH' } and
-        e.default_value == 'default' and
-        e.track_events is False)
+    assert (
+        e.key == feature.key
+        and e.flag == feature
+        and e.context == context
+        and e.value == 'value'
+        and e.variation == 0
+        and e.reason == {'kind': 'FALLTHROUGH'}
+        and e.default_value == 'default'
+        and e.track_events is False
+    )
 
 
 def test_event_for_unknown_feature():
@@ -285,14 +288,16 @@ def test_event_for_unknown_feature():
         assert 'default' == client.variation('feature.key', context, default='default')
         e = get_first_event(client)
         assert isinstance(e, EventInputEvaluation)
-        assert (e.key == 'feature.key' and
-            e.flag is None and
-            e.context == context and
-            e.value == 'default' and
-            e.variation is None and
-            e.reason is None and
-            e.default_value == 'default' and
-            e.track_events is False)
+        assert (
+            e.key == 'feature.key'
+            and e.flag is None
+            and e.context == context
+            and e.value == 'default'
+            and e.variation is None
+            and e.reason is None
+            and e.default_value == 'default'
+            and e.track_events is False
+        )
 
 
 def test_no_event_for_existing_feature_with_invalid_context():

--- a/ldclient/testing/test_ldclient_hooks.py
+++ b/ldclient/testing/test_ldclient_hooks.py
@@ -126,7 +126,7 @@ def test_exceptions_do_not_affect_data_passing_order():
     # NOTE: These are reversed since the push happens in the after_evaluation
     # (when hooks are reversed)
     assert calls[0] == "third hook"
-    assert calls[1] ==  {}
+    assert calls[1] == {}
     assert calls[2] == "first hook"
 
 

--- a/ldclient/testing/test_ldclient_hooks.py
+++ b/ldclient/testing/test_ldclient_hooks.py
@@ -1,10 +1,10 @@
-from ldclient.evaluation import EvaluationDetail
-from ldclient import LDClient, Config, Context
-from ldclient.hook import Hook, Metadata, EvaluationSeriesContext
-from ldclient.migrations import Stage
-from ldclient.integrations.test_data import TestData
-
 from typing import Callable
+
+from ldclient import Config, Context, LDClient
+from ldclient.evaluation import EvaluationDetail
+from ldclient.hook import EvaluationSeriesContext, Hook, Metadata
+from ldclient.integrations.test_data import TestData
+from ldclient.migrations import Stage
 
 
 def record(label, log):

--- a/ldclient/testing/test_ldclient_listeners.py
+++ b/ldclient/testing/test_ldclient_listeners.py
@@ -1,11 +1,13 @@
-from ldclient.client import LDClient, Config
-from ldclient.interfaces import DataSourceState
-from ldclient.config import BigSegmentsConfig
-from ldclient.testing.mock_components import MockBigSegmentStore
-from ldclient.testing.stub_util import MockEventProcessor, MockUpdateProcessor, make_put_event, stream_content
-from ldclient.testing.http_util import start_server
-
 from queue import Queue
+
+from ldclient.client import Config, LDClient
+from ldclient.config import BigSegmentsConfig
+from ldclient.interfaces import DataSourceState
+from ldclient.testing.http_util import start_server
+from ldclient.testing.mock_components import MockBigSegmentStore
+from ldclient.testing.stub_util import (MockEventProcessor,
+                                        MockUpdateProcessor, make_put_event,
+                                        stream_content)
 
 
 def test_big_segment_store_status_unavailable():

--- a/ldclient/testing/test_ldclient_listeners.py
+++ b/ldclient/testing/test_ldclient_listeners.py
@@ -11,7 +11,7 @@ from queue import Queue
 def test_big_segment_store_status_unavailable():
     config = Config(sdk_key='SDK_KEY', event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor)
     client = LDClient(config)
-    assert client.big_segment_store_status_provider.status.available == False
+    assert client.big_segment_store_status_provider.status.available is False
 
 
 def test_big_segment_store_status_updates():
@@ -24,21 +24,21 @@ def test_big_segment_store_status_updates():
         client.big_segment_store_status_provider.add_listener(lambda status: statuses.put(status))
 
         status1 = client.big_segment_store_status_provider.status
-        assert status1.available == True
-        assert status1.stale == False
+        assert status1.available is True
+        assert status1.stale is False
 
         segstore.setup_metadata_always_stale()
 
         status2 = statuses.get(True, 1.0)
-        assert status2.available == True
-        assert status2.stale == True
+        assert status2.available is True
+        assert status2.stale is True
 
         segstore.setup_metadata_always_up_to_date()
 
         status3 = statuses.get(True, 1.0)
-        assert status3.available == True
-        assert status3.stale == False
-        assert client.big_segment_store_status_provider.status.available == True
+        assert status3.available is True
+        assert status3.stale is False
+        assert client.big_segment_store_status_provider.status.available is True
 
 
 def test_data_source_status_default():

--- a/ldclient/testing/test_ldclient_listeners.py
+++ b/ldclient/testing/test_ldclient_listeners.py
@@ -9,11 +9,7 @@ from queue import Queue
 
 
 def test_big_segment_store_status_unavailable():
-    config=Config(
-        sdk_key='SDK_KEY',
-        event_processor_class=MockEventProcessor,
-        update_processor_class=MockUpdateProcessor
-    )
+    config = Config(sdk_key='SDK_KEY', event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor)
     client = LDClient(config)
     assert client.big_segment_store_status_provider.status.available == False
 
@@ -21,12 +17,7 @@ def test_big_segment_store_status_unavailable():
 def test_big_segment_store_status_updates():
     segstore = MockBigSegmentStore()
     segstore.setup_metadata_always_up_to_date()
-    config=Config(
-        sdk_key='SDK_KEY',
-        big_segments=BigSegmentsConfig(store=segstore, status_poll_interval=0.01),
-        event_processor_class=MockEventProcessor,
-        update_processor_class=MockUpdateProcessor
-    )
+    config = Config(sdk_key='SDK_KEY', big_segments=BigSegmentsConfig(store=segstore, status_poll_interval=0.01), event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor)
     statuses = Queue()
 
     with LDClient(config) as client:
@@ -51,11 +42,7 @@ def test_big_segment_store_status_updates():
 
 
 def test_data_source_status_default():
-    config=Config(
-        sdk_key='SDK_KEY',
-        event_processor_class=MockEventProcessor,
-        update_processor_class=MockUpdateProcessor
-    )
+    config = Config(sdk_key='SDK_KEY', event_processor_class=MockEventProcessor, update_processor_class=MockUpdateProcessor)
     client = LDClient(config)
     assert client.data_source_status_provider.status.state == DataSourceState.INITIALIZING
 

--- a/ldclient/testing/test_ldclient_listeners.py
+++ b/ldclient/testing/test_ldclient_listeners.py
@@ -17,6 +17,7 @@ def test_big_segment_store_status_unavailable():
     client = LDClient(config)
     assert client.big_segment_store_status_provider.status.available == False
 
+
 def test_big_segment_store_status_updates():
     segstore = MockBigSegmentStore()
     segstore.setup_metadata_always_up_to_date()

--- a/ldclient/testing/test_ldclient_migration_variation.py
+++ b/ldclient/testing/test_ldclient_migration_variation.py
@@ -1,10 +1,10 @@
 import pytest
-from ldclient.feature_store import InMemoryFeatureStore
-from ldclient.versioned_data_kind import FEATURES
-from ldclient.migrations import Stage, Operation, Origin
 
+from ldclient.feature_store import InMemoryFeatureStore
+from ldclient.migrations import Operation, Origin, Stage
 from ldclient.testing.builders import FlagBuilder
 from ldclient.testing.test_ldclient import make_client, user
+from ldclient.versioned_data_kind import FEATURES
 
 
 def test_uses_default_if_flag_not_found():

--- a/ldclient/testing/test_ldclient_singleton.py
+++ b/ldclient/testing/test_ldclient_singleton.py
@@ -11,6 +11,7 @@ sdk_key = 'sdk-key'
 # These are end-to-end tests like test_ldclient_end_to_end, but less detailed in terms of the client's
 # network behavior because what we're really testing is the singleton mechanism.
 
+
 def test_set_sdk_key_before_init():
     _reset_client()
     with start_server() as stream_server:
@@ -25,6 +26,7 @@ def test_set_sdk_key_before_init():
                 assert r.headers['Authorization'] == sdk_key
             finally:
                 _reset_client()
+
 
 def test_set_sdk_key_after_init():
     _reset_client()
@@ -50,6 +52,7 @@ def test_set_sdk_key_after_init():
                 assert r.headers['Authorization'] == sdk_key
             finally:
                 _reset_client()
+
 
 def test_set_config():
     _reset_client()

--- a/ldclient/testing/test_ldclient_singleton.py
+++ b/ldclient/testing/test_ldclient_singleton.py
@@ -1,10 +1,11 @@
+import json
+
 import ldclient
 from ldclient import _reset_client
 from ldclient.config import Config
-from ldclient.testing.http_util import start_server, BasicResponse
+from ldclient.testing.http_util import BasicResponse, start_server
 from ldclient.testing.stub_util import make_put_event, stream_content
 from ldclient.testing.sync_util import wait_until
-import json
 
 sdk_key = 'sdk-key'
 

--- a/ldclient/testing/test_ldclient_singleton.py
+++ b/ldclient/testing/test_ldclient_singleton.py
@@ -19,7 +19,7 @@ def test_set_sdk_key_before_init():
             try:
                 stream_server.for_path('/all', stream_handler)
 
-                ldclient.set_config(Config(sdk_key, stream_uri = stream_server.uri, send_events = False))
+                ldclient.set_config(Config(sdk_key, stream_uri=stream_server.uri, send_events=False))
                 wait_until(ldclient.get().is_initialized, timeout=10)
 
                 r = stream_server.await_request()
@@ -36,7 +36,7 @@ def test_set_sdk_key_after_init():
             try:
                 stream_server.for_path('/all', BasicResponse(401))
 
-                config = Config(other_key, stream_uri = stream_server.uri, send_events = False)
+                config = Config(other_key, stream_uri=stream_server.uri, send_events=False)
                 ldclient.set_config(config)
                 assert ldclient.get().is_initialized() is False
 
@@ -64,7 +64,7 @@ def test_set_config():
                 ldclient.set_config(Config(sdk_key, offline=True))
                 assert ldclient.get().is_offline() is True
 
-                ldclient.set_config(Config(sdk_key, stream_uri = stream_server.uri, send_events = False))
+                ldclient.set_config(Config(sdk_key, stream_uri=stream_server.uri, send_events=False))
                 assert ldclient.get().is_offline() is False
                 wait_until(ldclient.get().is_initialized, timeout=10)
 

--- a/ldclient/testing/test_util.py
+++ b/ldclient/testing/test_util.py
@@ -4,6 +4,7 @@ import os
 
 skip_database_tests = os.environ.get('LD_SKIP_DATABASE_TESTS') == '1'
 
+
 @pytest.fixture(params = [
     ("rediss://user:password=@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED", "rediss://user:xxxx@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED"),
     ("rediss://user-matches-password:user-matches-password@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED", "rediss://xxxx:xxxx@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED"),
@@ -12,6 +13,7 @@ skip_database_tests = os.environ.get('LD_SKIP_DATABASE_TESTS') == '1'
 ])
 def password_redaction_tests(request):
     return request.param
+
 
 def test_can_redact_password(password_redaction_tests):
     input, expected = password_redaction_tests

--- a/ldclient/testing/test_util.py
+++ b/ldclient/testing/test_util.py
@@ -5,12 +5,14 @@ import os
 skip_database_tests = os.environ.get('LD_SKIP_DATABASE_TESTS') == '1'
 
 
-@pytest.fixture(params = [
-    ("rediss://user:password=@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED", "rediss://user:xxxx@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED"),
-    ("rediss://user-matches-password:user-matches-password@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED", "rediss://xxxx:xxxx@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED"),
-    ("rediss://redis-server-url", "rediss://redis-server-url"),
-    ("invalid urls are left alone", "invalid urls are left alone"),
-])
+@pytest.fixture(
+    params=[
+        ("rediss://user:password=@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED", "rediss://user:xxxx@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED"),
+        ("rediss://user-matches-password:user-matches-password@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED", "rediss://xxxx:xxxx@redis-server-url:6380/0?ssl_cert_reqs=CERT_REQUIRED"),
+        ("rediss://redis-server-url", "rediss://redis-server-url"),
+        ("invalid urls are left alone", "invalid urls are left alone"),
+    ]
+)
 def password_redaction_tests(request):
     return request.param
 

--- a/ldclient/testing/test_util.py
+++ b/ldclient/testing/test_util.py
@@ -1,6 +1,8 @@
-from ldclient.impl.util import redact_password
-import pytest
 import os
+
+import pytest
+
+from ldclient.impl.util import redact_password
 
 skip_database_tests = os.environ.get('LD_SKIP_DATABASE_TESTS') == '1'
 

--- a/ldclient/version.py
+++ b/ldclient/version.py
@@ -1,1 +1,1 @@
-VERSION = "9.8.0" # x-release-please-version
+VERSION = "9.8.0"  # x-release-please-version

--- a/ldclient/versioned_data_kind.py
+++ b/ldclient/versioned_data_kind.py
@@ -18,8 +18,7 @@ from typing import Any, Callable, Iterable, Optional
 # Note that VersionedDataKind without the extra attributes is no longer used in the SDK,
 # but it's preserved here for backward compatibility just in case someone else used it
 class VersionedDataKind:
-    def __init__(self, namespace: str, request_api_path: str, stream_api_path: str,
-        decoder: Optional[Callable[[dict], Any]] = None):
+    def __init__(self, namespace: str, request_api_path: str, stream_api_path: str, decoder: Optional[Callable[[dict], Any]] = None):
         self._namespace = namespace
         self._request_api_path = request_api_path
         self._stream_api_path = stream_api_path
@@ -47,9 +46,9 @@ class VersionedDataKind:
 
 
 class VersionedDataKindWithOrdering(VersionedDataKind):
-    def __init__(self, namespace: str, request_api_path: str, stream_api_path: str,
-                 decoder: Optional[Callable[[dict], Any]],
-                 priority: int, get_dependency_keys: Optional[Callable[[dict], Iterable[str]]]):
+    def __init__(
+        self, namespace: str, request_api_path: str, stream_api_path: str, decoder: Optional[Callable[[dict], Any]], priority: int, get_dependency_keys: Optional[Callable[[dict], Iterable[str]]]
+    ):
         super().__init__(namespace, request_api_path, stream_api_path, decoder)
         self._priority = priority
         self._get_dependency_keys = get_dependency_keys
@@ -62,16 +61,14 @@ class VersionedDataKindWithOrdering(VersionedDataKind):
     def get_dependency_keys(self) -> Optional[Callable[[dict], Iterable[str]]]:
         return self._get_dependency_keys
 
-FEATURES = VersionedDataKindWithOrdering(namespace = "features",
-    request_api_path = "/sdk/latest-flags",
-    stream_api_path = "/flags/",
-    decoder = FeatureFlag,
-    priority = 1,
-    get_dependency_keys = lambda flag: (p.get('key') for p in flag.get('prerequisites', [])))
 
-SEGMENTS = VersionedDataKindWithOrdering(namespace = "segments",
-    request_api_path = "/sdk/latest-segments",
-    stream_api_path = "/segments/",
-    decoder = Segment,
-    priority = 0,
-    get_dependency_keys = None)
+FEATURES = VersionedDataKindWithOrdering(
+    namespace="features",
+    request_api_path="/sdk/latest-flags",
+    stream_api_path="/flags/",
+    decoder=FeatureFlag,
+    priority=1,
+    get_dependency_keys=lambda flag: (p.get('key') for p in flag.get('prerequisites', [])),
+)
+
+SEGMENTS = VersionedDataKindWithOrdering(namespace="segments", request_api_path="/sdk/latest-segments", stream_api_path="/segments/", decoder=Segment, priority=0, get_dependency_keys=None)

--- a/ldclient/versioned_data_kind.py
+++ b/ldclient/versioned_data_kind.py
@@ -14,6 +14,7 @@ from ldclient.impl.model import FeatureFlag, ModelEntity, Segment
 from collections import namedtuple
 from typing import Any, Callable, Iterable, Optional
 
+
 # Note that VersionedDataKind without the extra attributes is no longer used in the SDK,
 # but it's preserved here for backward compatibility just in case someone else used it
 class VersionedDataKind:
@@ -43,6 +44,7 @@ class VersionedDataKind:
 
     def encode(self, item: Any) -> dict:
         return item.to_json_dict() if isinstance(item, ModelEntity) else item
+
 
 class VersionedDataKindWithOrdering(VersionedDataKind):
     def __init__(self, namespace: str, request_api_path: str, stream_api_path: str,

--- a/ldclient/versioned_data_kind.py
+++ b/ldclient/versioned_data_kind.py
@@ -9,10 +9,10 @@ storable objects as completely generic JSON dictionaries, rather than having any
 for features or segments.
 """
 
-from ldclient.impl.model import FeatureFlag, ModelEntity, Segment
-
 from collections import namedtuple
 from typing import Any, Callable, Iterable, Optional
+
+from ldclient.impl.model import FeatureFlag, ModelEntity, Segment
 
 
 # Note that VersionedDataKind without the extra attributes is no longer used in the SDK,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ pytest-cov = ">=2.4.0"
 pytest-mypy = "==0.10.3"
 mypy = "==1.8.0"
 pycodestyle = "^2.12.1"
+isort = "^5.13.2"
 
 
 [tool.poetry.group.contract-tests]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ jsonpickle = ">1.4.1"
 pytest-cov = ">=2.4.0"
 pytest-mypy = "==0.10.3"
 mypy = "==1.8.0"
+pycodestyle = "^2.12.1"
 
 
 [tool.poetry.group.contract-tests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [pycodestyle]
-ignore = E252,E501
+ignore = E252,E501,W503


### PR DESCRIPTION
This commit introduces both pycodestyle and isort tooling to the CI check
pipeline. These tools ensure a consistent code style and import order across
the codebase.

The commit also includes a number of fixes to the codebase to ensure it passes
the new checks. Most of these were automated through the use of the CLI tool
`black`. The rest were fixed manually.
