### PR TITLE
chore: Drop python 3.8 test support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,13 @@ name: Quality control checks
 
 on:
   push:
-    branches: [ main, 'feat/**' ]
+    branches: [main, "feat/**"]
     paths-ignore:
-      - '**.md' # Do not need to run CI for markdown changes.
+      - "**.md" # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ main, 'feat/**' ]
+    branches: [main, "feat/**"]
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
   linux:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     services:
       redis:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Is this a dry run? If so no package will be published.'
+        description: "Is this a dry run? If so no package will be published."
         type: boolean
         required: true
 
@@ -21,16 +21,16 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install poetry
         uses: abatilo/actions-poetry@7b6d33e44b4f08d7021a1dee3c044e9c253d6439
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
-        name: 'Get PyPI token'
+        name: "Get PyPI token"
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN'
+          ssm_parameter_pairs: "/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN"
 
       - uses: ./.github/actions/build
         id: build
@@ -42,7 +42,7 @@ jobs:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
   release-provenance:
-    needs: [ 'build-publish' ]
+    needs: ["build-publish"]
     permissions:
       actions: read
       id-token: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ name: Run Release Please
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   release-package:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install poetry
         if: ${{ steps.release.outputs.releases_created == 'true' }}
@@ -35,10 +35,10 @@ jobs:
 
       - uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        name: 'Get PyPI token'
+        name: "Get PyPI token"
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN'
+          ssm_parameter_pairs: "/production/common/releasing/pypi/token = PYPI_AUTH_TOKEN"
 
       - uses: ./.github/actions/build
         id: build
@@ -54,7 +54,7 @@ jobs:
           password: ${{env.PYPI_AUTH_TOKEN}}
 
   release-provenance:
-    needs: [ 'release-package' ]
+    needs: ["release-package"]
     if: ${{ needs.release-package.outputs.release-created == 'true' }}
     permissions:
       actions: read


### PR DESCRIPTION
Python 3.8 has been EOL since October of 2024. As a result, builds are
starting to fail because tooling support is moving on. To combat this,
we are bumping our testing to only include 3.9 or higher.
