### PR TITLE
fix: Bump pyRFC3339 >=1.0 -> >=2.1.0

### DIFF
--- a/ldclient/testing/impl/test_operators.py
+++ b/ldclient/testing/impl/test_operators.py
@@ -57,7 +57,7 @@ from ldclient.testing.builders import *
         ["before", "1970-01-01T00:00:00.500Z", 1000, True],
         ["before", True, 1000, False],  # wrong type
         ["after", "1970-01-01T00:00:02.500Z", 1000, True],
-        ["after", "1970-01-01 00:00:02.500Z", 1000, False],  # malformed timestamp
+        ["after", "1970-01-01 00:00:02.500Z", 1000, True],
         ["after", "1970-01-01T00:00:02+01:00", None, False],
         ["after", None, "1970-01-01T00:00:02+01:00", False],
         ["before", "1970-01-01T00:00:02+01:00", 1000, True],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ exclude = [
 python = ">=3.9"
 certifi = ">=2018.4.16"
 expiringdict = ">=1.1.4"
-pyRFC3339 = ">=1.0"
+pyRFC3339 = ">=2.1.0"
 semver = ">=2.10.2"
 urllib3 = ">=1.26.0,<3"
 launchdarkly-eventsource = ">=1.2.4,<2.0.0"


### PR DESCRIPTION
With the latest release, pyRFC3339 allows a more flexible format. Prior
versions required an explicit T separator before the time section even
though the spec allows for a space.

Both of these are considered valid formats:

    1970-01-01T00:00:02.500Z
    1970-01-01 00:00:02.500Z
