### PR TITLE
chore: Remove LDConfig requirement from top level DS function helpers

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -260,7 +260,7 @@ class LDClient:
 
             self._data_system: DataSystem = FDv1(self._config)
         else:
-            self._data_system = FDv2(datasystem_config, disabled=self._config.offline)
+            self._data_system = FDv2(self._config, datasystem_config)
 
         # Provide flag evaluation function for value-change tracking
         self._data_system.set_flag_value_eval_fn(  # type: ignore

--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -157,7 +157,7 @@ class HTTPConfig:
 
 T = TypeVar("T")
 
-Builder = Callable[[], T]
+Builder = Callable[['Config'], T]
 
 
 @dataclass(frozen=True)

--- a/ldclient/integrations/test_datav2.py
+++ b/ldclient/integrations/test_datav2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 from typing import Any, Dict, List, Optional, Set, Union
 
+from ldclient.config import Config
 from ldclient.context import Context
 from ldclient.impl.integrations.test_datav2.test_data_sourcev2 import (
     _TestDataSourceV2
@@ -693,7 +694,7 @@ class TestDataV2:
         finally:
             self._lock.unlock()
 
-    def build_initializer(self) -> _TestDataSourceV2:
+    def build_initializer(self, _: Config) -> _TestDataSourceV2:
         """
         Creates an initializer that can be used with the FDv2 data system.
 
@@ -701,7 +702,7 @@ class TestDataV2:
         """
         return _TestDataSourceV2(self)
 
-    def build_synchronizer(self) -> _TestDataSourceV2:
+    def build_synchronizer(self, _: Config) -> _TestDataSourceV2:
         """
         Creates a synchronizer that can be used with the FDv2 data system.
 

--- a/ldclient/testing/impl/datasystem/test_config.py
+++ b/ldclient/testing/impl/datasystem/test_config.py
@@ -126,9 +126,7 @@ def test_custom_builder():
 
 def test_default_config_builder():
     """Test that default() returns a properly configured ConfigBuilder."""
-    mock_ld_config = Mock(spec=LDConfig)
-
-    builder = default(mock_ld_config)
+    builder = default()
 
     assert isinstance(builder, ConfigBuilder)
     # The actual implementation details would be tested in integration tests
@@ -137,9 +135,7 @@ def test_default_config_builder():
 
 def test_streaming_config_builder():
     """Test that streaming() returns a properly configured ConfigBuilder."""
-    mock_ld_config = Mock(spec=LDConfig)
-
-    builder = streaming(mock_ld_config)
+    builder = streaming()
 
     assert isinstance(builder, ConfigBuilder)
     # The actual implementation details would be tested in integration tests
@@ -148,9 +144,7 @@ def test_streaming_config_builder():
 
 def test_polling_config_builder():
     """Test that polling() returns a properly configured ConfigBuilder."""
-    mock_ld_config = Mock(spec=LDConfig)
-
-    builder = polling(mock_ld_config)
+    builder = polling()
 
     assert isinstance(builder, ConfigBuilder)
     # The actual implementation details would be tested in integration tests

--- a/ldclient/testing/integrations/test_test_data_sourcev2.py
+++ b/ldclient/testing/integrations/test_test_data_sourcev2.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 import pytest
 
+from ldclient.config import Config
 from ldclient.impl.datasystem.protocolv2 import (
     ChangeType,
     IntentCode,
@@ -19,7 +20,7 @@ from ldclient.interfaces import DataSourceState
 def test_creates_valid_initializer():
     """Test that TestDataV2 creates a working initializer"""
     td = TestDataV2.data_source()
-    initializer = td.build_initializer()
+    initializer = td.build_initializer(Config(sdk_key="dummy"))
 
     result = initializer.fetch()
     assert isinstance(result, _Success)
@@ -34,7 +35,7 @@ def test_creates_valid_initializer():
 def test_creates_valid_synchronizer():
     """Test that TestDataV2 creates a working synchronizer"""
     td = TestDataV2.data_source()
-    synchronizer = td.build_synchronizer()
+    synchronizer = td.build_synchronizer(Config(sdk_key="dummy"))
 
     updates = []
     update_count = 0
@@ -238,7 +239,7 @@ def test_initializer_fetches_flag_data():
     td = TestDataV2.data_source()
     td.update(td.flag('some-flag').variation_for_all(True))
 
-    initializer = td.build_initializer()
+    initializer = td.build_initializer(Config(sdk_key="dummy"))
     result = initializer.fetch()
 
     assert isinstance(result, _Success)
@@ -258,7 +259,7 @@ def test_synchronizer_yields_initial_data():
     td = TestDataV2.data_source()
     td.update(td.flag('initial-flag').variation_for_all(False))
 
-    synchronizer = td.build_synchronizer()
+    synchronizer = td.build_synchronizer(Config(sdk_key="dummy"))
 
     update_iter = iter(synchronizer.sync())
     initial_update = next(update_iter)
@@ -277,7 +278,7 @@ def test_synchronizer_yields_initial_data():
 def test_synchronizer_receives_updates():
     """Test that synchronizer receives flag updates"""
     td = TestDataV2.data_source()
-    synchronizer = td.build_synchronizer()
+    synchronizer = td.build_synchronizer(Config(sdk_key="dummy"))
 
     updates = []
     update_count = 0
@@ -321,8 +322,8 @@ def test_synchronizer_receives_updates():
 def test_multiple_synchronizers_receive_updates():
     """Test that multiple synchronizers receive the same updates"""
     td = TestDataV2.data_source()
-    sync1 = td.build_synchronizer()
-    sync2 = td.build_synchronizer()
+    sync1 = td.build_synchronizer(Config(sdk_key="dummy"))
+    sync2 = td.build_synchronizer(Config(sdk_key="dummy"))
 
     updates1 = []
     updates2 = []
@@ -367,7 +368,7 @@ def test_multiple_synchronizers_receive_updates():
 def test_closed_synchronizer_stops_yielding():
     """Test that closed synchronizer stops yielding updates"""
     td = TestDataV2.data_source()
-    synchronizer = td.build_synchronizer()
+    synchronizer = td.build_synchronizer(Config(sdk_key="dummy"))
 
     updates = []
 
@@ -399,7 +400,7 @@ def test_initializer_can_sync():
     td = TestDataV2.data_source()
     td.update(td.flag('test-flag').variation_for_all(True))
 
-    initializer = td.build_initializer()
+    initializer = td.build_initializer(Config(sdk_key="dummy"))
     sync_gen = initializer.sync()
 
     # Should get initial update with data
@@ -438,7 +439,7 @@ def test_version_increment():
 def test_error_handling_in_fetch():
     """Test error handling in the fetch method"""
     td = TestDataV2.data_source()
-    initializer = td.build_initializer()
+    initializer = td.build_initializer(Config(sdk_key="dummy"))
 
     # Close the initializer to trigger error condition
     initializer.close()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors data system builders to be config-aware and updates FDv2/client integration and tests accordingly.
> 
> - **Data system config API**:
>   - Change `Builder` type to `Callable[[Config], T]` in `ldclient/config.py` and `impl/datasystem/config.py`.
>   - Convert `default()`, `streaming()`, `polling()`, `daemon()`, `persistent_store()` to no-arg helpers that return builders which accept `Config`.
>   - Internal polling/streaming builder factories now return functions `(config) -> DataSource`.
> - **FDv2**:
>   - Update constructor to `FDv2(config: Config, data_system_config: DataSystemConfig)` and derive offline state from `config.offline`.
>   - Use `data_system_config` for initializers/synchronizers/store; pass `config` into initializer/synchronizer builders.
>   - Minor logging cleanup to parameterized logging.
> - **Client**:
>   - Instantiate FDv2 with `FDv2(self._config, datasystem_config)`.
> - **TestDataV2**:
>   - `build_initializer`/`build_synchronizer` now accept a `Config` arg (unused) to match new `Builder` signature.
> - **Tests**:
>   - Update all tests to new signatures and helper APIs; add `Config(sdk_key="dummy")` where needed.
>   - Minor formatting adjustments in test stubs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77b1e822621bb730c12971b31931efa0f94802c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->