### PR TITLE
fix: Fix incorrect event count in failure message

### DIFF
--- a/ldclient/impl/events/event_processor.py
+++ b/ldclient/impl/events/event_processor.py
@@ -218,7 +218,7 @@ class EventPayloadSendTask:
             json_body = json.dumps(output_events, separators=(',', ':'))
             log.debug('Sending events payload: ' + json_body)
             payload_id = str(uuid.uuid4())
-            r = _post_events_with_retry(self._http, self._config, self._config.events_uri, payload_id, json_body, "%d events" % len(self._payload.events))
+            r = _post_events_with_retry(self._http, self._config, self._config.events_uri, payload_id, json_body, "%d events" % len(output_events))
             if r:
                 self._response_fn(r)
             return r


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use `len(output_events)` instead of buffered `len(self._payload.events)` when describing the number of events sent/retried.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c80cc86d734d000e82ec1488da5b8d088ae63e29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->