### PR TITLE
chore: Provide selector for use as basis on FDv2 data sources

### DIFF
--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -299,7 +299,7 @@ class FDv2:
                 initializer = initializer_builder(self._config)
                 log.info("Attempting to initialize via %s", initializer.name)
 
-                basis_result = initializer.fetch()
+                basis_result = initializer.fetch(self._store)
 
                 if isinstance(basis_result, _Fail):
                     log.warning("Initializer %s failed: %s", initializer.name, basis_result.error)
@@ -426,7 +426,7 @@ class FDv2:
         :return: Tuple of (should_remove_sync, fallback_to_fdv1)
         """
         try:
-            for update in synchronizer.sync():
+            for update in synchronizer.sync(self._store):
                 log.info("Synchronizer %s update: %s", synchronizer.name, update.state)
                 if self._stop_event.is_set():
                     return False, False

--- a/ldclient/testing/impl/datasourcev2/test_polling_initializer.py
+++ b/ldclient/testing/impl/datasourcev2/test_polling_initializer.py
@@ -11,6 +11,7 @@ from ldclient.impl.datasourcev2.polling import (
 )
 from ldclient.impl.datasystem.protocolv2 import ChangeSetBuilder, IntentCode
 from ldclient.impl.util import UnsuccessfulResponseException, _Fail, _Success
+from ldclient.testing.mock_components import MockSelectorStore
 
 
 class MockExceptionThrowingPollingRequester:  # pylint: disable=too-few-public-methods
@@ -37,7 +38,7 @@ def test_error_is_returned_on_failure():
     mock_requester = MockPollingRequester(_Fail(error="failure message"))
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Fail)
     assert result.error == "failure message"
@@ -50,7 +51,7 @@ def test_error_is_recoverable():
     )
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Fail)
     assert result.error is not None
@@ -64,7 +65,7 @@ def test_error_is_unrecoverable():
     )
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Fail)
     assert result.error is not None
@@ -78,7 +79,7 @@ def test_handles_transfer_none():
     )
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Success)
     assert result.value is not None
@@ -92,7 +93,7 @@ def test_handles_uncaught_exception():
     mock_requester = MockExceptionThrowingPollingRequester()
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Fail)
     assert result.error is not None
@@ -111,7 +112,7 @@ def test_handles_transfer_full():
     mock_requester = MockPollingRequester(_Success(value=(change_set_result.value, {})))
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Success)
     assert result.value is not None
@@ -129,7 +130,7 @@ def test_handles_transfer_changes():
     mock_requester = MockPollingRequester(_Success(value=(change_set_result.value, {})))
     ds = PollingDataSource(poll_interval=1.0, requester=mock_requester)
 
-    result = ds.fetch()
+    result = ds.fetch(MockSelectorStore(Selector.no_selector()))
 
     assert isinstance(result, _Success)
     assert result.value is not None

--- a/ldclient/testing/impl/datasourcev2/test_polling_synchronizer.py
+++ b/ldclient/testing/impl/datasourcev2/test_polling_synchronizer.py
@@ -22,6 +22,7 @@ from ldclient.impl.datasystem.protocolv2 import (
 )
 from ldclient.impl.util import UnsuccessfulResponseException, _Fail, _Success
 from ldclient.interfaces import DataSourceErrorKind, DataSourceState
+from ldclient.testing.mock_components import MockSelectorStore
 
 
 class ListBasedRequester:
@@ -103,7 +104,7 @@ def test_handles_no_changes():
         poll_interval=0.01, requester=ListBasedRequester(results=iter([polling_result]))
     )
 
-    valid = next(synchronizer.sync())
+    valid = next(synchronizer.sync(MockSelectorStore(Selector.no_selector())))
 
     assert valid.state == DataSourceState.VALID
     assert valid.error is None
@@ -124,7 +125,7 @@ def test_handles_empty_changeset():
     synchronizer = PollingDataSource(
         poll_interval=0.01, requester=ListBasedRequester(results=iter([polling_result]))
     )
-    valid = next(synchronizer.sync())
+    valid = next(synchronizer.sync(MockSelectorStore(Selector.no_selector())))
 
     assert valid.state == DataSourceState.VALID
     assert valid.error is None
@@ -152,7 +153,7 @@ def test_handles_put_objects():
     synchronizer = PollingDataSource(
         poll_interval=0.01, requester=ListBasedRequester(results=iter([polling_result]))
     )
-    valid = next(synchronizer.sync())
+    valid = next(synchronizer.sync(MockSelectorStore(Selector.no_selector())))
 
     assert valid.state == DataSourceState.VALID
     assert valid.error is None
@@ -183,7 +184,7 @@ def test_handles_delete_objects():
     synchronizer = PollingDataSource(
         poll_interval=0.01, requester=ListBasedRequester(results=iter([polling_result]))
     )
-    valid = next(synchronizer.sync())
+    valid = next(synchronizer.sync(MockSelectorStore(Selector.no_selector())))
 
     assert valid.state == DataSourceState.VALID
     assert valid.error is None
@@ -216,7 +217,7 @@ def test_generic_error_interrupts_and_recovers():
             results=iter([_Fail(error="error for test"), polling_result])
         ),
     )
-    sync = synchronizer.sync()
+    sync = synchronizer.sync(MockSelectorStore(Selector.no_selector()))
     interrupted = next(sync)
     valid = next(sync)
 
@@ -250,7 +251,7 @@ def test_recoverable_error_continues():
         poll_interval=0.01,
         requester=ListBasedRequester(results=iter([_failure, polling_result])),
     )
-    sync = synchronizer.sync()
+    sync = synchronizer.sync(MockSelectorStore(Selector.no_selector()))
     interrupted = next(sync)
     valid = next(sync)
 
@@ -288,7 +289,7 @@ def test_unrecoverable_error_shuts_down():
         poll_interval=0.01,
         requester=ListBasedRequester(results=iter([_failure, polling_result])),
     )
-    sync = synchronizer.sync()
+    sync = synchronizer.sync(MockSelectorStore(Selector.no_selector()))
     off = next(sync)
     assert off.state == DataSourceState.OFF
     assert off.error is not None

--- a/ldclient/testing/mock_components.py
+++ b/ldclient/testing/mock_components.py
@@ -1,6 +1,7 @@
 import time
 from typing import Callable
 
+from ldclient.impl.datasystem.protocolv2 import Selector
 from ldclient.interfaces import BigSegmentStore, BigSegmentStoreMetadata
 
 
@@ -42,3 +43,11 @@ class MockBigSegmentStore(BigSegmentStore):
 
     def __fail(self):
         raise Exception("deliberate error")
+
+
+class MockSelectorStore():
+    def __init__(self, selector: Selector):
+        self._selector = selector
+
+    def selector(self) -> Selector:
+        return self._selector


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces SelectorStore and threads selectors through polling/streaming APIs, FDv2, and tests, including SSE basis query support.
> 
> - **Core API (datasystem)**:
>   - Add `SelectorStore` protocol and require `selector()`.
>   - Change `Initializer.fetch` and `Synchronizer.sync` signatures to accept `SelectorStore`.
> - **Polling (datasourcev2/polling.py)**:
>   - Update `PollingDataSource.fetch/sync/_poll` to use `ss.selector()` when requesting data.
>   - Propagate selector to `Requester.fetch`; no-change/full/changes handling unchanged.
> - **Streaming (datasourcev2/streaming.py)**:
>   - Update `SseClientBuilder` to take `(Config, SelectorStore)` and build client with dynamic `query_params` using selector `basis`.
>   - Update `StreamingDataSource.sync` to pass `SelectorStore` to client builder.
> - **FDv2 orchestration**:
>   - Pass store as `SelectorStore` to initializers and synchronizers; consume updates unchanged.
> - **Test data source (TestDataV2 impl)**:
>   - Conform to new interfaces: `fetch(ss)`, `sync(ss)`, `stop()` (renamed from `close`).
> - **Tests/Mocks**:
>   - Add `MockSelectorStore` and update all tests to pass a `SelectorStore`.
>   - Adjust streaming builder/test helpers for new signatures and basis query behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6b2b3d7c9c37a44a6a35f55f6d0a82af8f56a0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->