### PR TITLE
fix: Fix overly generic type hint on File data source

### DIFF
--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -3,8 +3,10 @@ This submodule contains factory/configuration methods for integrating the SDK wi
 other than LaunchDarkly.
 """
 
-from typing import Any, Dict, List, Mapping, Optional
+from threading import Event
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from ldclient.config import Config
 from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
 from ldclient.impl.integrations.consul.consul_feature_store import (
@@ -23,7 +25,7 @@ from ldclient.impl.integrations.redis.redis_big_segment_store import (
 from ldclient.impl.integrations.redis.redis_feature_store import (
     _RedisFeatureStoreCore
 )
-from ldclient.interfaces import BigSegmentStore
+from ldclient.interfaces import BigSegmentStore, FeatureStore, UpdateProcessor
 
 
 class Consul:
@@ -206,7 +208,7 @@ class Files:
     """Provides factory methods for integrations with filesystem data."""
 
     @staticmethod
-    def new_data_source(paths: List[str], auto_update: bool = False, poll_interval: float = 1, force_polling: bool = False) -> object:
+    def new_data_source(paths: List[str], auto_update: bool = False, poll_interval: float = 1, force_polling: bool = False) -> Optional[Callable[[Config, FeatureStore, Event], UpdateProcessor]]:
         """Provides a way to use local files as a source of feature flag state. This would typically be
         used in a test environment, to operate using a predetermined feature flag state without an
         actual LaunchDarkly connection.


### PR DESCRIPTION
fixes #364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `Files.new_data_source` typing and adds corresponding imports, with no runtime logic changes.
> 
> - **Types**:
>   - Narrow `Files.new_data_source` return type to `Optional[Callable[[Config, FeatureStore, Event], UpdateProcessor]]`.
>   - Add required imports: `Event`, `Callable`, `Config`, `FeatureStore`, `UpdateProcessor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d494584c7b32b67800167f97b3a427dc2900baa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->