### PR TITLE
chore: Add support for diagnostic events

### DIFF
--- a/ldclient/impl/datasystem/__init__.py
+++ b/ldclient/impl/datasystem/__init__.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from threading import Event
-from typing import Callable, Generator, Optional, Protocol
+from typing import Generator, Optional, Protocol, runtime_checkable
 
 from ldclient.impl.datasystem.protocolv2 import Basis, ChangeSet, Selector
 from ldclient.impl.util import _Result
@@ -147,6 +147,27 @@ class DataSystem(Protocol):
     def store(self) -> ReadOnlyStore:
         """
         Returns the data store used by the data system.
+        """
+        raise NotImplementedError
+
+
+class DiagnosticAccumulator(Protocol):
+    def record_stream_init(self, timestamp, duration, failed):
+        raise NotImplementedError
+
+    def record_events_in_batch(self, events_in_batch):
+        raise NotImplementedError
+
+    def create_event_and_reset(self, dropped_events, deduplicated_users):
+        raise NotImplementedError
+
+
+@runtime_checkable
+class DiagnosticSource(Protocol):
+    @abstractmethod
+    def set_diagnostic_accumulator(self, diagnostic_accumulator: DiagnosticAccumulator):
+        """
+        Set the diagnostic_accumulator to be used for reporting diagnostic events.
         """
         raise NotImplementedError
 

--- a/ldclient/impl/datasystem/fdv1.py
+++ b/ldclient/impl/datasystem/fdv1.py
@@ -13,7 +13,7 @@ from ldclient.impl.datastore.status import (
     DataStoreStatusProviderImpl,
     DataStoreUpdateSinkImpl
 )
-from ldclient.impl.datasystem import DataAvailability
+from ldclient.impl.datasystem import DataAvailability, DiagnosticAccumulator
 from ldclient.impl.flag_tracker import FlagTrackerImpl
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.stubs import NullUpdateProcessor
@@ -78,7 +78,7 @@ class FDv1:
         self._update_processor: Optional[UpdateProcessor] = None
 
         # Diagnostic accumulator provided by client for streaming metrics
-        self._diagnostic_accumulator = None
+        self._diagnostic_accumulator: Optional[DiagnosticAccumulator] = None
 
         # Track current data availability
         self._data_availability: DataAvailability = (
@@ -122,7 +122,7 @@ class FDv1:
         """
         self._flag_tracker_impl = FlagTrackerImpl(self._flag_change_listeners, eval_fn)
 
-    def set_diagnostic_accumulator(self, diagnostic_accumulator):
+    def set_diagnostic_accumulator(self, diagnostic_accumulator: DiagnosticAccumulator):
         """
         Sets the diagnostic accumulator for streaming initialization metrics.
         This should be called before start() to ensure metrics are collected.

--- a/ldclient/impl/datasystem/protocolv2.py
+++ b/ldclient/impl/datasystem/protocolv2.py
@@ -6,9 +6,12 @@ LaunchDarkly data system version 2 (FDv2).
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional, Protocol
+from typing import TYPE_CHECKING, Generator, List, Optional, Protocol
 
 from ldclient.impl.util import Result
+
+if TYPE_CHECKING:
+    from ldclient.impl.datasystem import SelectorStore, Update
 
 
 class EventName(str, Enum):
@@ -502,7 +505,13 @@ class Synchronizer(Protocol):
         """Returns the name of the initializer."""
         raise NotImplementedError
 
-    # TODO(fdv2): Need sync method
+    def sync(self, ss: "SelectorStore") -> "Generator[Update, None, None]":
+        """
+        sync should begin the synchronization process for the data source, yielding
+        Update objects until the connection is closed or an unrecoverable error
+        occurs.
+        """
+        raise NotImplementedError
 
     def close(self):
         """

--- a/ldclient/testing/impl/datasourcev2/test_streaming_synchronizer.py
+++ b/ldclient/testing/impl/datasourcev2/test_streaming_synchronizer.py
@@ -53,6 +53,10 @@ class ListBasedSseClient:
     def all(self) -> Iterable[Action]:
         return self._events
 
+    @property
+    def next_retry_delay(self):
+        return 1
+
     def interrupt(self):
         pass
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Plumbs diagnostic instrumentation through FDv1/FDv2 and the FDv2 streaming data source, recording stream-init metrics and wiring the accumulator into synchronizers, with protocol/typing and test updates.
> 
> - **Diagnostics**:
>   - Introduce `DiagnosticAccumulator` and `DiagnosticSource` protocols in `ldclient.impl.datasystem` (runtime-checkable) and add setter APIs.
>   - Add optional diagnostic accumulator to `FDv1`/`FDv2`; provide `set_diagnostic_accumulator` and propagate to synchronizers that implement `DiagnosticSource`.
> - **Streaming (FDv2)**:
>   - Make `StreamingDataSource` implement `DiagnosticSource`; track connection attempt start time and record `record_stream_init` on success/failure (using `next_retry_delay`).
>   - Handle `Start` fallback header `X-LD-FD-Fallback` by recording failure and yielding `revert_to_fdv1=True`.
>   - Enhance error handling to record diagnostics and manage retry timing for JSON errors, HTTP errors, and unexpected errors; clear timing on permanent failures.
> - **Protocol/typing**:
>   - Define `Synchronizer.sync(ss)` in `protocolv2` with proper `Generator[Update,...]` typing and TYPE_CHECKING imports.
> - **Tests**:
>   - Update test SSE client to expose `next_retry_delay`; adjust streaming synchronizer tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383a39695a8d6d1fd7cd981b6b74f535e99bfc92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->