### PR TITLE
chore: Flush in memory store on persistent store recovery

### DIFF
--- a/ldclient/impl/datasourcev2/polling.py
+++ b/ldclient/impl/datasourcev2/polling.py
@@ -257,7 +257,7 @@ class Urllib3PollingRequester:
         if self._config.payload_filter_key is not None:
             query_params["filter"] = self._config.payload_filter_key
 
-        if selector is not None:
+        if selector is not None and selector.is_defined():
             query_params["selector"] = selector.state
 
         uri = self._poll_uri

--- a/ldclient/impl/datasystem/protocolv2.py
+++ b/ldclient/impl/datasystem/protocolv2.py
@@ -505,7 +505,7 @@ class Synchronizer(Protocol):
         """Returns the name of the initializer."""
         raise NotImplementedError
 
-    def sync(self, ss: "SelectorStore") -> "Generator[Update, None, None]":
+    def sync(self, ss: "SelectorStore") -> Generator["Update", None, None]:
         """
         sync should begin the synchronization process for the data source, yielding
         Update objects until the connection is closed or an unrecoverable error


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Flushes in-memory data to the persistent store on recovery with stale data, switches client evaluations to use the data system store, tightens polling selector handling, and adds thorough persistence tests.
> 
> - **Data system (FDv2)**:
>   - **Outage recovery**: Add `_persistent_store_outage_recovery` to flush via `Store.commit()` when `DataStoreStatus(available=True, stale=True)`; register listener; set status with `DataStoreStatus(available, True)` on availability.
>   - **Store.commit**: Encode `FEATURES`/`SEGMENTS` via `VersionedDataKind.encode` before calling persistent `init()`.
> - **Client**:
>   - Use `_data_system.store` for evaluator sources, initialization checks, and `all_flags_state()` reads.
> - **Polling**:
>   - Only send `selector` query param when `selector.is_defined()`.
> - **Protocol/typing**:
>   - Fix `Synchronizer.sync` return type to `Generator["Update", None, None]`.
> - **Tests**:
>   - Add tests for outage recovery flush behavior, commit encoding, commit without persistent store, and error handling in commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e81cdbf7750d7b7c524e5a08f315f85965f6da7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->