### PR TITLE
chore: Remove release-as override

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "release-as": "9.13.0",
       "versioning": "default",
       "include-v-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `release-as` override from `release-please-config.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a279ac06a1d68e0e6e045fc3010bfebeb30fb06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->