### PR TITLE
chore: Clean up unused _data_availability

### DIFF
--- a/ldclient/impl/datasystem/fdv1.py
+++ b/ldclient/impl/datasystem/fdv1.py
@@ -22,8 +22,6 @@ from ldclient.impl.flag_tracker import FlagTrackerImpl
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.stubs import NullUpdateProcessor
 from ldclient.interfaces import (
-    DataSourceState,
-    DataSourceStatus,
     DataSourceStatusProvider,
     DataStoreStatusProvider,
     FeatureStore,
@@ -83,20 +81,6 @@ class FDv1(DataSystem):
 
         # Diagnostic accumulator provided by client for streaming metrics
         self._diagnostic_accumulator: Optional[DiagnosticAccumulator] = None
-
-        # Track current data availability
-        self._data_availability: DataAvailability = (
-            DataAvailability.CACHED
-            if getattr(self._store_wrapper, "initialized", False)
-            else DataAvailability.DEFAULTS
-        )
-
-        # React to data source status updates to adjust availability
-        def _on_status_change(status: DataSourceStatus):
-            if status.state == DataSourceState.VALID:
-                self._data_availability = DataAvailability.REFRESHED
-
-        self._data_source_status_provider_impl.add_listener(_on_status_change)
 
     def start(self, set_on_ready: Event):
         """


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Remove unused `_data_availability` state and its status-listener, and delete related unused imports.
> 
> - **Datasystem (`ldclient/impl/datasystem/fdv1.py`)**:
>   - Remove `_data_availability` tracking and the `DataSourceStatus` listener that updated it.
>   - Drop unused imports `DataSourceState` and `DataSourceStatus`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32b7db6123ea25759e77ab9e63a3bc4f9e3cdf72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->