### PR TITLE
chore: Expose flag change listeners from data system

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -263,8 +263,8 @@ class LDClient:
         else:
             self._data_system = FDv2(self._config, datasystem_config)
 
-        # Provide flag evaluation function for value-change tracking
-        self._data_system.set_flag_value_eval_fn(  # type: ignore
+        self.__flag_tracker = FlagTrackerImpl(
+            self._data_system.flag_change_listeners,
             lambda key, context: self.variation(key, context, None)
         )
         # Expose providers and store from data system
@@ -272,7 +272,6 @@ class LDClient:
         self.__data_source_status_provider = (
             self._data_system.data_source_status_provider
         )
-        self.__flag_tracker = self._data_system.flag_tracker
 
         big_segment_store_manager = BigSegmentStoreManager(self._config.big_segments)
         self.__big_segment_store_manager = big_segment_store_manager

--- a/ldclient/impl/datasystem/__init__.py
+++ b/ldclient/impl/datasystem/__init__.py
@@ -8,6 +8,7 @@ from enum import Enum
 from threading import Event
 from typing import Protocol, runtime_checkable
 
+from ldclient.impl.listeners import Listeners
 from ldclient.interfaces import (
     DataSourceStatusProvider,
     DataStoreStatusProvider,
@@ -111,13 +112,9 @@ class DataSystem(Protocol):
 
     @property
     @abstractmethod
-    def flag_tracker(self) -> FlagTracker:
+    def flag_change_listeners(self) -> Listeners:
         """
-        Returns an interface for tracking changes in feature flag configurations.
-
-        The :class:`ldclient.interfaces.FlagTracker` contains methods for
-        requesting notifications about feature flag changes using an event
-        listener model.
+        Returns the collection of listeners for flag change events.
         """
         raise NotImplementedError
 

--- a/ldclient/impl/datasystem/fdv1.py
+++ b/ldclient/impl/datasystem/fdv1.py
@@ -60,10 +60,6 @@ class FDv1(DataSystem):
         # Set up data source plumbing
         self._data_source_listeners = Listeners()
         self._flag_change_listeners = Listeners()
-        self._flag_tracker_impl = FlagTrackerImpl(
-            self._flag_change_listeners,
-            lambda key, context: None,  # Replaced by client to use its evaluation method
-        )
         self._data_source_update_sink = DataSourceUpdateSinkImpl(
             self._store_wrapper,
             self._data_source_listeners,
@@ -102,14 +98,6 @@ class FDv1(DataSystem):
     def store(self) -> ReadOnlyStore:
         return self._store_wrapper
 
-    def set_flag_value_eval_fn(self, eval_fn):
-        """
-        Injects the flag value evaluation function used by the flag tracker to
-        compute FlagValueChange events. The function signature should be
-        (key: str, context: Context) -> Any.
-        """
-        self._flag_tracker_impl = FlagTrackerImpl(self._flag_change_listeners, eval_fn)
-
     def set_diagnostic_accumulator(self, diagnostic_accumulator: DiagnosticAccumulator):
         """
         Sets the diagnostic accumulator for streaming initialization metrics.
@@ -126,8 +114,8 @@ class FDv1(DataSystem):
         return self._data_store_status_provider_impl
 
     @property
-    def flag_tracker(self) -> FlagTracker:
-        return self._flag_tracker_impl
+    def flag_change_listeners(self) -> Listeners:
+        return self._flag_change_listeners
 
     @property
     def data_availability(self) -> DataAvailability:

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -295,12 +295,6 @@ class FDv2(DataSystem):
                 wrapper, writable, self._data_store_status_provider
             )
 
-        # Flag tracker (evaluation function set later by client)
-        self._flag_tracker = FlagTrackerImpl(
-            self._flag_change_listeners,
-            lambda key, context: None  # Placeholder, replaced by client
-        )
-
         # Threading
         self._stop_event = Event()
         self._lock = ReadWriteLock()
@@ -659,14 +653,6 @@ class FDv2(DataSystem):
         """Get the underlying store for flag evaluation."""
         return self._store.get_active_store()
 
-    def set_flag_value_eval_fn(self, eval_fn):
-        """
-        Set the flag value evaluation function for the flag tracker.
-
-        :param eval_fn: Function with signature (key: str, context: Context) -> Any
-        """
-        self._flag_tracker = FlagTrackerImpl(self._flag_change_listeners, eval_fn)
-
     @property
     def data_source_status_provider(self) -> DataSourceStatusProvider:
         """Get the data source status provider."""
@@ -678,9 +664,9 @@ class FDv2(DataSystem):
         return self._data_store_status_provider
 
     @property
-    def flag_tracker(self) -> FlagTracker:
-        """Get the flag tracker for monitoring flag changes."""
-        return self._flag_tracker
+    def flag_change_listeners(self) -> Listeners:
+        """Get the collection of listeners for flag change events."""
+        return self._flag_change_listeners
 
     @property
     def data_availability(self) -> DataAvailability:

--- a/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
@@ -55,7 +55,7 @@ def test_two_phase_init():
         if count == 3:
             modified.set()
 
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
 
     fdv2.start(set_on_ready)
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -86,7 +86,7 @@ def test_can_stop_fdv2():
         changes.append(flag_change)
         changed.set()
 
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
 
     fdv2.start(set_on_ready)
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -140,7 +140,7 @@ def test_fdv2_fallsback_to_secondary_synchronizer():
 
     set_on_ready = Event()
     fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
     assert set_on_ready.wait(1), "Data system did not become ready in time"
 
@@ -215,7 +215,7 @@ def test_fdv2_falls_back_to_fdv1_on_polling_error_with_header():
 
     set_on_ready = Event()
     fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
 
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -269,7 +269,7 @@ def test_fdv2_falls_back_to_fdv1_on_polling_success_with_header():
 
     set_on_ready = Event()
     fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
 
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -324,7 +324,7 @@ def test_fdv2_falls_back_to_fdv1_with_initializer():
 
     set_on_ready = Event()
     fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
 
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -484,7 +484,7 @@ def test_fdv2_initializer_should_run_until_success():
             if count == 3:
                 synchronizer_ran.set()
 
-        fdv2.flag_tracker.add_listener(listener)
+        fdv2.flag_change_listeners.add(listener)
 
         fdv2.start(set_on_ready)
         assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -537,7 +537,7 @@ def test_fdv2_should_finish_initialization_on_first_successful_initializer():
             nonlocal count
             count += 1
 
-        fdv2.flag_tracker.add_listener(listener)
+        fdv2.flag_change_listeners.add(listener)
 
         fdv2.start(set_on_ready)
         assert set_on_ready.wait(1), "Data system did not become ready in time"

--- a/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
@@ -239,7 +239,7 @@ def test_persistent_store_delta_updates_read_write():
         ):  # First change is from initial sync, second is our update
             flag_changed.set()
 
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
 
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -293,7 +293,7 @@ def test_persistent_store_delta_updates_read_only():
         ):  # First change is from initial sync, second is our update
             flag_changed.set()
 
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
 
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -341,7 +341,7 @@ def test_persistent_store_with_initializer_and_synchronizer():
         if flag_change.key == "sync-flag":
             sync_flag_arrived.set()
 
-    fdv2.flag_tracker.add_listener(listener)
+    fdv2.flag_change_listeners.add(listener)
     fdv2.start(set_on_ready)
 
     assert set_on_ready.wait(1), "Data system did not become ready in time"
@@ -571,7 +571,7 @@ def test_persistent_store_outage_recovery_flushes_on_recovery():
     persistent_store.reset_operation_tracking()
 
     event = Event()
-    fdv2.flag_tracker.add_listener(lambda _flag_change: event.set())
+    fdv2.flag_change_listeners.add(lambda _flag_change: event.set())
     # Simulate a new flag being added while store is "offline"
     # (In reality, the store is still online, but we're testing the recovery mechanism)
     td_synchronizer.update(td_synchronizer.flag("new-flag").on(False))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose `flag_change_listeners` on data systems and move `FlagTracker` construction to `LDClient`, updating FDv1/FDv2 and tests accordingly.
> 
> - **Core API (DataSystem)**:
>   - Replace `flag_tracker` property with `flag_change_listeners` returning `Listeners`.
> - **Client (`ldclient/client.py`)**:
>   - Instantiate `FlagTrackerImpl` in client using `data_system.flag_change_listeners` and client `variation` eval fn.
>   - Remove use of data system `set_flag_value_eval_fn` and `flag_tracker`.
> - **FDv1/FDv2 Implementations**:
>   - Remove internal `FlagTrackerImpl` management and `set_flag_value_eval_fn` method.
>   - Expose `flag_change_listeners()` instead of `flag_tracker`.
> - **Tests**:
>   - Update FDv2 tests to register listeners via `fdv2.flag_change_listeners.add(...)` instead of `fdv2.flag_tracker.add_listener(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e06bc72eb6eb013eb14bd713347f8b858817308b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->