### PR TITLE
fix: Fix data and target availability for daemon mode

### DIFF
--- a/ldclient/impl/datasystem/fdv1.py
+++ b/ldclient/impl/datasystem/fdv1.py
@@ -134,6 +134,11 @@ class FDv1(DataSystem):
         if self._config.offline:
             return DataAvailability.DEFAULTS
 
+        if self._config.use_ldd:
+            return DataAvailability.CACHED \
+                if self._store_wrapper.initialized \
+                else DataAvailability.DEFAULTS
+
         if self._update_processor is not None and self._update_processor.initialized():
             return DataAvailability.REFRESHED
 
@@ -146,7 +151,9 @@ class FDv1(DataSystem):
     def target_availability(self) -> DataAvailability:
         if self._config.offline:
             return DataAvailability.DEFAULTS
-        # In LDD mode or normal connected modes, the ideal is to be refreshed
+        if self._config.use_ldd:
+            return DataAvailability.CACHED
+
         return DataAvailability.REFRESHED
 
     def _make_update_processor(self, config: Config, store: FeatureStore, ready: Event):

--- a/ldclient/testing/impl/datasystem/test_fdv1_availability.py
+++ b/ldclient/testing/impl/datasystem/test_fdv1_availability.py
@@ -1,0 +1,68 @@
+# pylint: disable=missing-docstring
+
+from threading import Event
+
+from ldclient.config import Config
+from ldclient.feature_store import InMemoryFeatureStore
+from ldclient.impl.datasystem import DataAvailability
+from ldclient.impl.datasystem.fdv1 import FDv1
+from ldclient.versioned_data_kind import FEATURES
+
+
+def test_fdv1_availability_offline():
+    """Test that FDv1 returns DEFAULTS for both data and target availability when offline."""
+    config = Config(sdk_key="sdk-key", offline=True)
+    fdv1 = FDv1(config)
+
+    assert fdv1.data_availability == DataAvailability.DEFAULTS
+    assert fdv1.target_availability == DataAvailability.DEFAULTS
+
+
+def test_fdv1_availability_ldd_mode_uninitialized():
+    """Test that FDv1 returns DEFAULTS for data and CACHED for target when LDD mode with uninitialized store."""
+    store = InMemoryFeatureStore()
+    config = Config(sdk_key="sdk-key", use_ldd=True, feature_store=store)
+    fdv1 = FDv1(config)
+
+    # Store is not initialized yet
+    assert not store.initialized
+    assert fdv1.data_availability == DataAvailability.DEFAULTS
+    assert fdv1.target_availability == DataAvailability.CACHED
+
+
+def test_fdv1_availability_ldd_mode_initialized():
+    """Test that FDv1 returns CACHED for both when LDD mode with initialized store."""
+    store = InMemoryFeatureStore()
+    config = Config(sdk_key="sdk-key", use_ldd=True, feature_store=store)
+    fdv1 = FDv1(config)
+
+    # Initialize the store
+    store.init({FEATURES: {}})
+
+    assert store.initialized
+    assert fdv1.data_availability == DataAvailability.CACHED
+    assert fdv1.target_availability == DataAvailability.CACHED
+
+
+def test_fdv1_availability_normal_mode_uninitialized():
+    """Test that FDv1 returns DEFAULTS for data and REFRESHED for target in normal mode when not initialized."""
+    store = InMemoryFeatureStore()
+    config = Config(sdk_key="sdk-key", feature_store=store)
+    fdv1 = FDv1(config)
+
+    # Update processor not started, store not initialized
+    assert fdv1.data_availability == DataAvailability.DEFAULTS
+    assert fdv1.target_availability == DataAvailability.REFRESHED
+
+
+def test_fdv1_availability_normal_mode_store_initialized():
+    """Test that FDv1 returns CACHED for data and REFRESHED for target when store is initialized but update processor is not."""
+    store = InMemoryFeatureStore()
+    config = Config(sdk_key="sdk-key", feature_store=store)
+    fdv1 = FDv1(config)
+
+    # Initialize store but don't start update processor
+    fdv1._store_wrapper.init({FEATURES: {}})
+
+    assert fdv1.data_availability == DataAvailability.CACHED
+    assert fdv1.target_availability == DataAvailability.REFRESHED

--- a/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
@@ -545,3 +545,157 @@ def test_fdv2_should_finish_initialization_on_first_successful_initializer():
         fdv2.stop()
     finally:
         os.remove(path)
+
+
+def test_fdv2_availability_offline():
+    """Test that FDv2 returns DEFAULTS for target availability and data availability when offline."""
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=None,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy", offline=True), data_system_config)
+
+    assert fdv2.data_availability == DataAvailability.DEFAULTS
+    assert fdv2.target_availability == DataAvailability.DEFAULTS
+
+
+def test_fdv2_availability_with_data_sources_no_store():
+    """Test that FDv2 returns DEFAULTS for data and REFRESHED for target when configured with data sources but no store and uninitialized."""
+    td = TestDataV2.data_source()
+
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=td.build_synchronizer,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # Store is not initialized, and we have data sources configured
+    assert not fdv2._store.is_initialized()
+    assert fdv2.data_availability == DataAvailability.DEFAULTS
+    assert fdv2.target_availability == DataAvailability.REFRESHED
+
+
+def test_fdv2_availability_no_data_sources_with_readonly_store_uninitialized():
+    """Test that FDv2 returns DEFAULTS for both when no data sources and read-only store is uninitialized."""
+    from ldclient.interfaces import DataStoreMode
+    from ldclient.testing.impl.datasystem.test_fdv2_persistence import (
+        StubFeatureStore
+    )
+
+    store = StubFeatureStore()
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=None,
+        data_store=store,
+        data_store_mode=DataStoreMode.READ_ONLY,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # Store is not initialized
+    assert not store.initialized
+    assert fdv2.data_availability == DataAvailability.DEFAULTS
+    assert fdv2.target_availability == DataAvailability.CACHED
+
+
+def test_fdv2_availability_no_data_sources_with_readonly_store_initialized():
+    """Test that FDv2 returns CACHED for both when no data sources and read-only store is initialized."""
+    from ldclient.interfaces import DataStoreMode
+    from ldclient.testing.impl.datasystem.test_fdv2_persistence import (
+        StubFeatureStore
+    )
+
+    store = StubFeatureStore()
+    store.init({FEATURES: {}})
+
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=None,
+        data_store=store,
+        data_store_mode=DataStoreMode.READ_ONLY,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # Store is initialized
+    assert store.initialized
+    assert fdv2.data_availability == DataAvailability.CACHED
+    assert fdv2.target_availability == DataAvailability.CACHED
+
+
+def test_fdv2_availability_no_data_sources_with_readwrite_store_initialized():
+    """Test that FDv2 returns CACHED for both when no data sources and read-write store is initialized."""
+    from ldclient.interfaces import DataStoreMode
+    from ldclient.testing.impl.datasystem.test_fdv2_persistence import (
+        StubFeatureStore
+    )
+
+    store = StubFeatureStore()
+    store.init({FEATURES: {}})
+
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=None,
+        data_store=store,
+        data_store_mode=DataStoreMode.READ_WRITE,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # Store is initialized
+    assert store.initialized
+    assert fdv2.data_availability == DataAvailability.CACHED
+    assert fdv2.target_availability == DataAvailability.CACHED
+
+
+def test_fdv2_availability_with_data_sources_and_store_uninitialized():
+    """Test that FDv2 returns DEFAULTS for data and REFRESHED for target when data sources configured with uninitialized store."""
+    from ldclient.interfaces import DataStoreMode
+    from ldclient.testing.impl.datasystem.test_fdv2_persistence import (
+        StubFeatureStore
+    )
+
+    td = TestDataV2.data_source()
+    store = StubFeatureStore()
+
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=td.build_synchronizer,
+        data_store=store,
+        data_store_mode=DataStoreMode.READ_WRITE,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # Store is not initialized
+    assert not store.initialized
+    assert fdv2.data_availability == DataAvailability.DEFAULTS
+    assert fdv2.target_availability == DataAvailability.REFRESHED
+
+
+def test_fdv2_availability_with_data_sources_and_store_initialized():
+    """Test that FDv2 returns CACHED for data and REFRESHED for target when data sources configured with initialized store."""
+    from ldclient.interfaces import DataStoreMode
+    from ldclient.testing.impl.datasystem.test_fdv2_persistence import (
+        StubFeatureStore
+    )
+
+    td = TestDataV2.data_source()
+    store = StubFeatureStore()
+    store.init({FEATURES: {}})
+
+    data_system_config = DataSystemConfig(
+        initializers=None,
+        primary_synchronizer=td.build_synchronizer,
+        data_store=store,
+        data_store_mode=DataStoreMode.READ_WRITE,
+    )
+
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # Store is initialized but selector not defined yet (synchronizer not started)
+    assert store.initialized
+    assert fdv2.data_availability == DataAvailability.CACHED
+    assert fdv2.target_availability == DataAvailability.REFRESHED


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust availability calculations in FDv1/FDv2 and add tests for offline, LDD, data-source, and store-initialization states.
> 
> - **Core datasystem logic**:
>   - **FDv1 (`ldclient/impl/datasystem/fdv1.py`)**:
>     - Update `data_availability` to return `CACHED` in LDD mode only when the store is initialized; otherwise `DEFAULTS`.
>     - Update `target_availability` to return `CACHED` in LDD mode; `DEFAULTS` when offline; otherwise `REFRESHED`.
>   - **FDv2 (`ldclient/impl/datasystem/fdv2.py`)**:
>     - Use `config.offline` directly in `start()` to disable the system.
>     - Refine `data_availability`: `REFRESHED` when selector is defined; `CACHED` when store initialized; else `DEFAULTS`.
>     - Refine `target_availability`: `DEFAULTS` when offline or no data sources and no store; `REFRESHED` when configured with data sources; otherwise `CACHED`.
> - **Tests**:
>   - Add `test_fdv1_availability.py` covering offline, LDD (initialized/uninitialized), and normal mode scenarios.
>   - Expand `test_fdv2_datasystem.py` with availability cases for offline, with/without data sources, and read-only/read-write store (initialized/uninitialized).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c998cda4c5d010c46abdc5a29e6c36416efa0e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->