### PR TITLE
fix: Add warning if relying on Redis `max_connections` parameter

### DIFF
--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -6,6 +6,7 @@ other than LaunchDarkly.
 from threading import Event
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from ldclient import log
 from ldclient.config import Builder, Config
 from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
@@ -168,11 +169,20 @@ class Redis:
         :param url: the URL of the Redis host; defaults to ``DEFAULT_URL``
         :param prefix: a namespace prefix to be prepended to all Redis keys; defaults to
           ``DEFAULT_PREFIX``
+        :param max_connections: (deprecated and unused) This parameter is not used. To configure
+          the maximum number of connections, use ``redis_opts={'max_connections': N}`` instead.
         :param caching: specifies whether local caching should be enabled and if so,
           sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`
         :param redis_opts: extra options for initializing Redis connection from the url,
           see `redis.connection.ConnectionPool.from_url` for more details.
         """
+
+        if max_connections != Redis.DEFAULT_MAX_CONNECTIONS:
+            log.warning(
+                "The max_connections parameter is not used and will be removed in a future version. "
+                "Please set max_connections in redis_opts instead, e.g., redis_opts={'max_connections': %d}",
+                max_connections
+            )
 
         core = _RedisFeatureStoreCore(url, prefix, redis_opts)
         wrapper = CachingStoreWrapper(core, caching)
@@ -200,9 +210,18 @@ class Redis:
         :param url: the URL of the Redis host; defaults to ``DEFAULT_URL``
         :param prefix: a namespace prefix to be prepended to all Redis keys; defaults to
           ``DEFAULT_PREFIX``
+        :param max_connections: (deprecated and unused) This parameter is not used. To configure
+          the maximum number of connections, use ``redis_opts={'max_connections': N}`` instead.
         :param redis_opts: extra options for initializing Redis connection from the url,
           see `redis.connection.ConnectionPool.from_url` for more details.
         """
+
+        if max_connections != Redis.DEFAULT_MAX_CONNECTIONS:
+            log.warning(
+                "The max_connections parameter is not used and will be removed in a future version. "
+                "Please set max_connections in redis_opts instead, e.g., redis_opts={'max_connections': %d}",
+                max_connections
+            )
 
         return _RedisBigSegmentStore(url, prefix, redis_opts)
 

--- a/ldclient/testing/integrations/test_redis.py
+++ b/ldclient/testing/integrations/test_redis.py
@@ -125,3 +125,85 @@ class TestRedisBigSegmentStore(BigSegmentStoreTestBase):
     @property
     def tester_class(self):
         return RedisBigSegmentStoreTester
+
+
+@pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
+def test_feature_store_max_connections_is_not_used():
+    """Test that the max_connections parameter is NOT passed to the Redis connection pool."""
+    custom_max_connections = 42
+    store = Redis.new_feature_store(max_connections=custom_max_connections)
+
+    # Access the connection pool through the wrapper's core
+    actual_max_connections = store._core._pool.max_connections
+
+    # Should NOT be our custom value since the parameter is unused
+    assert actual_max_connections != custom_max_connections, \
+        f"Expected max_connections to NOT be {custom_max_connections}, but it was set"
+
+
+@pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
+def test_big_segment_store_max_connections_is_not_used():
+    """Test that the max_connections parameter is NOT passed to the Redis connection pool."""
+    custom_max_connections = 42
+    store = Redis.new_big_segment_store(max_connections=custom_max_connections)
+
+    # Access the connection pool directly from the store
+    actual_max_connections = store._pool.max_connections
+
+    # Should NOT be our custom value since the parameter is unused
+    assert actual_max_connections != custom_max_connections, \
+        f"Expected max_connections to NOT be {custom_max_connections}, but it was set"
+
+
+@pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
+def test_feature_store_max_connections_warns_when_non_default(caplog):
+    """Test that a warning is logged when max_connections differs from the default."""
+    import logging
+    caplog.set_level(logging.WARNING)
+
+    custom_max_connections = 42
+    Redis.new_feature_store(max_connections=custom_max_connections)
+
+    assert any("max_connections parameter is not used" in record.message for record in caplog.records), \
+        "Expected warning that parameter is not used"
+    assert any("redis_opts" in record.message for record in caplog.records), \
+        "Expected warning to mention redis_opts"
+
+
+@pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
+def test_big_segment_store_max_connections_warns_when_non_default(caplog):
+    """Test that a warning is logged when max_connections differs from the default."""
+    import logging
+    caplog.set_level(logging.WARNING)
+
+    custom_max_connections = 42
+    Redis.new_big_segment_store(max_connections=custom_max_connections)
+
+    assert any("max_connections parameter is not used" in record.message for record in caplog.records), \
+        "Expected warning that parameter is not used"
+    assert any("redis_opts" in record.message for record in caplog.records), \
+        "Expected warning to mention redis_opts"
+
+
+@pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
+def test_feature_store_max_connections_no_warn_when_default(caplog):
+    """Test that no warning is logged when max_connections is the default value."""
+    import logging
+    caplog.set_level(logging.WARNING)
+
+    Redis.new_feature_store(max_connections=Redis.DEFAULT_MAX_CONNECTIONS)
+
+    assert not any("max_connections parameter is not used" in record.message for record in caplog.records), \
+        "Expected no warning when using default value"
+
+
+@pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
+def test_big_segment_store_max_connections_no_warn_when_default(caplog):
+    """Test that no warning is logged when max_connections is the default value."""
+    import logging
+    caplog.set_level(logging.WARNING)
+
+    Redis.new_big_segment_store(max_connections=Redis.DEFAULT_MAX_CONNECTIONS)
+
+    assert not any("max_connections parameter is not used" in record.message for record in caplog.records), \
+        "Expected no warning when using default value"


### PR DESCRIPTION
The `new_feature_store` and `new_big_segment_store` methods accept a
`max_connections` parameter that has been unused since v8.

We cannot start using this parameter now as it would be a functionally
breaking change. Instead, we are opting to warn customers who might try
setting it explicitly.

fixes #386

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Warns when non-default `max_connections` is passed to Redis stores, documents it as unused, and adds tests verifying behavior.
> 
> - **Redis integrations**:
>   - Add warning in `Redis.new_feature_store` and `Redis.new_big_segment_store` when `max_connections` differs from `Redis.DEFAULT_MAX_CONNECTIONS`; advise using `redis_opts={'max_connections': N}`.
>   - Update docstrings to mark `max_connections` as deprecated/unused.
>   - Import `ldclient.log` to emit warnings.
> - **Tests (`ldclient/testing/integrations/test_redis.py`)**:
>   - Verify `max_connections` arg does not affect Redis connection pool for feature store and big segment store.
>   - Verify warnings are logged when `max_connections` is non-default and not when default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e767c514c7308abad5048e745596e15ea81b84b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->