### PR TITLE
fix: Remove all synchronizers in daemon mode

### DIFF
--- a/ldclient/datasystem.py
+++ b/ldclient/datasystem.py
@@ -212,7 +212,7 @@ def daemon(store: FeatureStore) -> ConfigBuilder:
     that is populated by Relay Proxy or other SDKs. The SDK will not connect
     to LaunchDarkly. In this mode, the SDK never writes to the data store.
     """
-    return default().data_store(store, DataStoreMode.READ_ONLY)
+    return custom().data_store(store, DataStoreMode.READ_ONLY)
 
 
 def persistent_store(store: FeatureStore) -> ConfigBuilder:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch `daemon()` to use `custom()` instead of `default()`, removing all synchronizers/initializers and keeping a read-only persistent store.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bdf8802eef44a2fcdbafbe4223f46c18c04398f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->