### PR TITLE
chore: Update fetch-depth comment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
-          fetch-depth: 0 # If you only need the current version keep this.
+          fetch-depth: 0 # Full history is required for proper changelog generation
 
       - uses: actions/setup-python@v5
         if: ${{ steps.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
## Summary
- Fix incorrect comment on `fetch-depth` in GitHub Actions workflow(s)
- The old comment implied `fetch-depth: 0` was for getting only the current version, when it actually fetches full history

## Test plan
- [ ] Verify CI workflows still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in a GitHub Actions workflow; no behavioral impact.
> 
> **Overview**
> Updates the comment on `actions/checkout`’s `fetch-depth: 0` in `release-please.yml` to correctly state that a full git history is required for changelog generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9456370101c37a1955cbaede33967b546cfcbb19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->