### PR TITLE
fix: align FDv2 goodbye event with spec (reason-only)

### DIFF
--- a/ldclient/impl/datasourcev2/streaming.py
+++ b/ldclient/impl/datasourcev2/streaming.py
@@ -289,12 +289,7 @@ class StreamingDataSource(Synchronizer, DiagnosticSource):
 
         if msg.event == EventName.GOODBYE:
             goodbye = Goodbye.from_dict(json.loads(msg.data))
-            if not goodbye.silent:
-                log.error(
-                    "SSE server received error: %s (%s)",
-                    goodbye.reason,
-                    goodbye.catastrophe,
-                )
+            log.info("SSE server sent goodbye: %s", goodbye.reason)
 
             return None
 

--- a/ldclient/impl/datasystem/protocolv2.py
+++ b/ldclient/impl/datasystem/protocolv2.py
@@ -120,8 +120,6 @@ class Goodbye:
     """
 
     reason: str
-    silent: bool
-    catastrophe: bool
 
     def to_dict(self) -> dict:
         """
@@ -129,8 +127,6 @@ class Goodbye:
         """
         return {
             "reason": self.reason,
-            "silent": self.silent,
-            "catastrophe": self.catastrophe,
         }
 
     @staticmethod
@@ -139,13 +135,11 @@ class Goodbye:
         Deserializes a Goodbye event from a JSON-compatible dictionary.
         """
         reason = data.get("reason")
-        silent = data.get("silent")
-        catastrophe = data.get("catastrophe")
 
-        if reason is None or silent is None or catastrophe is None:
+        if reason is None:
             raise ValueError("Missing required fields in Goodbye JSON.")
 
-        return Goodbye(reason=reason, silent=silent, catastrophe=catastrophe)
+        return Goodbye(reason=reason)
 
 
 @dataclass(frozen=True)

--- a/ldclient/testing/impl/datasourcev2/test_polling_synchronizer.py
+++ b/ldclient/testing/impl/datasourcev2/test_polling_synchronizer.py
@@ -78,7 +78,7 @@ def events() -> dict:
         data=json.dumps(selector.to_dict()),
     )
 
-    goodbye = Goodbye(reason="test reason", silent=True, catastrophe=False)
+    goodbye = Goodbye(reason="test reason")
     goodbye_event = Event(
         event=EventName.GOODBYE,
         data=json.dumps(goodbye.to_dict()),

--- a/ldclient/testing/impl/datasourcev2/test_streaming_synchronizer.py
+++ b/ldclient/testing/impl/datasourcev2/test_streaming_synchronizer.py
@@ -156,7 +156,7 @@ def events() -> dict:
         data=json.dumps(selector.to_dict()),
     )
 
-    goodbye = Goodbye(reason="test reason", silent=True, catastrophe=False)
+    goodbye = Goodbye(reason="test reason")
     goodbye_event = Event(
         event=EventName.GOODBYE,
         data=json.dumps(goodbye.to_dict()),


### PR DESCRIPTION
## Summary
- The FDv2 `goodbye` event is specified to carry only a `reason` field. The Python SDK's `Goodbye` dataclass incorrectly declared `silent` and `catastrophe`, and `from_dict` *raised* `ValueError` if either was missing — meaning a spec-compliant payload would fail to parse.
- This PR removes both fields from the dataclass and from `to_dict`/`from_dict`. `from_dict` now requires only `reason`.
- Streaming consumer in `ldclient/impl/datasourcev2/streaming.py` was logging at `log.error` and reading `goodbye.silent` / `goodbye.catastrophe`. Replaced with a single `log.info("SSE server sent goodbye: %s", goodbye.reason)` — a goodbye is a normal protocol signal, matching what the Java SDK does.

## Test plan
- [x] `poetry run pytest ldclient/testing/impl/datasourcev2/` — 71 tests pass.
- [x] `poetry run pytest ldclient/testing/` — full unit test suite (1161 tests) passes.
- [x] `grep -rn "silent\|catastrophe" ldclient/` — no remaining references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to FDv2 `Goodbye` event serialization/parsing and corresponding log/test updates, with no new behavior beyond accepting spec-compliant payloads and adjusting log level.
> 
> **Overview**
> Aligns the FDv2 `Goodbye` event with the spec by removing the `silent` and `catastrophe` fields from the `Goodbye` dataclass and its `to_dict`/`from_dict` methods, so parsing no longer fails on reason-only payloads.
> 
> Updates the streaming SSE consumer to treat `GOODBYE` as a normal protocol signal (logs `info` with the reason only) and adjusts datasourcev2 polling/streaming tests to construct `Goodbye` with just `reason`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1eb5ccc4f690370867c20748e290b626ff15676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->