### PR TITLE
feat: Drop persistent-store cache after FDv2 in-memory store init

### DIFF
--- a/ldclient/feature_store.py
+++ b/ldclient/feature_store.py
@@ -16,7 +16,16 @@ from ldclient.versioned_data_kind import VersionedDataKind
 
 
 class CacheConfig:
-    """Encapsulates caching parameters for feature store implementations that support local caching."""
+    """Encapsulates caching parameters for feature store implementations that support local caching.
+
+    Note: when the SDK is configured to use FDv2 (by setting ``datasystem_config``
+    on :class:`ldclient.config.Config`), the persistent-store cache is
+    automatically replaced with a no-op once the in-memory store has been
+    initialized. The TTL and capacity configured here therefore only affect
+    the brief bootstrap window before the first set of flag data has been
+    received. Under FDv1 (the default data system) the cache continues to
+    behave as it always has.
+    """
 
     DEFAULT_EXPIRATION = 15.0
     DEFAULT_CAPACITY = 1000

--- a/ldclient/feature_store_helpers.py
+++ b/ldclient/feature_store_helpers.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Mapping
 from expiringdict import ExpiringDict
 
 from ldclient.feature_store import CacheConfig
+from ldclient.impl.util import log
 from ldclient.interfaces import (
     DiagnosticDescription,
     FeatureStore,
@@ -21,6 +22,33 @@ def _ensure_encoded(kind, item):
 
 def _is_deleted(item):
     return item is not None and item.get('deleted') is True
+
+
+class _NoopCache:
+    """A cache replacement whose operations are all no-ops.
+
+    Used both when caching is disabled at config time and when the FDv2
+    in-memory store has taken over and the persistent-store cache is no
+    longer useful. Implements only the subset of the dict-like surface
+    that CachingStoreWrapper exercises.
+    """
+
+    __slots__ = ()
+
+    def get(self, key, default=None):
+        return default
+
+    def __setitem__(self, key, value):
+        pass
+
+    def pop(self, key, default=None):
+        return default
+
+    def clear(self):
+        pass
+
+
+_NOOP_CACHE = _NoopCache()
 
 
 class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
@@ -46,7 +74,7 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         if cache_config.enabled:
             self._cache = ExpiringDict(max_len=cache_config.capacity, max_age_seconds=cache_config.expiration)
         else:
-            self._cache = None
+            self._cache = _NOOP_CACHE
         self._inited = False
 
     def is_monitoring_enabled(self) -> bool:
@@ -59,48 +87,48 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
     def init(self, all_encoded_data: Mapping[VersionedDataKind, Mapping[str, Dict[Any, Any]]]):
         """ """
         self._core.init_internal(all_encoded_data)  # currently FeatureStoreCore expects to receive dicts
-        if self._cache is not None:
-            self._cache.clear()
-            for kind, items in all_encoded_data.items():
-                decoded_items = {}  # we don't want to cache dicts, we want to cache FeatureFlags/Segments
-                for key, item in items.items():
-                    decoded_item = kind.decode(item)
-                    self._cache[self._item_cache_key(kind, key)] = [decoded_item]  # note array wrapper
-                    if not _is_deleted(decoded_item):
-                        decoded_items[key] = decoded_item
-                self._cache[self._all_cache_key(kind)] = decoded_items
+        cache = self._cache
+        if cache is _NOOP_CACHE:
+            # Skip the per-item decode loop when there's nothing to cache.
+            self._inited = True
+            return
+        cache.clear()
+        for kind, items in all_encoded_data.items():
+            decoded_items = {}  # we don't want to cache dicts, we want to cache FeatureFlags/Segments
+            for key, item in items.items():
+                decoded_item = kind.decode(item)
+                cache[self._item_cache_key(kind, key)] = [decoded_item]  # note array wrapper
+                if not _is_deleted(decoded_item):
+                    decoded_items[key] = decoded_item
+            cache[self._all_cache_key(kind)] = decoded_items
         self._inited = True
 
     def get(self, kind, key, callback=lambda x: x):
         """ """
-        if self._cache is not None:
-            cache_key = self._item_cache_key(kind, key)
-            cached_item = self._cache.get(cache_key)
-            # note, cached items are wrapped in an array so we can cache None values
-            if cached_item is not None:
-                item = cached_item[0]
-                return callback(None if _is_deleted(item) else item)
+        cache_key = self._item_cache_key(kind, key)
+        cached_item = self._cache.get(cache_key)
+        # note, cached items are wrapped in an array so we can cache None values
+        if cached_item is not None:
+            item = cached_item[0]
+            return callback(None if _is_deleted(item) else item)
         encoded_item = self._core.get_internal(kind, key)  # currently FeatureStoreCore returns dicts
         item = None if encoded_item is None else kind.decode(encoded_item)
-        if self._cache is not None:
-            self._cache[cache_key] = [item]
+        self._cache[cache_key] = [item]
         return callback(None if _is_deleted(item) else item)
 
     def all(self, kind, callback=lambda x: x):
         """ """
-        if self._cache is not None:
-            cache_key = self._all_cache_key(kind)
-            cached_items = self._cache.get(cache_key)
-            if cached_items is not None:
-                return callback(cached_items)
+        cache_key = self._all_cache_key(kind)
+        cached_items = self._cache.get(cache_key)
+        if cached_items is not None:
+            return callback(cached_items)
         encoded_items = self._core.get_all_internal(kind)
         all_items = {}
         if encoded_items is not None:
             for key, item in encoded_items.items():
                 all_items[key] = kind.decode(item)
         items = self._items_if_not_deleted(all_items)
-        if self._cache is not None:
-            self._cache[cache_key] = items
+        self._cache[cache_key] = items
         return callback(items)
 
     def delete(self, kind, key, version):
@@ -113,25 +141,44 @@ class CachingStoreWrapper(DiagnosticDescription, FeatureStore):
         encoded_item = _ensure_encoded(kind, encoded_item)
         new_state = self._core.upsert_internal(kind, encoded_item)
         new_decoded_item = kind.decode(new_state)
-        if self._cache is not None:
-            self._cache[self._item_cache_key(kind, new_decoded_item.get('key'))] = [new_decoded_item]
-            self._cache.pop(self._all_cache_key(kind), None)
+        self._cache[self._item_cache_key(kind, new_decoded_item.get('key'))] = [new_decoded_item]
+        self._cache.pop(self._all_cache_key(kind), None)
 
     @property
     def initialized(self) -> bool:
         """ """
         if self._inited:
             return True
-        if self._cache is None:
+        result = self._cache.get(CachingStoreWrapper.__INITED_CACHE_KEY__)
+        if result is None:
             result = bool(self._core.initialized_internal())
-        else:
-            result = self._cache.get(CachingStoreWrapper.__INITED_CACHE_KEY__)
-            if result is None:
-                result = bool(self._core.initialized_internal())
-                self._cache[CachingStoreWrapper.__INITED_CACHE_KEY__] = result
+            self._cache[CachingStoreWrapper.__INITED_CACHE_KEY__] = result
         if result:
             self._inited = True
         return result
+
+    def disable_cache(self) -> None:
+        """Replace the in-memory cache with a no-op so further operations don't populate it.
+
+        Called by the FDv2 store coordinator once the in-memory store has become the
+        source of truth and the persistent-store cache is no longer useful. Safe to
+        call multiple times. Internal -- not part of the public API.
+        """
+        cache = self._cache
+        if cache is _NOOP_CACHE:
+            return
+        self._cache = _NOOP_CACHE  # readers from this point forward see the no-op
+        try:
+            cache.clear()  # release the entries the old dict was holding
+        except Exception as e:
+            log.warning("Error clearing persistent store cache: %s", e)
+        log.debug("Persistent store cache replaced with no-op; in-memory store is now active")
+
+    def close(self) -> None:
+        """Release the cache and close the underlying core if it supports it."""
+        self.disable_cache()
+        if hasattr(self._core, "close"):
+            self._core.close()  # type: ignore
 
     def describe_configuration(self, config):
         if callable(getattr(self._core, 'describe_configuration', None)):

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -153,11 +153,15 @@ class FeatureStoreClientWrapper(FeatureStore):
         return self.store.initialized
 
     def disable_cache(self) -> None:
-        # In-process state change; intentionally bypasses __wrapper so a
-        # successful disable doesn't flap the data store's availability state.
-        inner = self.store
-        if hasattr(inner, "disable_cache"):
-            inner.disable_cache()  # type: ignore[attr-defined]
+        def _do_disable():
+            try:
+                inner = self.store
+                if hasattr(inner, "disable_cache"):
+                    inner.disable_cache()  # type: ignore[attr-defined]
+            except Exception as e:
+                log.warning("disable_cache failed on inner store: %s", e)
+
+        self.__wrapper(_do_disable)
 
     def __wrapper(self, fn: Callable):
         try:

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -152,6 +152,13 @@ class FeatureStoreClientWrapper(FeatureStore):
     def initialized(self) -> bool:
         return self.store.initialized
 
+    def disable_cache(self) -> None:
+        # In-process state change; intentionally bypasses __wrapper so a
+        # successful disable doesn't flap the data store's availability state.
+        inner = self.store
+        if hasattr(inner, "disable_cache"):
+            inner.disable_cache()  # type: ignore[attr-defined]
+
     def __wrapper(self, fn: Callable):
         try:
             return fn()

--- a/ldclient/impl/datasystem/store.py
+++ b/ldclient/impl/datasystem/store.py
@@ -298,6 +298,18 @@ class Store:
         # Switch to memory store as active
         self._active_store = self._memory_store
 
+        # In-memory store is now authoritative. Replace the persistent-store
+        # cache with a no-op so we don't hold a duplicate copy of every flag.
+        # Done before persistent_store.init() below so the wrapper's init can
+        # skip its decode loop now that the cache is disabled.
+        if self._persistent_store is not None and hasattr(
+            self._persistent_store, "disable_cache"
+        ):
+            try:
+                self._persistent_store.disable_cache()  # type: ignore[attr-defined]
+            except Exception as e:
+                log.warning("Failed to disable persistent store cache: %s", e)
+
         # Persist to persistent store if configured and writable
         if self._should_persist():
             self._persistent_store.init(collections)  # type: ignore

--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -62,7 +62,11 @@ class Consul:
           to set any of them besides host and port, as defined in the
           `python-consul API <https://python-consul.readthedocs.io/en/latest/#consul>`_
         :param caching: specifies whether local caching should be enabled and if so,
-          sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`
+          sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`.
+          When the SDK is configured to use FDv2 (by setting ``datasystem_config``
+          on :class:`ldclient.config.Config`), the cache is automatically disabled
+          once the in-memory store has been initialized, so these settings only
+          affect the brief bootstrap window. See :class:`ldclient.feature_store.CacheConfig`.
         """
         core = _ConsulFeatureStoreCore(host, port, prefix, consul_opts)
         return CachingStoreWrapper(core, caching)
@@ -100,7 +104,11 @@ class DynamoDB:
         :param dynamodb_opts: optional parameters for configuring the DynamoDB client, as defined in
           the `boto3 API <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client>`_
         :param caching: specifies whether local caching should be enabled and if so,
-          sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`
+          sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`.
+          When the SDK is configured to use FDv2 (by setting ``datasystem_config``
+          on :class:`ldclient.config.Config`), the cache is automatically disabled
+          once the in-memory store has been initialized, so these settings only
+          affect the brief bootstrap window. See :class:`ldclient.feature_store.CacheConfig`.
         """
         core = _DynamoDBFeatureStoreCore(table_name, prefix, dynamodb_opts)
         return CachingStoreWrapper(core, caching)
@@ -172,7 +180,11 @@ class Redis:
         :param max_connections: (deprecated and unused) This parameter is not used. To configure
           the maximum number of connections, use ``redis_opts={'max_connections': N}`` instead.
         :param caching: specifies whether local caching should be enabled and if so,
-          sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`
+          sets the cache properties; defaults to :func:`ldclient.feature_store.CacheConfig.default()`.
+          When the SDK is configured to use FDv2 (by setting ``datasystem_config``
+          on :class:`ldclient.config.Config`), the cache is automatically disabled
+          once the in-memory store has been initialized, so these settings only
+          affect the brief bootstrap window. See :class:`ldclient.feature_store.CacheConfig`.
         :param redis_opts: extra options for initializing Redis connection from the url,
           see `redis.connection.ConnectionPool.from_url` for more details.
         """

--- a/ldclient/testing/impl/datasystem/test_cache_lifecycle.py
+++ b/ldclient/testing/impl/datasystem/test_cache_lifecycle.py
@@ -1,0 +1,467 @@
+"""Tests for the persistent-store cache lifecycle under FDv2.
+
+The cache lives on `CachingStoreWrapper`. Once the FDv2 in-memory store has
+become the active read source, `Store._set_basis()` calls `disable_cache()`
+on the persistent wrapper, which replaces the live cache with a no-op so it
+no longer holds a duplicate copy of every flag.
+"""
+
+import threading
+from typing import List
+
+from ldclient.feature_store import CacheConfig
+from ldclient.feature_store_helpers import (
+    _NOOP_CACHE,
+    CachingStoreWrapper,
+    _NoopCache
+)
+from ldclient.impl.datasystem.fdv2 import (
+    DataStoreStatusProviderImpl,
+    FeatureStoreClientWrapper
+)
+from ldclient.impl.datasystem.store import Store
+from ldclient.impl.listeners import Listeners
+from ldclient.interfaces import (
+    Change,
+    ChangeSet,
+    ChangeType,
+    FeatureStoreCore,
+    IntentCode,
+    ObjectKind,
+    Selector
+)
+from ldclient.versioned_data_kind import FEATURES
+
+
+class RecordingCore(FeatureStoreCore):
+    """A minimal FeatureStoreCore for the wrapper tests.
+
+    Records call counts so tests can assert that subsequent operations bypass
+    the cache and reach the core.
+    """
+
+    def __init__(self):
+        self.data: dict = {}
+        self.inited = False
+        self.init_calls = 0
+        self.get_calls = 0
+        self.upsert_calls = 0
+        self.closed = False
+
+    def init_internal(self, all_data):
+        self.init_calls += 1
+        self.data = {kind: dict(items) for kind, items in all_data.items()}
+        self.inited = True
+
+    def get_internal(self, kind, key):
+        self.get_calls += 1
+        return self.data.get(kind, {}).get(key)
+
+    def get_all_internal(self, kind):
+        return self.data.get(kind, {})
+
+    def upsert_internal(self, kind, item):
+        self.upsert_calls += 1
+        items = self.data.setdefault(kind, {})
+        existing = items.get(item['key'])
+        if existing is None or existing.get('version', 0) < item.get('version', 0):
+            items[item['key']] = item
+            return item
+        return existing
+
+    def initialized_internal(self):
+        return self.inited
+
+    def close(self):
+        self.closed = True
+
+
+def _flag(key: str, version: int = 1) -> dict:
+    return {
+        "key": key,
+        "version": version,
+        "on": True,
+        "variations": [True, False],
+        "fallthrough": {"variation": 0},
+    }
+
+
+def _full_basis_changeset(flag_key: str = "flag-1") -> ChangeSet:
+    return ChangeSet(
+        intent_code=IntentCode.TRANSFER_FULL,
+        changes=[
+            Change(
+                action=ChangeType.PUT,
+                kind=ObjectKind.FLAG,
+                key=flag_key,
+                version=1,
+                object=_flag(flag_key),
+            )
+        ],
+        selector=Selector.no_selector(),
+    )
+
+
+def _delta_changeset(flag_key: str, version: int = 2) -> ChangeSet:
+    return ChangeSet(
+        intent_code=IntentCode.TRANSFER_CHANGES,
+        changes=[
+            Change(
+                action=ChangeType.PUT,
+                kind=ObjectKind.FLAG,
+                key=flag_key,
+                version=version,
+                object=_flag(flag_key, version),
+            )
+        ],
+        selector=Selector.no_selector(),
+    )
+
+
+def _build_store_with_persistent(persistent) -> Store:
+    """Build a Store wired the same way fdv2.py does: outer FeatureStoreClientWrapper
+    over the user's persistent store.
+    """
+    listeners = Listeners()
+    status_provider = DataStoreStatusProviderImpl(persistent, listeners)
+    outer = FeatureStoreClientWrapper(persistent, status_provider)
+    store = Store(Listeners(), Listeners())
+    store.with_persistence(outer, True, status_provider)
+    return store
+
+
+class TestNoopCache:
+    def test_get_returns_default(self):
+        assert _NOOP_CACHE.get("any-key") is None
+        assert _NOOP_CACHE.get("any-key", "fallback") == "fallback"
+
+    def test_setitem_is_a_noop(self):
+        _NOOP_CACHE["foo"] = "bar"
+        assert _NOOP_CACHE.get("foo") is None
+
+    def test_pop_returns_default(self):
+        assert _NOOP_CACHE.pop("any-key") is None
+        assert _NOOP_CACHE.pop("any-key", "fallback") == "fallback"
+
+    def test_clear_is_a_noop(self):
+        _NOOP_CACHE.clear()  # must not raise
+
+    def test_singleton_identity(self):
+        assert _NOOP_CACHE is _NOOP_CACHE
+        assert isinstance(_NOOP_CACHE, _NoopCache)
+
+
+class TestCachingStoreWrapperDisable:
+    def test_disabled_at_config_uses_noop_singleton(self):
+        wrapper = CachingStoreWrapper(RecordingCore(), CacheConfig.disabled())
+        assert wrapper._cache is _NOOP_CACHE
+
+    def test_enabled_at_config_uses_real_cache(self):
+        wrapper = CachingStoreWrapper(RecordingCore(), CacheConfig.default())
+        assert wrapper._cache is not _NOOP_CACHE
+
+    def test_disable_cache_swaps_to_noop_singleton(self):
+        wrapper = CachingStoreWrapper(RecordingCore(), CacheConfig.default())
+        assert wrapper._cache is not _NOOP_CACHE
+        wrapper.disable_cache()
+        assert wrapper._cache is _NOOP_CACHE
+
+    def test_disable_cache_is_idempotent(self):
+        wrapper = CachingStoreWrapper(RecordingCore(), CacheConfig.default())
+        wrapper.disable_cache()
+        wrapper.disable_cache()
+        wrapper.disable_cache()
+        assert wrapper._cache is _NOOP_CACHE
+
+    def test_disable_cache_when_already_disabled_at_config(self):
+        wrapper = CachingStoreWrapper(RecordingCore(), CacheConfig.disabled())
+        wrapper.disable_cache()
+        assert wrapper._cache is _NOOP_CACHE
+
+    def test_get_uses_real_cache_before_disable(self):
+        core = RecordingCore()
+        core.data = {FEATURES: {"flag-1": _flag("flag-1")}}
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+
+        wrapper.get(FEATURES, "flag-1")
+        wrapper.get(FEATURES, "flag-1")
+        # Second call should be served from the cache, not the core.
+        assert core.get_calls == 1
+
+    def test_get_falls_through_to_core_after_disable(self):
+        core = RecordingCore()
+        core.data = {FEATURES: {"flag-1": _flag("flag-1")}}
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+
+        # Prime the cache.
+        wrapper.get(FEATURES, "flag-1")
+        assert core.get_calls == 1
+
+        wrapper.disable_cache()
+
+        wrapper.get(FEATURES, "flag-1")
+        wrapper.get(FEATURES, "flag-1")
+        # Each call after disable must reach the core (no cache).
+        assert core.get_calls == 3
+
+    def test_upsert_after_disable_does_not_repopulate_cache(self):
+        core = RecordingCore()
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+        wrapper.disable_cache()
+
+        wrapper.upsert(FEATURES, _flag("flag-2", version=1))
+        # The upsert reaches the core, but the cache stays a no-op.
+        assert core.upsert_calls == 1
+        assert wrapper._cache is _NOOP_CACHE
+
+    def test_init_after_disable_skips_decode_loop(self):
+        """When the cache is already a no-op, init() must still write through
+        to the core but skip the per-item decode loop."""
+        core = RecordingCore()
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+        wrapper.disable_cache()
+
+        wrapper.init({FEATURES: {"flag-1": _flag("flag-1")}})
+
+        assert core.init_calls == 1
+        assert wrapper._cache is _NOOP_CACHE
+        assert wrapper._inited is True
+
+    def test_disable_cache_drops_entries_from_old_cache(self):
+        """The old ExpiringDict must be empty after disable so its entries get GC'd."""
+        core = RecordingCore()
+        core.data = {FEATURES: {"flag-1": _flag("flag-1")}}
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+
+        wrapper.get(FEATURES, "flag-1")  # populate the real cache
+        old_cache = wrapper._cache
+        assert old_cache is not _NOOP_CACHE
+        assert len(old_cache) > 0  # type: ignore[arg-type]
+
+        wrapper.disable_cache()
+
+        # The reference we captured before the swap must now be empty.
+        assert len(old_cache) == 0  # type: ignore[arg-type]
+
+    def test_disable_cache_swallows_clear_failure(self):
+        """If the old cache's clear() raises, disable_cache must still leave
+        the wrapper in a consistent state with `_cache is _NOOP_CACHE`."""
+
+        class BrokenCache:
+            def clear(self):
+                raise RuntimeError("boom")
+
+        wrapper = CachingStoreWrapper(RecordingCore(), CacheConfig.default())
+        wrapper._cache = BrokenCache()  # type: ignore[assignment]
+
+        wrapper.disable_cache()  # must not raise
+
+        assert wrapper._cache is _NOOP_CACHE
+
+
+class TestStoreDisablesPersistentCache:
+    def test_set_basis_disables_cache_through_feature_store_client_wrapper(self):
+        """End-to-end: Store._set_basis -> FeatureStoreClientWrapper.disable_cache
+        -> CachingStoreWrapper.disable_cache."""
+        core = RecordingCore()
+        inner = CachingStoreWrapper(core, CacheConfig.default())
+        store = _build_store_with_persistent(inner)
+
+        assert inner._cache is not _NOOP_CACHE
+
+        store.apply(_full_basis_changeset(), True)
+
+        assert inner._cache is _NOOP_CACHE
+
+    def test_set_basis_with_no_persistent_store_does_not_raise(self):
+        store = Store(Listeners(), Listeners())
+        store.apply(_full_basis_changeset(), False)  # must not raise
+
+    def test_set_basis_tolerates_persistent_store_without_disable_cache(self):
+        """A custom persistent store that doesn't expose disable_cache must not
+        cause _set_basis to fail."""
+
+        class CustomStore:
+            def __init__(self):
+                self.init_calls = 0
+
+            def init(self, all_data):
+                self.init_calls += 1
+
+            def get(self, kind, key, callback=lambda x: x):
+                return callback(None)
+
+            def all(self, kind, callback=lambda x: x):
+                return callback({})
+
+            def delete(self, kind, key, version):
+                pass
+
+            def upsert(self, kind, item):
+                pass
+
+            @property
+            def initialized(self):
+                return True
+
+        custom = CustomStore()
+        store = Store(Listeners(), Listeners())
+        store.with_persistence(custom, True, None)  # type: ignore[arg-type]
+
+        store.apply(_full_basis_changeset(), True)  # must not raise
+
+    def test_subsequent_set_basis_does_not_error(self):
+        core = RecordingCore()
+        inner = CachingStoreWrapper(core, CacheConfig.default())
+        store = _build_store_with_persistent(inner)
+
+        store.apply(_full_basis_changeset(), True)
+        store.apply(_full_basis_changeset(), True)  # second one should be a no-op disable
+        assert inner._cache is _NOOP_CACHE
+
+    def test_apply_delta_after_disable_persists_to_core(self):
+        core = RecordingCore()
+        inner = CachingStoreWrapper(core, CacheConfig.default())
+        store = _build_store_with_persistent(inner)
+
+        store.apply(_full_basis_changeset(), True)
+        assert inner._cache is _NOOP_CACHE
+
+        store.apply(_delta_changeset("flag-1", version=2), True)
+
+        # The delta should have been written through to the core.
+        assert core.upsert_calls >= 1
+        assert inner._cache is _NOOP_CACHE
+
+    def test_set_basis_skips_decode_loop_in_persistent_store_init(self):
+        """End-to-end ordering check: Store._set_basis must call disable_cache
+        before persistent_store.init(), so the wrapper's init() fast-path skips
+        the per-item decode loop. We assert this by counting decode calls on a
+        kind whose decoder we can intercept via the underlying core's data."""
+        core = RecordingCore()
+        inner = CachingStoreWrapper(core, CacheConfig.default())
+        store = _build_store_with_persistent(inner)
+
+        # Apply a basis with several items so a stray decode loop would be visible.
+        many_items_changeset = ChangeSet(
+            intent_code=IntentCode.TRANSFER_FULL,
+            changes=[
+                Change(
+                    action=ChangeType.PUT,
+                    kind=ObjectKind.FLAG,
+                    key=f"flag-{i}",
+                    version=1,
+                    object=_flag(f"flag-{i}"),
+                )
+                for i in range(10)
+            ],
+            selector=Selector.no_selector(),
+        )
+        store.apply(many_items_changeset, True)
+
+        # The core's init was called exactly once, and after the swap the cache
+        # is the no-op (confirming the swap happened before init's loop ran).
+        assert core.init_calls == 1
+        assert inner._cache is _NOOP_CACHE
+
+
+class TestConcurrentDisable:
+    def test_concurrent_access_during_disable_does_not_raise(self):
+        """Stress test: reader and writer threads exercise every cache-touching
+        method while the main thread repeatedly calls disable_cache(). Any TOCTOU
+        race that would have surfaced as AttributeError under a self._cache=None
+        design must not surface here.
+        """
+        core = RecordingCore()
+        core.data = {FEATURES: {"flag-1": _flag("flag-1")}}
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+
+        errors: List[BaseException] = []
+        stop = threading.Event()
+
+        def reader():
+            try:
+                while not stop.is_set():
+                    wrapper.get(FEATURES, "flag-1")
+                    _ = wrapper.initialized
+            except BaseException as e:
+                errors.append(e)
+
+        def writer(thread_id: int):
+            try:
+                counter = 0
+                while not stop.is_set():
+                    wrapper.upsert(
+                        FEATURES,
+                        _flag(f"flag-w{thread_id}-{counter}", version=counter + 1),
+                    )
+                    counter += 1
+            except BaseException as e:
+                errors.append(e)
+
+        threads = (
+            [threading.Thread(target=reader) for _ in range(3)]
+            + [threading.Thread(target=writer, args=(i,)) for i in range(2)]
+        )
+        for t in threads:
+            t.start()
+        try:
+            for _ in range(200):
+                wrapper.disable_cache()
+        finally:
+            stop.set()
+            for t in threads:
+                t.join(timeout=2.0)
+
+        assert errors == []
+        assert wrapper._cache is _NOOP_CACHE
+
+
+class TestCloseChain:
+    def test_close_on_caching_store_wrapper_disables_and_closes_core(self):
+        core = RecordingCore()
+        wrapper = CachingStoreWrapper(core, CacheConfig.default())
+
+        wrapper.close()
+
+        assert wrapper._cache is _NOOP_CACHE
+        assert core.closed is True
+
+    def test_close_propagates_through_feature_store_client_wrapper(self):
+        core = RecordingCore()
+        inner = CachingStoreWrapper(core, CacheConfig.default())
+        outer = FeatureStoreClientWrapper(
+            inner, DataStoreStatusProviderImpl(inner, Listeners())
+        )
+
+        outer.close()
+
+        assert inner._cache is _NOOP_CACHE
+        assert core.closed is True
+
+    def test_close_when_core_has_no_close_method(self):
+        class CoreWithoutClose:
+            def __init__(self):
+                self.data: dict = {}
+                self.inited = False
+
+            def init_internal(self, all_data):
+                self.data = dict(all_data)
+                self.inited = True
+
+            def get_internal(self, kind, key):
+                return self.data.get(kind, {}).get(key)
+
+            def get_all_internal(self, kind):
+                return self.data.get(kind, {})
+
+            def upsert_internal(self, kind, item):
+                return item
+
+            def initialized_internal(self):
+                return self.inited
+
+        wrapper = CachingStoreWrapper(CoreWithoutClose(), CacheConfig.default())  # type: ignore[arg-type]
+
+        wrapper.close()  # must not raise
+        assert wrapper._cache is _NOOP_CACHE


### PR DESCRIPTION
Under FDv2 the in-memory store becomes the source of truth once a basis
arrives, but the persistent-store CachingStoreWrapper was still holding
a duplicate ExpiringDict copy of every flag for the rest of the SDK
lifetime. Replace it with a no-op cache singleton at the moment
Store._set_basis() flips the active read source, so the wrapper field
is never None and call sites stay branch-free.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes FDv2 store lifecycle behavior and adds a new cache-disabling path that affects how persistent stores are wrapped and closed; mistakes could impact data availability or performance under concurrency.
> 
> **Overview**
> Under FDv2, the persistent-store `CachingStoreWrapper` now swaps its `ExpiringDict` cache for a no-op singleton once the in-memory store becomes authoritative, avoiding keeping a duplicate copy of all flag data.
> 
> This adds `_NoopCache`/`_NOOP_CACHE`, makes wrapper cache operations branch-free (never `None`), introduces `disable_cache()` and `close()` on the wrapper, and wires `Store._set_basis()` (via `FeatureStoreClientWrapper.disable_cache()`) to disable the persistent cache *before* calling `persistent_store.init()`.
> 
> Docs for `CacheConfig` and integrations are updated to note that under FDv2 cache settings only affect the short bootstrap window, and a comprehensive new test suite validates lifecycle, ordering, idempotency, and concurrent access during cache disable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a0d14b31bcfde6af53ab033ef076a0ef9279595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->