### PR TITLE
chore: remove FDv2 pre-release warnings for GA promotion

### DIFF
--- a/ldclient/impl/datasourcev2/__init__.py
+++ b/ldclient/impl/datasourcev2/__init__.py
@@ -6,6 +6,4 @@ All types and implementations in this module are considered internal
 and are not part of the public API of the LaunchDarkly Python SDK.
 They are subject to change without notice and should not be used directly
 by users of the SDK.
-
-You have been warned.
 """

--- a/ldclient/impl/datasystem/protocolv2.py
+++ b/ldclient/impl/datasystem/protocolv2.py
@@ -12,12 +12,6 @@ from ldclient.interfaces import EventName, ObjectKind
 class DeleteObject:
     """
     Specifies the deletion of a particular object.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     version: int
@@ -59,12 +53,6 @@ class DeleteObject:
 class PutObject:
     """
     Specifies the addition of a particular object with upsert semantics.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     version: int
@@ -111,12 +99,6 @@ class PutObject:
 class Goodbye:
     """
     Goodbye represents a goodbye event.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     reason: str
@@ -146,12 +128,6 @@ class Goodbye:
 class Error:
     """
     Error represents an error event.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     payload_id: str

--- a/ldclient/impl/integrations/files/file_data_sourcev2.py
+++ b/ldclient/impl/integrations/files/file_data_sourcev2.py
@@ -50,12 +50,6 @@ class _FileDataSourceV2:
     """
     Internal implementation of both Initializer and Synchronizer protocols for file-based data.
 
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
-
     This component reads feature flag and segment data from local files and provides them
     via the FDv2 protocol interfaces. Each instance implements both Initializer and Synchronizer
     protocols:

--- a/ldclient/integrations/__init__.py
+++ b/ldclient/integrations/__init__.py
@@ -289,12 +289,6 @@ class Files:
     def new_data_source_v2(paths: str | List[str], poll_interval: float = 1, force_polling: bool = False) -> DataSourceBuilder:
         """Provides a way to use local files as a source of feature flag state using the FDv2 protocol.
 
-        This type is not stable, and not subject to any backwards
-        compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-        Do not use it.
-        You have been warned.
-
         This returns a builder that can be used with the FDv2 data system configuration as both an
         Initializer and a Synchronizer. When used as an Initializer, it reads files once. When used
         as a Synchronizer, it watches for file changes and automatically updates when files are modified.

--- a/ldclient/integrations/test_datav2.py
+++ b/ldclient/integrations/test_datav2.py
@@ -540,12 +540,6 @@ class TestDataV2:
     A mechanism for providing dynamically updatable feature flag state in a
     simplified form to an SDK client in test scenarios using the FDv2 protocol.
 
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
-
     Unlike ``Files``, this mechanism does not use any external resources. It provides only
     the data that the application has put into it using the ``update`` method.
     ::

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -19,12 +19,6 @@ class DataStoreMode(Enum):
     """
     DataStoreMode represents the mode of operation of a Data Store in FDV2
     mode.
-
-    This enum is not stable, and not subject to any backwards compatibility
-    guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     READ_ONLY = 'read-only'
@@ -1143,12 +1137,6 @@ class DataStoreStatusProvider:
 class EventName(str, Enum):
     """
     EventName represents the name of an event that can be sent by the server for FDv2.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     PUT_OBJECT = "put-object"
@@ -1192,12 +1180,6 @@ class EventName(str, Enum):
 class Selector:
     """
     Selector represents a particular snapshot of data.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     state: str = ""
@@ -1252,12 +1234,6 @@ class Selector:
 class ChangeType(Enum):
     """
     ChangeType specifies if an object is being upserted or deleted.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     PUT = "put"
@@ -1274,12 +1250,6 @@ class ChangeType(Enum):
 class ObjectKind(str, Enum):
     """
     ObjectKind represents the kind of object.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     FLAG = "flag"
@@ -1290,12 +1260,6 @@ class ObjectKind(str, Enum):
 class Change:
     """
     Change represents a change to a piece of data, such as an update or deletion.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     action: ChangeType
@@ -1308,12 +1272,6 @@ class Change:
 class IntentCode(str, Enum):
     """
     IntentCode represents the various intents that can be sent by the server.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     TRANSFER_FULL = "xfer-full"
@@ -1336,12 +1294,6 @@ class IntentCode(str, Enum):
 class ChangeSet:
     """
     ChangeSet represents a list of changes to be applied.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     intent_code: IntentCode
@@ -1355,12 +1307,6 @@ class Basis:
     Basis represents the initial payload of data that a data source can
     provide. Initializers provide this via fetch, whereas Synchronizers provide
     it asynchronously.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     change_set: ChangeSet
@@ -1378,12 +1324,6 @@ class Basis:
 class ChangeSetBuilder:
     """
     ChangeSetBuilder is a helper for constructing a ChangeSet.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     def __init__(self):
@@ -1490,12 +1430,6 @@ class ChangeSetBuilder:
 class Payload:
     """
     Payload represents a payload delivered in a streaming response.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     id: str
@@ -1539,12 +1473,6 @@ class ServerIntent:
     """
     ServerIntent represents the type of change associated with the payload
     (e.g., transfer full, transfer changes, etc.)
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     payload: Payload
@@ -1582,12 +1510,6 @@ class SelectorStore(Protocol):
     """
     SelectorStore represents a component capable of providing Selectors
     for data retrieval.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     @abstractmethod
@@ -1611,12 +1533,6 @@ class Initializer(Protocol):  # pylint: disable=too-few-public-methods
     which may be stale but is fast to retrieve. This initial data serves as a
     foundation for a Synchronizer to build upon, enabling it to provide updates
     as new changes occur.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     @property
@@ -1643,12 +1559,6 @@ class Update:
     """
     Update represents the results of a synchronizer's ongoing sync
     method.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
 
     state: DataSourceState
@@ -1673,12 +1583,6 @@ class Synchronizer(Protocol):  # pylint: disable=too-few-public-methods
     It is responsible for yielding Update objects that represent the current state
     of the data source, including any changes that have occurred since the last
     synchronization.
-
-    This type is not stable, and not subject to any backwards
-    compatibility guarantees or semantic versioning. It is not suitable for production usage.
-
-    Do not use it.
-    You have been warned.
     """
     @property
     @abstractmethod


### PR DESCRIPTION
## Summary

- FDv2 / data-saving mode is going GA per the [SDK Release Standards spec](https://github.com/launchdarkly/sdk-specs/tree/main/specs/RELEASE-sdk-release-standards). GA-stage features must not carry experimental / pre-release warning prose in their public API surface.
- Removes the pre-release warning prose ("not stable, and not subject to any backwards compatibility guarantees", "not suitable for production usage", "You have been warned") from docstrings on FDv2-related types in `ldclient/interfaces.py`, `ldclient/impl/datasystem/protocolv2.py`, `ldclient/impl/datasourcev2/__init__.py`, `ldclient/impl/integrations/files/file_data_sourcev2.py`, `ldclient/integrations/__init__.py`, and `ldclient/integrations/test_datav2.py`. Descriptive docstrings are preserved.

Tracking: [SDK-2349](https://launchdarkly.atlassian.net/browse/SDK-2349)

## Test plan

- [x] `python -m py_compile` clean on each changed file
- [ ] CI green

[SDK-2349]: https://launchdarkly.atlassian.net/browse/SDK-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docstring-only edits that do not change runtime behavior, but they touch public-facing documentation for FDv2 APIs and integrations.
> 
> **Overview**
> Removes the *pre-release/experimental* warning prose (e.g., "not stable", "not suitable for production", "You have been warned") from FDv2-related docstrings across `ldclient/interfaces.py`, `impl/datasystem/protocolv2.py`, and FDv2 file/test integrations.
> 
> No functional or behavioral changes were made; this PR is strictly a documentation/polish update to align FDv2 with GA expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9806d25346dc643288795e929c064e6dd68fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->