### PR TITLE
fix!: Replace Python 2-style ABC patterns with Python 3 equivalents

### DIFF
--- a/contract-tests/hook.py
+++ b/contract-tests/hook.py
@@ -3,7 +3,7 @@ from typing import Optional
 import requests
 
 from ldclient.evaluation import EvaluationDetail
-from ldclient.hook import EvaluationSeriesContext, Hook
+from ldclient.hook import EvaluationSeriesContext, Hook, Metadata
 
 
 class PostingHook(Hook):
@@ -12,6 +12,10 @@ class PostingHook(Hook):
         self.__callback = callback
         self.__data = data
         self.__errors = errors
+
+    @property
+    def metadata(self) -> Metadata:
+        return Metadata(name=self.__name)
 
     def before_evaluation(self, series_context: EvaluationSeriesContext, data: dict) -> dict:
         return self.__post("beforeEvaluation", series_context, data, None)

--- a/ldclient/hook.py
+++ b/ldclient/hook.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
@@ -28,7 +28,7 @@ class Metadata:
     name: str  #: A name representing a hook instance.
 
 
-class Hook:
+class Hook(ABC):
     """
     Abstract class for extending SDK functionality via hooks.
 
@@ -39,9 +39,8 @@ class Hook:
     customer integrations.
     """
 
-    __metaclass__ = ABCMeta
-
-    @abstractproperty
+    @property
+    @abstractmethod
     def metadata(self) -> Metadata:
         """
         Get metadata about the hook implementation.

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -3,7 +3,7 @@ This submodule contains interfaces for various components of the SDK.
 
 They may be useful in writing new implementations of these components, or for testing.
 """
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Generator, List, Mapping, Optional, Protocol
@@ -51,7 +51,7 @@ class ReadOnlyStore(Protocol):
         raise NotImplementedError
 
 
-class FeatureStore:
+class FeatureStore(ABC):
     """
     Interface for a versioned store for feature flags and related objects received from LaunchDarkly.
     Implementations should permit concurrent access and updates.
@@ -66,8 +66,6 @@ class FeatureStore:
     These semantics support the primary use case for the store, which synchronizes a collection
     of objects based on update messages that may be received out-of-order.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def get(self, kind: VersionedDataKind, key: str, callback: Callable[[Any], Any] = lambda x: x) -> Any:
@@ -125,7 +123,8 @@ class FeatureStore:
         :param item: The object to update or insert
         """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def initialized(self) -> bool:
         """
         Returns whether the store has been initialized yet or not
@@ -206,7 +205,7 @@ class FeatureStore:
     #     """
 
 
-class FeatureStoreCore:
+class FeatureStoreCore(ABC):
     """
     Interface for a simplified subset of the functionality of :class:`FeatureStore`, to be used
     in conjunction with :class:`ldclient.feature_store_helpers.CachingStoreWrapper`. This allows
@@ -214,8 +213,6 @@ class FeatureStoreCore:
     commonly be needed in any such implementation, such as caching. Instead, they can implement
     only ``FeatureStoreCore`` and then create a ``CachingStoreWrapper``.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def get_internal(self, kind: VersionedDataKind, key: str) -> dict:
@@ -321,14 +318,12 @@ class BackgroundOperation:
         return True
 
 
-class UpdateProcessor(BackgroundOperation):
+class UpdateProcessor(BackgroundOperation, ABC):
     """
     Interface for the component that obtains feature flag data in some way and passes it to a
     :class:`FeatureStore`. The built-in implementations of this are the client's standard streaming
     or polling behavior. For testing purposes, there is also :func:`ldclient.integrations.Files.new_data_source()`.
     """
-
-    __metaclass__ = ABCMeta
 
     def initialized(self) -> bool:  # type: ignore[empty-body]
         """
@@ -336,13 +331,11 @@ class UpdateProcessor(BackgroundOperation):
         """
 
 
-class EventProcessor:
+class EventProcessor(ABC):
     """
     Interface for the component that buffers analytics events and sends them to LaunchDarkly.
     The default implementation can be replaced for testing purposes.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def send_event(self, event):
@@ -366,13 +359,11 @@ class EventProcessor:
         """
 
 
-class FeatureRequester:
+class FeatureRequester(ABC):
     """
     Interface for the component that acquires feature flag data in polling mode. The default
     implementation can be replaced for testing purposes.
     """
-
-    __metaclass__ = ABCMeta
 
     def get_all(self):
         """
@@ -531,7 +522,8 @@ class BigSegmentStoreStatusProvider:
     might return incorrect values. Use :func:`add_listener()` to register a callback for notifications.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def status(self) -> BigSegmentStoreStatus:
         """
         Gets the current status of the store.
@@ -713,7 +705,7 @@ class DataSourceStatus:
         return self.__last_error
 
 
-class DataSourceStatusProvider:
+class DataSourceStatusProvider(ABC):
     """
     An interface for querying the status of the SDK's data source. The data source is the component
     that receives updates to feature flag data; normally this is a streaming connection, but it
@@ -724,9 +716,8 @@ class DataSourceStatusProvider:
     implement this interface.
     """
 
-    __metaclass__ = ABCMeta
-
-    @abstractproperty
+    @property
+    @abstractmethod
     def status(self) -> DataSourceStatus:
         """
         Returns the current status of the data source.
@@ -765,7 +756,7 @@ class DataSourceStatusProvider:
         pass
 
 
-class DataSourceUpdateSink:
+class DataSourceUpdateSink(ABC):
     """
     Interface that a data source implementation will use to push data into
     the SDK.
@@ -774,8 +765,6 @@ class DataSourceUpdateSink:
     the data store directly, so that the SDK can perform any other
     necessary operations that must happen when data is updated.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def init(self, all_data: Mapping[VersionedDataKind, Mapping[str, dict]]):
@@ -892,15 +881,13 @@ class FlagValueChange:
         return self.__new_value
 
 
-class FlagTracker:
+class FlagTracker(ABC):
     """
     An interface for tracking changes in feature flag configurations.
 
     An implementation of this interface is returned by :class:`ldclient.client.LDClient.flag_tracker`.
     Application code never needs to implement this interface.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def add_listener(self, listener: Callable[[FlagChange], None]):
@@ -979,8 +966,6 @@ class DataStoreStatus:
     Information about the data store's status.
     """
 
-    __metaclass__ = ABCMeta
-
     def __init__(self, available: bool, stale: bool):
         self._available = available
         self._stale = stale
@@ -1025,13 +1010,11 @@ class DataStoreStatus:
         return False
 
 
-class DataStoreUpdateSink:
+class DataStoreUpdateSink(ABC):
     """
     Interface that a data store implementation can use to report information
     back to the SDK.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def status(self) -> DataStoreStatus:
@@ -1052,7 +1035,8 @@ class DataStoreUpdateSink:
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def listeners(self) -> Listeners:
         """
         Access the listeners associated with this sink instance.
@@ -1060,7 +1044,7 @@ class DataStoreUpdateSink:
         pass
 
 
-class DataStoreStatusProvider:
+class DataStoreStatusProvider(ABC):
     """
     An interface for querying the status of a persistent data store.
 
@@ -1068,9 +1052,8 @@ class DataStoreStatusProvider:
     Application code should not implement this interface.
     """
 
-    __metaclass__ = ABCMeta
-
-    @abstractproperty
+    @property
+    @abstractmethod
     def status(self) -> DataStoreStatus:
         """
         Returns the current status of the store.

--- a/ldclient/migrations/migrator.py
+++ b/ldclient/migrations/migrator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from datetime import datetime
 from random import Random
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
@@ -25,13 +25,11 @@ if TYPE_CHECKING:
     from ldclient import Context, LDClient
 
 
-class Migrator:
+class Migrator(ABC):
     """
     A migrator is the interface through which migration support is executed. A
     migrator is configured through the :class:`MigratorBuilder`.
     """
-
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def read(self, key: str, context: Context, default_stage: Stage, payload: Optional[Any] = None) -> OperationResult:

--- a/ldclient/plugin.py
+++ b/ldclient/plugin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
@@ -58,7 +58,7 @@ class PluginMetadata:
     name: str  #: A name representing the plugin instance
 
 
-class Plugin:
+class Plugin(ABC):
     """
     Abstract base class for extending SDK functionality via plugins.
 
@@ -71,8 +71,6 @@ class Plugin:
     Plugins provide an interface which allows for initialization, access to
     credentials, and hook registration in a single interface.
     """
-
-    __metaclass__ = ABCMeta
 
     @property
     @abstractmethod

--- a/ldclient/testing/integrations/big_segment_store_test_base.py
+++ b/ldclient/testing/integrations/big_segment_store_test_base.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 from os import environ
 from typing import List
 
@@ -66,7 +66,8 @@ class BigSegmentStoreTestScope:
 
 @pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
 class BigSegmentStoreTestBase:
-    @abstractproperty
+    @property
+    @abstractmethod
     def tester_class(self):
         pass
 

--- a/ldclient/testing/integrations/persistent_feature_store_test_base.py
+++ b/ldclient/testing/integrations/persistent_feature_store_test_base.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, abstractproperty
+from abc import abstractmethod
 
 import pytest
 
@@ -46,7 +46,8 @@ class PersistentFeatureStoreTester(FeatureStoreTester):
 
 @pytest.mark.skipif(skip_database_tests, reason="skipping database tests")
 class PersistentFeatureStoreTestBase(FeatureStoreTestBase):
-    @abstractproperty
+    @property
+    @abstractmethod
     def tester_class(self):
         pass
 


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Replace Python 2-style ABC patterns with Python 3 equivalents
END_COMMIT_OVERRIDE

## Summary

- Replace `__metaclass__ = ABCMeta` class-body assignments (Python 2-only, silently ignored in Python 3) with proper `(ABC)` base class inheritance across 4 modules and 11 classes.
- Replace `@abstractproperty` decorators (deprecated since Python 3.3) with the correct `@property` + `@abstractmethod` stacking in 7 locations across 4 files.
- Remove now-unused `ABCMeta` and `abstractproperty` from all `from abc import ...` lines.

## Files changed

| File | Changes |
|---|---|
| `ldclient/interfaces.py` | 11 classes: `__metaclass__` → `(ABC)`; 5 `@abstractproperty` → `@property` + `@abstractmethod` |
| `ldclient/hook.py` | `Hook` class + `metadata` property |
| `ldclient/plugin.py` | `Plugin` class |
| `ldclient/migrations/migrator.py` | `Migrator` class |
| `ldclient/testing/integrations/persistent_feature_store_test_base.py` | `tester_class` property |
| `ldclient/testing/integrations/big_segment_store_test_base.py` | `tester_class` property |

## Why

In Python 3, `__metaclass__ = ABCMeta` inside a class body is a no-op — the metaclass is never applied, so `@abstractmethod` decorators were not enforced. Using `(ABC)` as a base class is the correct Python 3 pattern and actually enforces the abstract interface.

`@abstractproperty` has been deprecated since Python 3.3 and emits `DeprecationWarning` in newer Python versions. The correct replacement is to stack `@property` on top of `@abstractmethod`.

## Test plan

- [x] `make test` — 1005 passed, 194 skipped (database integration tests, expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Marked breaking because stricter ABC enforcement can surface at runtime if custom subclasses omitted required abstract members; behavior of complete implementations should be unchanged.
> 
> **Overview**
> Replaces legacy Python 2 abstract-base patterns with idiomatic Python 3 across SDK interfaces, hooks, plugins, migrations, and integration test bases.
> 
> **`__metaclass__ = ABCMeta`** is removed in favor of inheriting **`(ABC)`** on classes such as `FeatureStore`, `Hook`, `Plugin`, `Migrator`, and related `ldclient.interfaces` types, so `@abstractmethod` is actually enforced at instantiation time. **`@abstractproperty`** is replaced with **`@property` + `@abstractmethod`** on abstract properties like `Hook.metadata`, `FeatureStore.initialized`, and test-base `tester_class`. Imports drop unused `ABCMeta` / `abstractproperty`.
> 
> Contract test **`PostingHook`** now implements **`metadata`** so it stays a valid `Hook` subclass under the stricter ABC rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3162cfafd83c6eb50e6e2241ea5f7924dd4f1e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Tracked Internally: SDK-2463