### PR TITLE
fix: Keep booleans and numbers distinct in the in operator

### DIFF
--- a/ldclient/impl/operators.py
+++ b/ldclient/impl/operators.py
@@ -37,6 +37,10 @@ def _semver_operator(clause_preprocessed: Optional[ClausePreprocessedValue], con
 
 
 def _in(context_value: Any, clause_value: Any, clause_preprocessed: Optional[ClausePreprocessedValue]) -> bool:
+    # bool is a subtype of int in Python, so True == 1 and False == 0. A value should only match a
+    # clause value of the same JSON type, so a boolean and a number must never be considered equal.
+    if isinstance(context_value, bool) != isinstance(clause_value, bool):
+        return False
     return context_value == clause_value
 
 

--- a/ldclient/testing/impl/test_operators.py
+++ b/ldclient/testing/impl/test_operators.py
@@ -33,6 +33,17 @@ from ldclient.testing.builders import *
         ["endsWith", "z", "xyz", False],
         ["contains", "xyz", "y", True],
         ["contains", "y", "xyz", False],
+        # booleans and numbers must remain distinct (bool is a subtype of int in Python)
+        ["in", True, True, True],
+        ["in", False, False, True],
+        ["in", True, 1, False],
+        ["in", 1, True, False],
+        ["in", True, 1.0, False],
+        ["in", 1.0, True, False],
+        ["in", False, 0, False],
+        ["in", 0, False, False],
+        ["in", False, 0.0, False],
+        ["in", 0.0, False, False],
         # mixed strings and numbers
         ["in", "99", 99, False],
         ["in", 99, "99", False],


### PR DESCRIPTION
## Summary

The `in` clause operator incorrectly matched boolean context values against numeric clause values (and vice versa). Python's `bool` is a subclass of `int`, so `True == 1` and `False == 0` evaluate as true, and `_in` used a raw `context_value == clause_value`. As a result:

- A rule checking `tier in [1]` incorrectly matched a context where `tier` is `True`.
- A rule checking `beta in [true]` incorrectly matched a context where `beta` is `1`.

The `in` operator now rejects a match when exactly one side is a `bool`, keeping boolean and numeric JSON values distinct while still matching `True == True` and `False == False`. This mirrors the bool-exclusion idea already used by `is_number` in `value_parsing.py`.

This is a Python-specific defect. The Ruby SDK (`true == 1` is `false`) and js-core (`true === 1` is `false` via strict equality) are unaffected.

Fixes #432

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag targeting semantics for `in` clauses; rules that accidentally relied on bool/number equality will behave differently, but the fix aligns with JSON types and other SDKs.
> 
> **Overview**
> Fixes incorrect flag rule matches in the Python SDK where **`in`** treated booleans and numbers as equal because `True == 1` and `False == 0`.
> 
> **`_in`** now returns false when exactly one of the context and clause values is a `bool`, so JSON booleans and numbers stay distinct while same-type equality still works. Parametrized tests cover bool/bool matches and bool vs int/float non-matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea94700d274da2735ece2df64f153c9ff5c6f53f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->