### PR TITLE
fix: Correct data source error reporting

### DIFF
--- a/ldclient/impl/datasource/polling.py
+++ b/ldclient/impl/datasource/polling.py
@@ -99,4 +99,4 @@ class PollingUpdateProcessor(UpdateProcessor):
             log.exception('Error: Exception encountered when updating flags. %s' % e)
 
             if self._data_source_update_sink is not None:
-                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time, str(e)))
+                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(e)))

--- a/ldclient/impl/datasource/status.py
+++ b/ldclient/impl/datasource/status.py
@@ -55,8 +55,8 @@ class DataSourceUpdateSinkImpl(DataSourceUpdateSink):
     def upsert(self, kind: VersionedDataKind, item: dict):
         self.__monitor_store_update(lambda: self.__store.upsert(kind, item))
 
-        # TODO(sc-212471): We only want to do this if the store successfully
-        # updates the record.
+        # TODO(SDK-62): We only want to do this if the store successfully wrote the record,
+        # which requires upsert to return a bool result (breaking change).
         key = item.get('key', '')
         self.__update_dependency_for_single_item(kind, key, item)
 

--- a/ldclient/impl/datasourcev2/polling.py
+++ b/ldclient/impl/datasourcev2/polling.py
@@ -303,7 +303,7 @@ class Urllib3PollingRequester(Requester):
 
         if response.status >= 400:
             return _Fail(
-                f"HTTP error {response}", UnsuccessfulResponseException(response.status),
+                f"HTTP error {response.status}", UnsuccessfulResponseException(response.status),
                 headers=headers,
             )
 
@@ -531,7 +531,7 @@ class Urllib3FDv1PollingRequester(Requester):
         headers = response.headers
         if response.status >= 400:
             return _Fail(
-                f"HTTP error {response}", UnsuccessfulResponseException(response.status),
+                f"HTTP error {response.status}", UnsuccessfulResponseException(response.status),
                 headers=headers
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyRFC3339>=1.0",
     "semver>=2.10.2",
     "urllib3>=1.26.0,<3",
-    "launchdarkly-eventsource>=1.5.0,<2.0.0",
+    "launchdarkly-eventsource>=1.7.1,<2.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Correct data source error reporting
fix: Bump python-eventsource to 1.7.1 to correct pool ownership when closing connections
END_COMMIT_OVERRIDE

## Summary

A bug fix and a small cleanup in the synchronous data-source error path, found while building the async SDK (SDK-60) and extracted as an independent PR ahead of the async slices. Neither depends on async; this is the first PR of that stacked sequence.

- **`datasource/polling.py`** (bug fix) — the UNKNOWN-error branch passed the *uncalled* `time.time` function (instead of `time.time()`) as the timestamp, so every unexpected polling error recorded a bogus non-numeric `DataSourceErrorInfo.time`.
- **`datasourcev2/polling.py`** (cleanup, no behavior change) — use `response.status` in the HTTP-error message instead of interpolating the whole `urllib3` response object. This string is currently unread on the HTTP-error path (consumers rebuild the message from the status code), so it's fixed for forward-cleanliness.

## Testing

Full unit suite green (1012 passed, 0 failed); mypy + isort + pycodestyle clean.

SDK-2592

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-reporting and dependency bumps with no auth, store, or evaluation logic changes.
> 
> **Overview**
> Fixes **incorrect timestamps** on unexpected polling failures in the legacy `PollingUpdateProcessor`: the UNKNOWN-error path now passes **`time.time()`** instead of the `time.time` function reference, so `DataSourceErrorInfo.time` is a real epoch value for status listeners and diagnostics.
> 
> In **datasource v2 polling**, HTTP failure `_Fail` messages now use **`response.status`** instead of stringifying the whole urllib3 response (cosmetic; consumers still derive messages from the status code).
> 
> Also bumps **`launchdarkly-eventsource`** to `>=1.7.1,<2.0.0` and refreshes a **TODO** comment in `DataSourceUpdateSinkImpl.upsert` (SDK-62); no behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67844ed9bb383c750c1fa0ed2b8a7789698c52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->