### PR TITLE
docs: clarify is_initialized() semantics (SDK-2641)

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -464,12 +464,26 @@ class LDClient:
         return self._config.offline
 
     def is_initialized(self) -> bool:
-        """Returns true if the client has successfully connected to LaunchDarkly.
+        """Returns whether the client is initialized and has flag data available to serve requests.
 
-        If this returns false, it means that the client has not yet successfully connected to LaunchDarkly.
-        It might still be in the process of starting up, or it might be attempting to reconnect after an
-        unsuccessful attempt, or it might have received an unrecoverable error (such as an invalid SDK key)
-        and given up.
+        If this returns true, it means the client has data it can use to evaluate flags. That could be
+        because it connected to LaunchDarkly at least once and received flag data, or because it has
+        cached data from a persistent store, or because it was configured for offline or LDD (daemon)
+        mode. It could still have encountered a connection problem after that point, and cached data may
+        not be current, so this does not guarantee that the flag data is up to date; if you need to know
+        the connection status in more detail, use :attr:`data_source_status_provider`.
+
+        Additionally, if the client was configured to be offline or to use LDD (daemon) mode, this will
+        always return true.
+
+        If this returns false, it means the client has not yet obtained any flag data. It might still be
+        starting up, or attempting to reconnect after an unsuccessful attempt, or it might have received
+        an unrecoverable error (such as an invalid SDK key) and given up. In this state, feature flag
+        evaluations will return default values -- unless you are using a persistent store integration and
+        flag data had already been stored by a successfully connected SDK in the past. You can use
+        :attr:`data_source_status_provider` to get information on errors, or to wait for a successful retry.
+
+        :return: true if the client is initialized and has flag data available
         """
         if self.is_offline() or self._config.use_ldd:
             return True

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -473,9 +473,6 @@ class LDClient:
         not be current, so this does not guarantee that the flag data is up to date; if you need to know
         the connection status in more detail, use :attr:`data_source_status_provider`.
 
-        Additionally, if the client was configured to be offline or to use LDD (daemon) mode, this will
-        always return true.
-
         If this returns false, it means the client has not yet obtained any flag data. It might still be
         starting up, or attempting to reconnect after an unsuccessful attempt, or it might have received
         an unrecoverable error (such as an invalid SDK key) and given up. In this state, feature flag


### PR DESCRIPTION
## What

Rewrites the `LDClient.is_initialized()` docstring in the Python server SDK. **Docstring only — no behavior change.**

## Why

The old docstring claimed the method "Returns true if the client has successfully connected to LaunchDarkly." That overpromises. The implementation returns `True` in three cases, only one of which involves a live connection:

1. **Offline mode** — returns `True` unconditionally, no connection attempted.
2. **LDD/daemon mode** (`use_ldd`) — returns `True` purely from the config flag.
3. **`data_availability.at_least(CACHED)`** — a populated (possibly stale) persistent store satisfies this even if the live data source never connected, is still retrying, or permanently failed. Per the enum, `CACHED` means "data, not necessarily the latest."

The Go, Ruby, and JS SDKs all word their equivalent around "initialized/ready" with explicit hedges. Go is the clearest, so this change aligns the Python wording with Go's `Initialized()`:

- Reframed as "initialized and has flag data available to serve requests" rather than "connected."
- Notes offline/LDD always return `True`.
- Warns that a `True` result does **not** guarantee flag data is up to date.
- Points to `data_source_status_provider` for connection-status detail.

## Ticket

[SDK-2641](https://launchdarkly.atlassian.net/browse/SDK-2641)

[SDK-2641]: https://launchdarkly.atlassian.net/browse/SDK-2641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docstring-only update with no logic, API, or runtime changes.
> 
> **Overview**
> **Documentation-only change** to `LDClient.is_initialized()` in `ldclient/client.py` — runtime behavior is unchanged.
> 
> The docstring no longer claims the client has **successfully connected** to LaunchDarkly. It now describes **initialized with flag data available** (live data, persistent cache, or offline/LDD), notes that **`True` does not mean data is current**, and directs integrators to **`data_source_status_provider`** for connection detail. It also spells out when **`False`** applies and how evaluations behave (defaults vs. prior persistent-store data).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a30032ec40ca519c03c7fed25b0438ecec1e1d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->