### PR TITLE
feat: Add async hook, plugin, and flag tracker

### DIFF
--- a/ldclient/hook.py
+++ b/ldclient/hook.py
@@ -79,6 +79,65 @@ class Hook(ABC):
         return data
 
 
+class AsyncHook(ABC):
+    """
+    Abstract class for extending AsyncLDClient functionality via hooks.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
+
+    All provided async hook implementations **MUST** inherit from this class.
+
+    This class includes default implementations for all hook handlers. This
+    allows LaunchDarkly to expand the list of hook handlers without breaking
+    customer integrations.
+
+    Unlike :class:`Hook`, the before and after methods are coroutines and will
+    be awaited by the async client.
+    """
+
+    @property
+    @abstractmethod
+    def metadata(self) -> Metadata:
+        """
+        Get metadata about the hook implementation.
+        """
+        return Metadata(name='UNDEFINED')
+
+    async def before_evaluation(self, series_context: EvaluationSeriesContext, data: dict) -> dict:
+        """
+        The before method is called during the execution of a variation method
+        before the flag value has been determined. The method is a coroutine
+        and will be awaited.
+
+        :param series_context: Contains information about the evaluation being performed. This is not mutable.
+        :param data: A record associated with each stage of hook invocations.
+            Each stage is called with the data of the previous stage for a series.
+            The input record should not be modified.
+        :return: Data to use when executing the next state of the hook in the evaluation series.
+        """
+        return data
+
+    async def after_evaluation(self, series_context: EvaluationSeriesContext, data: dict,
+                               detail: EvaluationDetail) -> dict:
+        """
+        The after method is called during the execution of the variation method
+        after the flag value has been determined. The method is a coroutine
+        and will be awaited.
+
+        :param series_context: Contains read-only information about the
+            evaluation being performed.
+        :param data: A record associated with each stage of hook invocations.
+            Each stage is called with the data of the previous stage for a series.
+        :param detail: The result of the evaluation. This value should not be modified.
+        :return: Data to use when executing the next state of the hook in the evaluation series.
+        """
+        return data
+
+
 @dataclass
 class _EvaluationWithHookResult:
     evaluation_detail: EvaluationDetail

--- a/ldclient/impl/async_flag_tracker.py
+++ b/ldclient/impl/async_flag_tracker.py
@@ -1,0 +1,62 @@
+from typing import Any, Callable
+
+from ldclient.context import Context
+from ldclient.impl.aio.concurrency import AsyncCallbackScheduler, AsyncLock
+from ldclient.impl.listeners import Listeners
+from ldclient.interfaces import FlagChange, FlagTracker, FlagValueChange
+
+
+class AsyncFlagValueChangeListener:
+    """Calls the user's listener when a specific flag's evaluated value changes for a specific context."""
+
+    def __init__(self, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler):
+        self.__key = key
+        self.__context = context
+        self.__listener = listener
+        self.__eval_fn = eval_fn
+        self.__scheduler = scheduler
+
+        self.__lock = AsyncLock()
+        self.__value: Any = None
+
+    @classmethod
+    async def create(cls, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler) -> 'AsyncFlagValueChangeListener':
+        """Evaluates the flag once to capture the baseline value, then returns the listener."""
+        instance = cls(key, context, listener, eval_fn, scheduler)
+        instance.__value = await eval_fn(key, context)
+        return instance
+
+    def __call__(self, flag_change: FlagChange):
+        self.__scheduler.call(self._on_flag_change, flag_change)
+
+    async def _on_flag_change(self, flag_change: FlagChange):
+        if flag_change.key != self.__key:
+            return
+
+        async with self.__lock:
+            new_value = await self.__eval_fn(self.__key, self.__context)
+            old_value, self.__value = self.__value, new_value
+
+        if new_value == old_value:
+            return
+
+        self.__listener(FlagValueChange(self.__key, old_value, new_value))
+
+
+class AsyncFlagTrackerImpl(FlagTracker):
+    def __init__(self, listeners: Listeners, eval_fn: Callable):
+        self.__listeners = listeners
+        self.__eval_fn = eval_fn
+        self.__scheduler = AsyncCallbackScheduler()
+
+    def add_listener(self, listener: Callable[[FlagChange], None]):
+        self.__listeners.add(listener)
+
+    def remove_listener(self, listener: Callable[[FlagChange], None]):
+        self.__listeners.remove(listener)
+
+    async def add_flag_value_change_listener(self, key: str, context: Context, fn: Callable[[FlagValueChange], None]) -> Callable[[FlagChange], None]:
+        listener = await AsyncFlagValueChangeListener.create(key, context, fn, self.__eval_fn, self.__scheduler)
+        self.add_listener(listener)
+
+        return listener

--- a/ldclient/impl/async_flag_tracker.py
+++ b/ldclient/impl/async_flag_tracker.py
@@ -26,12 +26,11 @@ class AsyncFlagValueChangeListener:
         return cls(key, context, listener, eval_fn, scheduler, value)
 
     def __call__(self, flag_change: FlagChange):
-        self.__scheduler.call(self._on_flag_change, flag_change)
-
-    async def _on_flag_change(self, flag_change: FlagChange):
         if flag_change.key != self.__key:
             return
+        self.__scheduler.call(self._on_flag_change)
 
+    async def _on_flag_change(self):
         async with self.__lock:
             new_value = await self.__eval_fn(self.__key, self.__context)
             old_value, self.__value = self.__value, new_value

--- a/ldclient/impl/async_flag_tracker.py
+++ b/ldclient/impl/async_flag_tracker.py
@@ -9,7 +9,7 @@ from ldclient.interfaces import FlagChange, FlagTracker, FlagValueChange
 class AsyncFlagValueChangeListener:
     """Calls the user's listener when a specific flag's evaluated value changes for a specific context."""
 
-    def __init__(self, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler, value: Any):
+    def __init__(self, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler, initial_value: Any):
         self.__key = key
         self.__context = context
         self.__listener = listener
@@ -17,13 +17,13 @@ class AsyncFlagValueChangeListener:
         self.__scheduler = scheduler
 
         self.__lock = AsyncLock()
-        self.__value = value
+        self.__value = initial_value
 
     @classmethod
     async def create(cls, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler) -> 'AsyncFlagValueChangeListener':
         """Evaluates the flag once to capture the baseline value, then returns the listener."""
-        value = await eval_fn(key, context)
-        return cls(key, context, listener, eval_fn, scheduler, value)
+        initial_value = await eval_fn(key, context)
+        return cls(key, context, listener, eval_fn, scheduler, initial_value)
 
     def __call__(self, flag_change: FlagChange):
         if flag_change.key != self.__key:

--- a/ldclient/impl/async_flag_tracker.py
+++ b/ldclient/impl/async_flag_tracker.py
@@ -9,7 +9,7 @@ from ldclient.interfaces import FlagChange, FlagTracker, FlagValueChange
 class AsyncFlagValueChangeListener:
     """Calls the user's listener when a specific flag's evaluated value changes for a specific context."""
 
-    def __init__(self, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler):
+    def __init__(self, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler, value: Any):
         self.__key = key
         self.__context = context
         self.__listener = listener
@@ -17,14 +17,13 @@ class AsyncFlagValueChangeListener:
         self.__scheduler = scheduler
 
         self.__lock = AsyncLock()
-        self.__value: Any = None
+        self.__value = value
 
     @classmethod
     async def create(cls, key: str, context: Context, listener: Callable[[FlagValueChange], None], eval_fn: Callable, scheduler: AsyncCallbackScheduler) -> 'AsyncFlagValueChangeListener':
         """Evaluates the flag once to capture the baseline value, then returns the listener."""
-        instance = cls(key, context, listener, eval_fn, scheduler)
-        instance.__value = await eval_fn(key, context)
-        return instance
+        value = await eval_fn(key, context)
+        return cls(key, context, listener, eval_fn, scheduler, value)
 
     def __call__(self, flag_change: FlagChange):
         self.__scheduler.call(self._on_flag_change, flag_change)

--- a/ldclient/impl/async_flag_tracker.py
+++ b/ldclient/impl/async_flag_tracker.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 from ldclient.context import Context
 from ldclient.impl.aio.concurrency import AsyncCallbackScheduler, AsyncLock
 from ldclient.impl.listeners import Listeners
-from ldclient.interfaces import FlagChange, FlagTracker, FlagValueChange
+from ldclient.interfaces import AsyncFlagTracker, FlagChange, FlagValueChange
 
 
 class AsyncFlagValueChangeListener:
@@ -41,7 +41,7 @@ class AsyncFlagValueChangeListener:
         self.__listener(FlagValueChange(self.__key, old_value, new_value))
 
 
-class AsyncFlagTrackerImpl(FlagTracker):
+class AsyncFlagTrackerImpl(AsyncFlagTracker):
     def __init__(self, listeners: Listeners, eval_fn: Callable):
         self.__listeners = listeners
         self.__eval_fn = eval_fn

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -310,6 +310,11 @@ class AsyncReadOnlyStore(Protocol):
     Both async data systems expose their active store through this uniform interface:
     :class:`AsyncFeatureStore` satisfies it directly (FDv1), and FDv2 adapts its
     synchronous in-memory store to it. This is the async analog of :class:`ReadOnlyStore`.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees.
     """
 
     @abstractmethod

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -691,6 +691,10 @@ class BigSegmentStoreStatusProvider:
         """
         Gets the current status of the store.
 
+        Before the first poll completes, the synchronous SDK performs a blocking store query and
+        returns its result, while the async SDK (``AsyncLDClient``) returns the last polled status
+        without blocking -- ``available=False`` until the first background poll completes.
+
         :return: the status
         """
         pass
@@ -1183,6 +1187,56 @@ class FlagTracker(ABC):
         :param key: The flag key to monitor
         :param context: The context to evaluate against the flag
         :param listener: The listener to trigger if the value has changed
+        """
+        pass
+
+
+class AsyncFlagTracker(ABC):
+    """
+    An interface for tracking changes in feature flag configurations, for use with the async client
+    (:class:`ldclient.async_client.AsyncLDClient`). It mirrors :class:`FlagTracker`, except
+    :meth:`add_flag_value_change_listener` is a coroutine.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees.
+
+    An implementation of this abstract class is returned by
+    :meth:`ldclient.async_client.AsyncLDClient.flag_tracker`. Application code never needs to
+    implement this interface.
+    """
+
+    @abstractmethod
+    def add_listener(self, listener: Callable[[FlagChange], None]) -> None:
+        """
+        Registers a listener to be notified of feature flag changes in general. Behaves identically
+        to :meth:`FlagTracker.add_listener`.
+
+        :param listener: listener to call when a flag has changed
+        """
+        pass
+
+    @abstractmethod
+    def remove_listener(self, listener: Callable[[FlagChange], None]) -> None:
+        """
+        Unregisters a listener so that it will no longer be notified of feature flag changes.
+
+        :param listener: the listener to remove
+        """
+        pass
+
+    @abstractmethod
+    async def add_flag_value_change_listener(self, key: str, context: Context, listener: Callable[[FlagValueChange], None]) -> Callable[[FlagChange], None]:
+        """
+        Registers a listener to be notified when a specific flag's evaluated value changes for a
+        specific context. Behaves like :meth:`FlagTracker.add_flag_value_change_listener`, but is a
+        **coroutine** and must be awaited (it evaluates the flag to capture the baseline value).
+
+        :param key: the flag key to monitor
+        :param context: the context to evaluate against the flag
+        :param listener: the listener to trigger if the value has changed
+        :return: the subscription; pass it to :meth:`remove_listener` to unsubscribe
         """
         pass
 

--- a/ldclient/plugin.py
+++ b/ldclient/plugin.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from ldclient.context import Context
 from ldclient.evaluation import EvaluationDetail, FeatureFlagsState
-from ldclient.hook import Hook
+from ldclient.hook import AsyncHook, Hook
 from ldclient.impl import AnyNum
 from ldclient.impl.evaluator import error_reason
 from ldclient.interfaces import (
@@ -17,6 +17,7 @@ from ldclient.interfaces import (
 )
 
 if TYPE_CHECKING:
+    from ldclient.async_client import AsyncLDClient
     from ldclient.client import LDClient
 
 
@@ -103,6 +104,67 @@ class Plugin(ABC):
 
         This method is called before register() to collect all hooks from
         plugins. The hooks returned will be added to the SDK's hook configuration.
+
+        :param metadata: Metadata about the environment in which the SDK is running
+        :return: A list of hooks to be registered with the SDK
+        """
+        return []
+
+
+class AsyncPlugin(ABC):
+    """
+    Abstract base class for extending AsyncLDClient functionality via plugins.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
+
+    All provided async plugin implementations **MUST** inherit from this class.
+
+    This class includes default implementations for optional methods. This
+    allows LaunchDarkly to expand the list of plugin methods without breaking
+    customer integrations.
+
+    Unlike :class:`Plugin`, the register() method is a coroutine and will be
+    awaited by the async client, allowing plugins to perform asynchronous
+    initialization such as connecting to telemetry backends.
+    """
+
+    @property
+    @abstractmethod
+    def metadata(self) -> PluginMetadata:
+        """
+        Get metadata about the plugin implementation.
+
+        :return: Metadata containing information about the plugin
+        """
+        return PluginMetadata(name='UNDEFINED')
+
+    async def register(self, client: 'AsyncLDClient', metadata: EnvironmentMetadata) -> None:
+        """
+        Register the plugin with the async SDK client.
+
+        This method is called during SDK initialization to allow the plugin
+        to set up any necessary integrations, register hooks, or perform
+        other initialization tasks. The method is a coroutine and will be
+        awaited, allowing asynchronous I/O during registration.
+
+        :param client: The AsyncLDClient instance
+        :param metadata: Metadata about the environment in which the SDK is running
+        """
+        pass
+
+    def get_hooks(self, metadata: EnvironmentMetadata) -> List[AsyncHook]:
+        """
+        Get a list of hooks that this plugin provides.
+
+        This method is called before register() to collect all hooks from
+        plugins. The hooks returned will be added to the SDK's hook configuration.
+        Async plugins provide async :class:`AsyncHook` instances only.
+
+        This method is synchronous (returns a list immediately — no I/O).
 
         :param metadata: Metadata about the environment in which the SDK is running
         :return: A list of hooks to be registered with the SDK

--- a/ldclient/testing/test_async_flag_tracker.py
+++ b/ldclient/testing/test_async_flag_tracker.py
@@ -1,0 +1,204 @@
+"""
+Tests for AsyncFlagValueChangeListener and AsyncFlagTrackerImpl.
+"""
+import asyncio
+import threading
+
+import pytest
+import pytest_asyncio
+
+from ldclient.context import Context
+from ldclient.impl.async_flag_tracker import (
+    AsyncFlagTrackerImpl,
+    AsyncFlagValueChangeListener
+)
+from ldclient.impl.listeners import Listeners
+from ldclient.interfaces import FlagChange, FlagValueChange
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def context():
+    return Context.create('user-1')
+
+
+@pytest.fixture
+def listeners():
+    return Listeners()
+
+
+@pytest.fixture
+def eval_values():
+    """Mutable container so tests can change the value returned by eval_fn."""
+    return {'value': 'initial'}
+
+
+@pytest.fixture
+def eval_fn(eval_values):
+    async def _fn(key, ctx):
+        return eval_values['value']
+    return _fn
+
+
+@pytest_asyncio.fixture
+async def tracker(listeners, eval_fn):
+    # The tracker's scheduler captures the running event loop at construction.
+    return AsyncFlagTrackerImpl(listeners, eval_fn)
+
+
+# ---------------------------------------------------------------------------
+# AsyncFlagValueChangeListener tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_initializes_value_without_notifying(tracker, context, eval_fn):
+    changes = []
+    await tracker.add_flag_value_change_listener('flag-key', context, changes.append)
+
+    # No notification on creation — only records the baseline value
+    assert changes == []
+
+
+@pytest.mark.asyncio
+async def test_flag_change_matching_key_triggers_listener(tracker, listeners, eval_values, context):
+    received = []
+    await tracker.add_flag_value_change_listener('flag-key', context, received.append)
+
+    # Change the value the eval_fn returns
+    eval_values['value'] = 'changed'
+
+    listeners.notify(FlagChange('flag-key'))
+    await asyncio.sleep(0.1)
+
+    assert len(received) == 1
+    change = received[0]
+    assert change.key == 'flag-key'
+    assert change.old_value == 'initial'
+    assert change.new_value == 'changed'
+
+
+@pytest.mark.asyncio
+async def test_flag_change_same_value_does_not_trigger_listener(tracker, listeners, context):
+    received = []
+    await tracker.add_flag_value_change_listener('flag-key', context, received.append)
+
+    # Value stays the same
+    listeners.notify(FlagChange('flag-key'))
+    await asyncio.sleep(0.1)
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_flag_change_non_matching_key_ignored(tracker, listeners, eval_values, context):
+    received = []
+    await tracker.add_flag_value_change_listener('flag-key', context, received.append)
+
+    eval_values['value'] = 'changed'
+
+    # Different flag key — should be ignored
+    listeners.notify(FlagChange('other-flag'))
+    await asyncio.sleep(0.1)
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_listener_callback_is_sync(tracker, listeners, eval_values, context):
+    """The listener callback is invoked synchronously (not awaited)."""
+    was_called = []
+
+    def sync_listener(change: FlagValueChange):
+        was_called.append(change)
+
+    await tracker.add_flag_value_change_listener('flag-key', context, sync_listener)
+
+    eval_values['value'] = 'new'
+    listeners.notify(FlagChange('flag-key'))
+    await asyncio.sleep(0.1)
+
+    assert len(was_called) == 1
+
+
+# ---------------------------------------------------------------------------
+# AsyncFlagTrackerImpl tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_add_flag_value_change_listener_returns_listener(tracker, context):
+    listener = await tracker.add_flag_value_change_listener('flag-key', context, lambda c: None)
+    assert isinstance(listener, AsyncFlagValueChangeListener)
+
+
+@pytest.mark.asyncio
+async def test_add_listener(tracker, listeners):
+    received = []
+
+    def listener(change: FlagChange):
+        received.append(change.key)
+
+    tracker.add_listener(listener)
+    listeners.notify(FlagChange('my-flag'))
+
+    assert received == ['my-flag']
+
+
+@pytest.mark.asyncio
+async def test_remove_listener(tracker, listeners):
+    received = []
+
+    def listener(change: FlagChange):
+        received.append(change.key)
+
+    tracker.add_listener(listener)
+    tracker.remove_listener(listener)
+
+    listeners.notify(FlagChange('my-flag'))
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_remove_flag_value_change_listener(tracker, listeners, eval_values, context):
+    received = []
+    listener = await tracker.add_flag_value_change_listener('flag-key', context, received.append)
+
+    tracker.remove_listener(listener)
+
+    eval_values['value'] = 'updated'
+    listeners.notify(FlagChange('flag-key'))
+    await asyncio.sleep(0.1)
+
+    # After removal, no notification should fire
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_notify_from_worker_thread_fires_listener(tracker, listeners, eval_values, context):
+    """Regression: notify() called from a background thread (no running event loop in
+    that thread) must still schedule the evaluation correctly and invoke the listener.
+
+    asyncio.create_task raises RuntimeError when called from a non-event-loop thread.
+    The scheduler uses run_coroutine_threadsafe, which works from any thread.
+    """
+    received = []
+    await tracker.add_flag_value_change_listener('flag-key', context, received.append)
+
+    eval_values['value'] = 'changed-from-thread'
+
+    def notify_from_thread():
+        # This thread has no running event loop — verifies run_coroutine_threadsafe is used
+        listeners.notify(FlagChange('flag-key'))
+
+    t = threading.Thread(target=notify_from_thread)
+    t.start()
+    t.join()
+
+    # Allow the scheduled coroutine to run on the event loop
+    await asyncio.sleep(0.1)
+
+    assert len(received) == 1
+    assert received[0].new_value == 'changed-from-thread'

--- a/ldclient/testing/test_async_hooks.py
+++ b/ldclient/testing/test_async_hooks.py
@@ -1,0 +1,215 @@
+"""
+Tests for AsyncHook dispatch in the evaluation pipeline.
+
+The _evaluate_with_hooks helper defined here mirrors the dispatch pattern that
+AsyncLDClient uses: async hooks are awaited, running in list order for
+before_evaluation and reverse order for after_evaluation.
+
+Each hook receives its own isolated data dict (matching the sync SDK pattern in
+client.py:__execute_before_evaluation). A failing hook logs an error and returns
+{} rather than aborting the evaluation (matching __try_execute_stage).
+"""
+import logging
+
+import pytest
+
+from ldclient.context import Context
+from ldclient.evaluation import EvaluationDetail
+from ldclient.hook import AsyncHook, EvaluationSeriesContext, Metadata
+
+log = logging.getLogger('ldclient')
+
+
+# ---------------------------------------------------------------------------
+# Helpers: inline dispatch function that mirrors AsyncLDClient behaviour
+# ---------------------------------------------------------------------------
+
+async def _try_execute_stage_async(method, hook_name, coro_or_fn):
+    """Execute a single hook stage, catching and logging any exceptions."""
+    try:
+        return await coro_or_fn()
+    except BaseException as e:
+        log.error(f"An error occurred in {method} of the hook {hook_name}: #{e}")
+        return {}
+
+
+async def _evaluate_with_hooks(hooks, series_context, eval_fn):
+    """Dispatch before/after hooks around an async evaluation function.
+
+    Each hook gets a fresh empty dict for before_evaluation (matching the sync
+    SDK's __execute_before_evaluation pattern). The per-hook data returned is
+    stored and passed back to the corresponding hook in after_evaluation.
+    A hook that raises an exception is caught and logged; it does not abort
+    the evaluation or affect other hooks.
+    """
+    # before_evaluation: each hook gets its own isolated {}
+    hook_data = []
+    for hook in hooks:
+        data = await _try_execute_stage_async(
+            "beforeEvaluation", hook.metadata.name,
+            lambda h=hook: h.before_evaluation(series_context, {})
+        )
+        hook_data.append(data)
+
+    detail = await eval_fn()
+
+    # after_evaluation: reversed order, each hook receives its own before data
+    for hook, data in reversed(list(zip(hooks, hook_data))):
+        await _try_execute_stage_async(
+            "afterEvaluation", hook.metadata.name,
+            lambda h=hook, d=data: h.after_evaluation(series_context, d, detail)
+        )
+
+    return detail
+
+
+# ---------------------------------------------------------------------------
+# Concrete hook implementations for testing
+# ---------------------------------------------------------------------------
+
+class RecordingAsyncHook(AsyncHook):
+    """Async hook that records calls and threads a counter through data."""
+
+    def __init__(self, name: str):
+        self._name = name
+        self.before_calls: list = []
+        self.after_calls: list = []
+
+    @property
+    def metadata(self) -> Metadata:
+        return Metadata(name=self._name)
+
+    async def before_evaluation(self, series_context: EvaluationSeriesContext, data: dict) -> dict:
+        self.before_calls.append(series_context.key)
+        return {**data, self._name + '_before': True}
+
+    async def after_evaluation(self, series_context: EvaluationSeriesContext, data: dict,
+                               detail: EvaluationDetail) -> dict:
+        self.after_calls.append(series_context.key)
+        return {**data, self._name + '_after': True}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def series_context():
+    return EvaluationSeriesContext(
+        key='test-flag',
+        context=Context.create('user-1'),
+        default_value=False,
+        method='variation',
+    )
+
+
+@pytest.fixture
+def mock_detail():
+    return EvaluationDetail(True, 0, {'kind': 'OFF'})
+
+
+@pytest.fixture
+def eval_fn(mock_detail):
+    async def _fn():
+        return mock_detail
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_async_hook_before_and_after_awaited(series_context, eval_fn):
+    hook = RecordingAsyncHook('async1')
+    await _evaluate_with_hooks([hook], series_context, eval_fn)
+
+    assert hook.before_calls == ['test-flag']
+    assert hook.after_calls == ['test-flag']
+
+
+@pytest.mark.asyncio
+async def test_hooks_called_in_order(series_context, eval_fn):
+    """before_evaluation runs in list order; after_evaluation runs in reverse."""
+    call_log = []
+
+    class OrderAsyncHook(AsyncHook):
+        def __init__(self, name):
+            self._name = name
+
+        @property
+        def metadata(self):
+            return Metadata(name=self._name)
+
+        async def before_evaluation(self, sc, data):
+            call_log.append(self._name + '_before')
+            return data
+
+        async def after_evaluation(self, sc, data, detail):
+            call_log.append(self._name + '_after')
+            return data
+
+    hooks = [OrderAsyncHook('first'), OrderAsyncHook('second')]
+    await _evaluate_with_hooks(hooks, series_context, eval_fn)
+
+    # before: list order (first, second)
+    # after: reversed (second, first)
+    assert call_log == ['first_before', 'second_before', 'second_after', 'first_after']
+
+
+@pytest.mark.asyncio
+async def test_hooks_each_called_with_series_context(series_context, eval_fn):
+    """Each async hook is invoked with the correct series context."""
+    hook_a = RecordingAsyncHook('a')
+    hook_b = RecordingAsyncHook('b')
+
+    hooks = [hook_a, hook_b]
+    await _evaluate_with_hooks(hooks, series_context, eval_fn)
+
+    assert hook_a.before_calls == ['test-flag']
+    assert hook_b.before_calls == ['test-flag']
+
+
+@pytest.mark.asyncio
+async def test_returns_evaluation_detail(series_context, mock_detail, eval_fn):
+    hook = RecordingAsyncHook('a')
+    result = await _evaluate_with_hooks([hook], series_context, eval_fn)
+    assert result is mock_detail
+
+
+@pytest.mark.asyncio
+async def test_no_hooks_returns_detail(series_context, mock_detail, eval_fn):
+    result = await _evaluate_with_hooks([], series_context, eval_fn)
+    assert result is mock_detail
+
+
+@pytest.mark.asyncio
+async def test_data_isolated_per_hook(series_context, eval_fn):
+    """Each hook receives its own fresh {} for before_evaluation (matching sync SDK pattern).
+
+    Data is not threaded across hooks — each hook's before_evaluation starts
+    with an empty dict and the result is passed only to that hook's own
+    after_evaluation. This matches client.py:__execute_before_evaluation.
+    """
+    before_data_received = {}
+
+    class CaptureAsyncHook(AsyncHook):
+        def __init__(self, name):
+            self._name = name
+
+        @property
+        def metadata(self):
+            return Metadata(name=self._name)
+
+        async def before_evaluation(self, sc, data):
+            before_data_received[self._name] = dict(data)
+            return {**data, self._name + '_key': 1}
+
+        async def after_evaluation(self, sc, data, detail):
+            return data
+
+    await _evaluate_with_hooks([CaptureAsyncHook('one'), CaptureAsyncHook('two')], series_context, eval_fn)
+
+    # Each hook should have received a fresh empty dict, not the other hook's output
+    assert before_data_received['one'] == {}
+    assert before_data_received['two'] == {}


### PR DESCRIPTION
## Overview

This slice adds the async counterparts of the SDK's hook and plugin extension points, plus the async flag tracker used by the async client:

- **`AsyncHook`** (`ldclient/hook.py`) — abstract base for async hooks. `before_evaluation` / `after_evaluation` are coroutines awaited by the async client.
- **`AsyncPlugin`** (`ldclient/plugin.py`) — abstract base for async plugins. `register()` is a coroutine (allowing async initialization such as connecting to telemetry backends); `get_hooks()` remains synchronous and returns `AsyncHook` instances.
- **`AsyncFlagTrackerImpl` / `AsyncFlagValueChangeListener`** (`ldclient/impl/async_flag_tracker.py`) — the async flag tracker implementation.

Unit tests are added in `ldclient/testing/test_async_hooks.py` and `ldclient/testing/test_async_flag_tracker.py`.

The async public classes carry the experimental `.. caution::` block, matching the rest of the async surface.

This PR depends only on already-merged foundation work and can be reviewed independently.

Tracked internally: SDK-2737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive experimental APIs and implementation behind the async client surface; no changes to sync evaluation paths, with behavior covered by new unit tests.
> 
> **Overview**
> Adds experimental async extension points and flag-change tracking for `AsyncLDClient`, paralleling the sync `Hook`, `Plugin`, and `FlagTracker` APIs.
> 
> **`AsyncHook`** and **`AsyncPlugin`** introduce coroutine-based `before_evaluation` / `after_evaluation` and `register()`, with sync `get_hooks()` returning `AsyncHook` instances. New public types are marked with the experimental caution block.
> 
> **`AsyncFlagTracker`** (interface) and **`AsyncFlagTrackerImpl`** implement async per-flag value listeners: subscription awaits an initial evaluation for a baseline, re-evaluates on config changes, and notifies only when the value differs. Work is scheduled via `AsyncCallbackScheduler` so notifications from worker threads remain safe.
> 
> Docs clarify that **`AsyncReadOnlyStore`** is experimental and that **`BigSegmentStoreStatusProvider.status`** is non-blocking on the async client (`available=False` until the first background poll). Unit tests cover hook dispatch semantics and flag-tracker behavior, including cross-thread notify.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733132b8596ec2fe09cf253d8e3baf90b7eb2bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->