### PR TITLE
chore: Remove Dependabot config in favor of Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
## What

Removes `.github/dependabot.yml`.

## Why

This repo already uses **Renovate** for dependency updates (`.github/renovate.json`, added in #434), so the Dependabot config is redundant — running both produces duplicate/competing dependency-update PRs.

This supersedes #452 (which was adding a version-update cooldown to the Dependabot config); rather than tune Dependabot, we drop it entirely and rely on Renovate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/tooling-only change with no application code or runtime behavior impact.
> 
> **Overview**
> Removes the **Dependabot** configuration file (`.github/dependabot.yml`), which previously scheduled daily pip updates for the repo root.
> 
> Dependency maintenance stays on **Renovate** (`.github/renovate.json`), avoiding duplicate or competing update PRs from both bots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b93d99c49ad9e2e4c7afc4ab3d965f86848eecd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->