### PR TITLE
feat: Add async FDv1 polling data source and feature requester

### DIFF
--- a/ldclient/impl/aio/concurrency.py
+++ b/ldclient/impl/aio/concurrency.py
@@ -228,10 +228,7 @@ class AsyncRepeatingTask:
         the task never started or is the current task."""
         task = self.__task
         if task is not None and task is not asyncio.current_task():
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+            await asyncio.wait({task})
 
     async def _run(self):
         try:

--- a/ldclient/impl/aio/concurrency.py
+++ b/ldclient/impl/aio/concurrency.py
@@ -223,6 +223,16 @@ class AsyncRepeatingTask:
         if task is not None and task is not asyncio.current_task():
             task.cancel()
 
+    async def wait_stopped(self):
+        """Waits for the task to finish unwinding after ``stop()``. A no-op if
+        the task never started or is the current task."""
+        task = self.__task
+        if task is not None and task is not asyncio.current_task():
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
     async def _run(self):
         try:
             if self.__initial_delay > 0:

--- a/ldclient/impl/datasource/async_feature_requester.py
+++ b/ldclient/impl/datasource/async_feature_requester.py
@@ -8,12 +8,10 @@ from typing import Optional
 from urllib import parse
 
 from ldclient.impl.aio.transport import AsyncHTTPTransport
+from ldclient.impl.datasource.datasource_common import FDV1_POLLING_ENDPOINT
 from ldclient.impl.util import _headers, log, throw_if_unsuccessful_response
 from ldclient.interfaces import FeatureRequester
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
-
-FDV1_POLLING_ENDPOINT = '/sdk/latest-all'
-
 
 CacheEntry = namedtuple('CacheEntry', ['data', 'etag'])
 

--- a/ldclient/impl/datasource/async_feature_requester.py
+++ b/ldclient/impl/datasource/async_feature_requester.py
@@ -1,0 +1,51 @@
+"""
+Default implementation of feature flag polling requests.
+"""
+
+import json
+from collections import namedtuple
+from typing import Optional
+from urllib import parse
+
+from ldclient.impl.aio.transport import AsyncHTTPTransport
+from ldclient.impl.util import _headers, log, throw_if_unsuccessful_response
+from ldclient.interfaces import FeatureRequester
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
+
+FDV1_POLLING_ENDPOINT = '/sdk/latest-all'
+
+
+CacheEntry = namedtuple('CacheEntry', ['data', 'etag'])
+
+
+class AsyncFeatureRequesterImpl(FeatureRequester):
+    def __init__(self, config, transport: Optional[AsyncHTTPTransport] = None):
+        self._cache: dict = dict()
+        self._transport = transport if transport is not None else AsyncHTTPTransport(config)
+        self._config = config
+        self._poll_uri = config.base_uri + FDV1_POLLING_ENDPOINT
+        if config.payload_filter_key is not None:
+            self._poll_uri += '?%s' % parse.urlencode({'filter': config.payload_filter_key})
+
+    async def get_all_data(self):
+        uri = self._poll_uri
+        hdrs = _headers(self._config)
+        cache_entry = self._cache.get(uri)
+        hdrs['Accept-Encoding'] = 'gzip'
+        if cache_entry is not None:
+            hdrs['If-None-Match'] = cache_entry.etag
+        r = await self._transport.request('GET', uri, headers=hdrs)
+        throw_if_unsuccessful_response(r)
+        if r.status == 304 and cache_entry is not None:
+            data = cache_entry.data
+            etag = cache_entry.etag
+            from_cache = True
+        else:
+            data = json.loads(r.body)
+            etag = r.headers.get('ETag')
+            from_cache = False
+            if etag is not None:
+                self._cache[uri] = CacheEntry(data=data, etag=etag)
+        log.debug("%s response status:[%d] From cache? [%s] ETag:[%s]", uri, r.status, from_cache, etag)
+
+        return {FEATURES: data['flags'], SEGMENTS: data['segments']}

--- a/ldclient/impl/datasource/async_feature_requester.py
+++ b/ldclient/impl/datasource/async_feature_requester.py
@@ -10,13 +10,13 @@ from urllib import parse
 from ldclient.impl.aio.transport import AsyncHTTPTransport
 from ldclient.impl.datasource.datasource_common import FDV1_POLLING_ENDPOINT
 from ldclient.impl.util import _headers, log, throw_if_unsuccessful_response
-from ldclient.interfaces import FeatureRequester
+from ldclient.interfaces import AsyncFeatureRequester
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 CacheEntry = namedtuple('CacheEntry', ['data', 'etag'])
 
 
-class AsyncFeatureRequesterImpl(FeatureRequester):
+class AsyncFeatureRequesterImpl(AsyncFeatureRequester):
     def __init__(self, config, transport: Optional[AsyncHTTPTransport] = None):
         self._cache: dict = dict()
         # Only close the transport on shutdown if we created it; an injected

--- a/ldclient/impl/datasource/async_feature_requester.py
+++ b/ldclient/impl/datasource/async_feature_requester.py
@@ -19,6 +19,9 @@ CacheEntry = namedtuple('CacheEntry', ['data', 'etag'])
 class AsyncFeatureRequesterImpl(FeatureRequester):
     def __init__(self, config, transport: Optional[AsyncHTTPTransport] = None):
         self._cache: dict = dict()
+        # Only close the transport on shutdown if we created it; an injected
+        # transport is owned by the caller.
+        self._owns_transport = transport is None
         self._transport = transport if transport is not None else AsyncHTTPTransport(config)
         self._config = config
         self._poll_uri = config.base_uri + FDV1_POLLING_ENDPOINT
@@ -47,3 +50,7 @@ class AsyncFeatureRequesterImpl(FeatureRequester):
         log.debug("%s response status:[%d] From cache? [%s] ETag:[%s]", uri, r.status, from_cache, etag)
 
         return {FEATURES: data['flags'], SEGMENTS: data['segments']}
+
+    async def close(self):
+        if self._owns_transport:
+            await self._transport.close()

--- a/ldclient/impl/datasource/async_polling.py
+++ b/ldclient/impl/datasource/async_polling.py
@@ -1,0 +1,90 @@
+"""
+Default implementation of the polling component.
+"""
+
+# currently excluded from documentation - see docs/README.md
+
+import time
+from typing import Optional
+
+from ldclient.async_config import AsyncConfig
+from ldclient.impl.aio.concurrency import AsyncEvent, AsyncRepeatingTask
+from ldclient.impl.datasource.async_feature_requester import (
+    AsyncFeatureRequesterImpl
+)
+from ldclient.impl.datasource.datasource_common import sink_or_store
+from ldclient.impl.util import (
+    UnsuccessfulResponseException,
+    http_error_message,
+    is_http_error_recoverable,
+    log
+)
+from ldclient.interfaces import (
+    AsyncFeatureStore,
+    AsyncUpdateProcessor,
+    DataSourceErrorInfo,
+    DataSourceErrorKind,
+    DataSourceState
+)
+
+
+class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
+    def __init__(self, config: AsyncConfig, requester: AsyncFeatureRequesterImpl, store: AsyncFeatureStore, ready: AsyncEvent):
+        self._config = config
+        self._data_source_update_sink = config.data_source_update_sink
+        self._requester = requester
+        self._store = store
+        self._ready = ready
+        self._task = AsyncRepeatingTask("ldclient.datasource.polling", config.poll_interval, 0, self._fetch_and_store)
+
+    def start(self):
+        log.info("Starting AsyncPollingUpdateProcessor with request interval: " + str(self._config.poll_interval))
+        self._task.start()
+
+    def initialized(self):
+        return self._ready.is_set() is True and self._store.initialized is True
+
+    async def stop(self):
+        self.__stop_with_error_info(None)
+
+    def __stop_with_error_info(self, error: Optional[DataSourceErrorInfo]):
+        log.info("Stopping AsyncPollingUpdateProcessor")
+        self._task.stop()
+
+        if self._data_source_update_sink is None:
+            return
+
+        self._data_source_update_sink.update_status(DataSourceState.OFF, error)
+
+    async def _fetch_and_store(self):
+        try:
+            all_data = await self._requester.get_all_data()
+            if all_data is not None:
+                await sink_or_store(self._data_source_update_sink, self._store).init(all_data)
+                if not self._ready.is_set() and self._store.initialized:
+                    log.info("AsyncPollingUpdateProcessor initialized ok")
+                    self._ready.set()
+
+            # Signal VALID on any successful response (200 or 304) once the store is populated.
+            if self._store.initialized and self._data_source_update_sink is not None:
+                self._data_source_update_sink.update_status(DataSourceState.VALID, None)
+        except UnsuccessfulResponseException as e:
+            error_info = DataSourceErrorInfo(DataSourceErrorKind.ERROR_RESPONSE, e.status, time.time(), str(e))
+
+            http_error_message_result = http_error_message(e.status, "polling request")
+            if not is_http_error_recoverable(e.status):
+                log.error(http_error_message_result)
+                self._ready.set()  # if client is initializing, make it stop waiting; has no effect if already inited
+                self.__stop_with_error_info(error_info)
+            else:
+                log.warning(http_error_message_result)
+
+                if self._data_source_update_sink is not None:
+                    self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, error_info)
+        except Exception as e:
+            log.exception('Error: Exception encountered when updating flags. %s' % e)
+            if not self._ready.is_set():
+                self._ready.set()
+
+            if self._data_source_update_sink is not None:
+                self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(e)))

--- a/ldclient/impl/datasource/async_polling.py
+++ b/ldclient/impl/datasource/async_polling.py
@@ -44,11 +44,13 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
 
     async def stop(self):
         self.__stop_with_error_info(None)
-        # Wait for the current poll to finish before closing the transport. This way
-        # stop() does not return until background work has stopped, so we never close
-        # the transport while a request is still using it.
-        await self._task.wait_stopped()
-        await self._requester.close()
+        # Wait for the current poll to finish before closing the transport, so we do
+        # not close it while a request is still using it. The close is in a finally
+        # so an owned transport is still released if stop() is cancelled mid-wait.
+        try:
+            await self._task.wait_stopped()
+        finally:
+            await self._requester.close()
 
     def __stop_with_error_info(self, error: Optional[DataSourceErrorInfo]):
         log.info("Stopping AsyncPollingUpdateProcessor")

--- a/ldclient/impl/datasource/async_polling.py
+++ b/ldclient/impl/datasource/async_polling.py
@@ -46,6 +46,7 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
 
     async def stop(self):
         self.__stop_with_error_info(None)
+        await self._requester.close()
 
     def __stop_with_error_info(self, error: Optional[DataSourceErrorInfo]):
         log.info("Stopping AsyncPollingUpdateProcessor")
@@ -59,13 +60,12 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
     async def _fetch_and_store(self):
         try:
             all_data = await self._requester.get_all_data()
-            if all_data is not None:
-                await sink_or_store(self._data_source_update_sink, self._store).init(all_data)
-                if not self._ready.is_set() and self._store.initialized:
-                    log.info("AsyncPollingUpdateProcessor initialized ok")
-                    self._ready.set()
+            await sink_or_store(self._data_source_update_sink, self._store).init(all_data)
+            if not self._ready.is_set() and self._store.initialized:
+                log.info("AsyncPollingUpdateProcessor initialized ok")
+                self._ready.set()
 
-            # Signal VALID on any successful response (200 or 304) once the store is populated.
+            # Signal VALID once the store is populated.
             if self._store.initialized and self._data_source_update_sink is not None:
                 self._data_source_update_sink.update_status(DataSourceState.VALID, None)
         except UnsuccessfulResponseException as e:
@@ -83,8 +83,5 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
                     self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, error_info)
         except Exception as e:
             log.exception('Error: Exception encountered when updating flags. %s' % e)
-            if not self._ready.is_set():
-                self._ready.set()
-
             if self._data_source_update_sink is not None:
                 self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(e)))

--- a/ldclient/impl/datasource/async_polling.py
+++ b/ldclient/impl/datasource/async_polling.py
@@ -9,9 +9,6 @@ from typing import Optional
 
 from ldclient.async_config import AsyncConfig
 from ldclient.impl.aio.concurrency import AsyncEvent, AsyncRepeatingTask
-from ldclient.impl.datasource.async_feature_requester import (
-    AsyncFeatureRequesterImpl
-)
 from ldclient.impl.datasource.datasource_common import sink_or_store
 from ldclient.impl.util import (
     UnsuccessfulResponseException,
@@ -20,6 +17,7 @@ from ldclient.impl.util import (
     log
 )
 from ldclient.interfaces import (
+    AsyncFeatureRequester,
     AsyncFeatureStore,
     AsyncUpdateProcessor,
     DataSourceErrorInfo,
@@ -29,7 +27,7 @@ from ldclient.interfaces import (
 
 
 class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
-    def __init__(self, config: AsyncConfig, requester: AsyncFeatureRequesterImpl, store: AsyncFeatureStore, ready: AsyncEvent):
+    def __init__(self, config: AsyncConfig, requester: AsyncFeatureRequester, store: AsyncFeatureStore, ready: AsyncEvent):
         self._config = config
         self._data_source_update_sink = config.data_source_update_sink
         self._requester = requester
@@ -42,7 +40,7 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
         self._task.start()
 
     def initialized(self):
-        return self._ready.is_set() is True and self._store.initialized is True
+        return self._ready.is_set() and self._store.initialized
 
     async def stop(self):
         self.__stop_with_error_info(None)
@@ -69,8 +67,7 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
                 log.info("AsyncPollingUpdateProcessor initialized ok")
                 self._ready.set()
 
-            # Signal VALID once the store is populated.
-            if self._store.initialized and self._data_source_update_sink is not None:
+            if self._data_source_update_sink is not None:
                 self._data_source_update_sink.update_status(DataSourceState.VALID, None)
         except UnsuccessfulResponseException as e:
             error_info = DataSourceErrorInfo(DataSourceErrorKind.ERROR_RESPONSE, e.status, time.time(), str(e))

--- a/ldclient/impl/datasource/async_polling.py
+++ b/ldclient/impl/datasource/async_polling.py
@@ -46,6 +46,10 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
 
     async def stop(self):
         self.__stop_with_error_info(None)
+        # Wait for the in-flight poll to finish unwinding before closing the
+        # transport, so awaiting stop() guarantees background work has stopped
+        # and we don't close the HTTP transport out from under a live request.
+        await self._task.wait_stopped()
         await self._requester.close()
 
     def __stop_with_error_info(self, error: Optional[DataSourceErrorInfo]):

--- a/ldclient/impl/datasource/async_polling.py
+++ b/ldclient/impl/datasource/async_polling.py
@@ -46,9 +46,9 @@ class AsyncPollingUpdateProcessor(AsyncUpdateProcessor):
 
     async def stop(self):
         self.__stop_with_error_info(None)
-        # Wait for the in-flight poll to finish unwinding before closing the
-        # transport, so awaiting stop() guarantees background work has stopped
-        # and we don't close the HTTP transport out from under a live request.
+        # Wait for the current poll to finish before closing the transport. This way
+        # stop() does not return until background work has stopped, so we never close
+        # the transport while a request is still using it.
         await self._task.wait_stopped()
         await self._requester.close()
 

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -571,6 +571,26 @@ class FeatureRequester(ABC):
         pass
 
 
+class AsyncFeatureRequester(ABC):
+    """
+    Async interface for the component that acquires feature flag data in polling
+    mode. The default implementation can be replaced for testing purposes.
+
+    .. caution::
+        This feature is experimental and should NOT be considered ready for production
+        use. It may change or be removed without notice and is not subject to backwards
+        compatibility guarantees. Pin to a specific minor version and review the changelog
+        before upgrading.
+    """
+
+    @abstractmethod
+    async def get_all_data(self) -> Mapping[VersionedDataKind, Mapping[str, dict]]:
+        """
+        Fetches all feature flag and segment data.
+        """
+        ...
+
+
 class DiagnosticDescription:
     """
     Optional interface for components to describe their own configuration.

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -590,6 +590,13 @@ class AsyncFeatureRequester(ABC):
         """
         ...
 
+    @abstractmethod
+    async def close(self) -> None:
+        """
+        Releases any resources (such as an HTTP transport) owned by the requester.
+        """
+        ...
+
 
 class DiagnosticDescription:
     """

--- a/ldclient/testing/impl/datasource/test_async_polling.py
+++ b/ldclient/testing/impl/datasource/test_async_polling.py
@@ -299,6 +299,36 @@ class TestAsyncPollingUpdateProcessor:
         processor._requester.close.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_stop_awaits_poll_before_closing_transport(self):
+        # The in-flight poll must finish unwinding before the transport is
+        # closed, so we never close it out from under a live request.
+        order = []
+        started = asyncio.Event()
+
+        async def slow_poll():
+            started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                order.append('poll_done')
+                raise
+
+        async def close():
+            order.append('transport_closed')
+
+        requester = MagicMock()
+        requester.get_all_data = slow_poll
+        requester.close = close
+
+        processor = make_processor(requester=requester)
+        processor.start()
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+
+        await processor.stop()
+
+        assert order == ['poll_done', 'transport_closed']
+
+    @pytest.mark.asyncio
     async def test_stop_cancels_polling_task_cleanly(self):
         store = MockAsyncFeatureStore()
         ready = asyncio.Event()

--- a/ldclient/testing/impl/datasource/test_async_polling.py
+++ b/ldclient/testing/impl/datasource/test_async_polling.py
@@ -14,7 +14,11 @@ from ldclient.impl.datasource.async_feature_requester import (
 )
 from ldclient.impl.datasource.async_polling import AsyncPollingUpdateProcessor
 from ldclient.impl.util import UnsuccessfulResponseException
-from ldclient.interfaces import DataSourceErrorKind, DataSourceState
+from ldclient.interfaces import (
+    AsyncDataSourceUpdateSink,
+    DataSourceErrorKind,
+    DataSourceState
+)
 from ldclient.testing.mock_async_components import MockAsyncFeatureStore
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
@@ -25,10 +29,7 @@ SAMPLE_DATA = {FEATURES: SAMPLE_FLAGS, SEGMENTS: SAMPLE_SEGMENTS}
 
 
 def make_config(**kwargs):
-    """Create a Config with a short poll_interval for tests.
-
-    Config enforces a minimum poll_interval of 30s, so we patch the property.
-    """
+    """Create a Config with the test SDK key."""
     return Config('SDK_KEY', **kwargs)
 
 
@@ -363,7 +364,7 @@ class TestAsyncPollingUpdateProcessor:
         ready = asyncio.Event()
         config = make_config()
 
-        sink = AsyncMock()
+        sink = MagicMock(spec=AsyncDataSourceUpdateSink)
         config._data_source_update_sink = sink
 
         processor = make_processor(config=config, store=store, ready=ready)
@@ -394,10 +395,10 @@ class TestAsyncPollingUpdateProcessor:
         ready = asyncio.Event()
         config = make_config()
 
-        # The processor checks self._store.initialized before sending VALID.
-        # Use an AsyncMock sink whose init() also marks the underlying store as initialized
-        # so that both the sink-path and the initialized check work correctly.
-        sink = AsyncMock()
+        # The sink's init() also marks the underlying store initialized, so the
+        # ready event fires (it gates on store.initialized) and ready.wait()
+        # below completes.
+        sink = MagicMock(spec=AsyncDataSourceUpdateSink)
 
         async def _init_and_store(data):
             await store.init(data)

--- a/ldclient/testing/impl/datasource/test_async_polling.py
+++ b/ldclient/testing/impl/datasource/test_async_polling.py
@@ -1,0 +1,387 @@
+"""
+Tests for AsyncFeatureRequesterImpl and AsyncPollingUpdateProcessor.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ldclient.config import Config
+from ldclient.impl.aio.transport_types import TransportResponse
+from ldclient.impl.datasource.async_feature_requester import (
+    AsyncFeatureRequesterImpl
+)
+from ldclient.impl.datasource.async_polling import AsyncPollingUpdateProcessor
+from ldclient.impl.util import UnsuccessfulResponseException
+from ldclient.interfaces import DataSourceErrorKind, DataSourceState
+from ldclient.testing.mock_async_components import MockAsyncFeatureStore
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
+
+# Sample data returned by a successful poll
+SAMPLE_FLAGS = {'flagkey': {'key': 'flagkey', 'version': 1, 'deleted': False}}
+SAMPLE_SEGMENTS = {'segkey': {'key': 'segkey', 'version': 1, 'deleted': False}}
+SAMPLE_DATA = {FEATURES: SAMPLE_FLAGS, SEGMENTS: SAMPLE_SEGMENTS}
+
+
+def make_config(**kwargs):
+    """Create a Config with a short poll_interval for tests.
+
+    Config enforces a minimum poll_interval of 30s, so we patch the property.
+    """
+    return Config('SDK_KEY', **kwargs)
+
+
+def make_processor(config=None, store=None, ready=None, requester=None):
+    if config is None:
+        config = make_config()
+    if store is None:
+        store = MockAsyncFeatureStore()
+    if ready is None:
+        ready = asyncio.Event()
+    if requester is None:
+        requester = MagicMock()
+    return AsyncPollingUpdateProcessor(
+        config=config,
+        requester=requester,
+        store=store,
+        ready=ready,
+    )
+
+
+def make_transport(*responses: TransportResponse):
+    """Create a stub transport whose request() returns the given responses in order."""
+    transport = MagicMock()
+    transport.request = AsyncMock(side_effect=list(responses))
+    return transport
+
+
+class TestAsyncFeatureRequesterImpl:
+    @pytest.mark.asyncio
+    async def test_successful_response_returns_flags_and_segments(self):
+        import json
+        config = make_config()
+        transport = make_transport(
+            TransportResponse(200, {}, json.dumps({'flags': SAMPLE_FLAGS, 'segments': SAMPLE_SEGMENTS}))
+        )
+        requester = AsyncFeatureRequesterImpl(config, transport)
+
+        data = await requester.get_all_data()
+
+        assert data[FEATURES] == SAMPLE_FLAGS
+        assert data[SEGMENTS] == SAMPLE_SEGMENTS
+
+    @pytest.mark.asyncio
+    async def test_304_not_modified_returns_cached_data(self):
+        from ldclient.impl.datasource.async_feature_requester import CacheEntry
+
+        config = make_config()
+        transport = make_transport(TransportResponse(304, {}, ''))
+        requester = AsyncFeatureRequesterImpl(config, transport)
+
+        # Pre-populate the cache with a known etag and data
+        cached_data = {'flags': SAMPLE_FLAGS, 'segments': SAMPLE_SEGMENTS}
+        requester._cache[requester._poll_uri] = CacheEntry(data=cached_data, etag='"abc"')
+
+        data = await requester.get_all_data()
+
+        # 304 returns the cached data rather than None
+        assert data[FEATURES] == SAMPLE_FLAGS
+        assert data[SEGMENTS] == SAMPLE_SEGMENTS
+        # The cached etag is sent as If-None-Match
+        headers = transport.request.call_args.kwargs['headers']
+        assert headers['If-None-Match'] == '"abc"'
+
+    @pytest.mark.asyncio
+    async def test_etag_and_data_stored_after_successful_response(self):
+        config = make_config()
+        transport = make_transport(
+            TransportResponse(200, {'ETag': '"v1"'}, '{"flags": {}, "segments": {}}')
+        )
+        requester = AsyncFeatureRequesterImpl(config, transport)
+
+        await requester.get_all_data()
+
+        cache_entry = requester._cache.get(requester._poll_uri)
+        assert cache_entry is not None
+        assert cache_entry.etag == '"v1"'
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises_unsuccessful_response_exception(self):
+        config = make_config()
+        transport = make_transport(TransportResponse(401, {}, ''))
+        requester = AsyncFeatureRequesterImpl(config, transport)
+
+        with pytest.raises(UnsuccessfulResponseException) as exc_info:
+            await requester.get_all_data()
+
+        assert exc_info.value.status == 401
+
+    @pytest.mark.asyncio
+    async def test_payload_filter_key_appended_to_uri(self):
+        config = Config('SDK_KEY', payload_filter_key='my-filter')
+        requester = AsyncFeatureRequesterImpl(config, MagicMock())
+
+        assert 'filter=my-filter' in requester._poll_uri
+
+
+class TestAsyncPollingUpdateProcessor:
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_successful_poll_initializes_store_and_sets_ready(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        processor._requester.get_all_data = AsyncMock(return_value=SAMPLE_DATA)
+
+        processor.start()
+        await asyncio.wait_for(ready.wait(), timeout=2.0)
+
+        assert ready.is_set()
+        assert store.initialized
+        assert processor.initialized()
+        assert len(store.inits) >= 1
+        assert store.inits[0] == SAMPLE_DATA
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_304_not_modified_does_not_reinitialize_store(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        call_count = 0
+
+        async def get_all_data():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return SAMPLE_DATA
+            return None  # Simulate 304 Not Modified on subsequent calls
+
+        processor._requester.get_all_data = get_all_data
+
+        processor.start()
+        await asyncio.wait_for(ready.wait(), timeout=2.0)
+
+        # Let it run at least a second poll cycle
+        await asyncio.sleep(0.05)
+
+        # Store should only have been initialized once (None return does not trigger re-init)
+        assert len(store.inits) == 1
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_unrecoverable_http_error_stops_polling_and_sets_ready(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        mock_requester = AsyncMock(side_effect=UnsuccessfulResponseException(401))
+        processor._requester.get_all_data = mock_requester
+
+        processor.start()
+        await asyncio.wait_for(ready.wait(), timeout=2.0)
+
+        assert ready.is_set()
+        assert not processor.initialized()
+
+        # The polling task must have stopped itself: no further polls occur.
+        await asyncio.sleep(0.05)
+        snapshot = mock_requester.call_count
+        await asyncio.sleep(0.05)
+        assert mock_requester.call_count == snapshot
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_recoverable_http_error_continues_polling(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        call_count = 0
+
+        async def get_all_data():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise UnsuccessfulResponseException(500)
+            return SAMPLE_DATA
+
+        processor._requester.get_all_data = get_all_data
+
+        processor.start()
+        await asyncio.wait_for(ready.wait(), timeout=2.0)
+
+        assert ready.is_set()
+        assert processor.initialized()
+        assert call_count >= 3
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_general_exception_does_not_stop_polling(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        call_count = 0
+
+        async def get_all_data():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise RuntimeError("transient error")
+            return SAMPLE_DATA
+
+        processor._requester.get_all_data = get_all_data
+
+        processor.start()
+
+        # _ready is set on the first exception (so the client is never stuck),
+        # but the loop continues.  Wait until the store is actually initialized
+        # (call_count reaches 3) to verify polling kept running.
+        async def wait_for_initialized():
+            while not store.initialized:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait_for_initialized(), timeout=2.0)
+
+        assert ready.is_set()
+        assert call_count >= 3
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_polling_task_cleanly(self):
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        poll_count = 0
+
+        async def slow_poll():
+            nonlocal poll_count
+            poll_count += 1
+            await asyncio.sleep(60)  # Would block indefinitely without cancel
+
+        processor._requester.get_all_data = slow_poll
+
+        processor.start()
+        await asyncio.sleep(0.05)  # Let the task start
+
+        # stop() should return promptly even though the poll is "sleeping"
+        await asyncio.wait_for(processor.stop(), timeout=1.0)
+
+        # No further polls occur after stopping
+        await asyncio.sleep(0.05)
+        assert poll_count == 1
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_unrecoverable_error_updates_sink_to_off(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+
+        sink = AsyncMock()
+        config._data_source_update_sink = sink
+
+        processor = make_processor(config=config, store=store, ready=ready)
+        processor._data_source_update_sink = sink
+
+        processor._requester.get_all_data = AsyncMock(
+            side_effect=UnsuccessfulResponseException(403)
+        )
+
+        processor.start()
+        await asyncio.wait_for(ready.wait(), timeout=2.0)
+
+        # Verify the sink was told to go OFF
+        calls = [call for call in sink.update_status.call_args_list if call.args[0] == DataSourceState.OFF]
+        assert len(calls) >= 1
+        error_info = calls[0].args[1]
+        assert error_info.kind == DataSourceErrorKind.ERROR_RESPONSE
+        assert error_info.status_code == 403
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_successful_poll_updates_sink_to_valid(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+
+        # The processor checks self._store.initialized before sending VALID.
+        # Use an AsyncMock sink whose init() also marks the underlying store as initialized
+        # so that both the sink-path and the initialized check work correctly.
+        sink = AsyncMock()
+
+        async def _init_and_store(data):
+            await store.init(data)
+
+        sink.init = _init_and_store
+        config._data_source_update_sink = sink
+
+        processor = make_processor(config=config, store=store, ready=ready)
+        processor._data_source_update_sink = sink
+
+        processor._requester.get_all_data = AsyncMock(return_value=SAMPLE_DATA)
+
+        processor.start()
+        await asyncio.wait_for(ready.wait(), timeout=2.0)
+
+        valid_calls = [c for c in sink.update_status.call_args_list if c.args[0] == DataSourceState.VALID]
+        assert len(valid_calls) >= 1
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    async def test_initialized_returns_false_before_first_poll(self):
+        processor = make_processor()
+        assert not processor.initialized()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_second_start_call_raises(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        processor = make_processor()
+        processor._requester.get_all_data = AsyncMock(return_value=SAMPLE_DATA)
+
+        processor.start()
+        # Like a thread, the polling task can only be started once
+        with pytest.raises(RuntimeError):
+            processor.start()
+
+        await processor.stop()

--- a/ldclient/testing/impl/datasource/test_async_polling.py
+++ b/ldclient/testing/impl/datasource/test_async_polling.py
@@ -438,3 +438,30 @@ class TestAsyncPollingUpdateProcessor:
             processor.start()
 
         await processor.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_transport_when_cancelled_mid_wait(self):
+        # If the caller of stop() is cancelled while it waits for the poll to
+        # finish, the owned transport must still be closed (the close is in a
+        # finally), rather than leaking.
+        requester = MagicMock()
+        requester.close = AsyncMock()
+        processor = make_processor(requester=requester)
+
+        # Replace the repeating task so wait_stopped() hangs until we cancel stop().
+        waiting = asyncio.Event()
+
+        async def hang():
+            waiting.set()
+            await asyncio.Event().wait()
+
+        processor._task = MagicMock()
+        processor._task.wait_stopped = hang
+
+        stop_task = asyncio.create_task(processor.stop())
+        await asyncio.wait_for(waiting.wait(), timeout=2.0)
+        stop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await stop_task
+
+        requester.close.assert_awaited_once()

--- a/ldclient/testing/impl/datasource/test_async_polling.py
+++ b/ldclient/testing/impl/datasource/test_async_polling.py
@@ -41,6 +41,7 @@ def make_processor(config=None, store=None, ready=None, requester=None):
         ready = asyncio.Event()
     if requester is None:
         requester = MagicMock()
+        requester.close = AsyncMock()
     return AsyncPollingUpdateProcessor(
         config=config,
         requester=requester,
@@ -124,6 +125,26 @@ class TestAsyncFeatureRequesterImpl:
 
         assert 'filter=my-filter' in requester._poll_uri
 
+    @pytest.mark.asyncio
+    async def test_close_closes_owned_transport(self):
+        with patch('ldclient.impl.datasource.async_feature_requester.AsyncHTTPTransport') as MockTransport:
+            MockTransport.return_value.close = AsyncMock()
+            requester = AsyncFeatureRequesterImpl(make_config())  # no transport -> owns one
+
+            await requester.close()
+
+            MockTransport.return_value.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_does_not_close_injected_transport(self):
+        transport = MagicMock()
+        transport.close = AsyncMock()
+        requester = AsyncFeatureRequesterImpl(make_config(), transport)
+
+        await requester.close()
+
+        transport.close.assert_not_called()
+
 
 class TestAsyncPollingUpdateProcessor:
 
@@ -147,38 +168,6 @@ class TestAsyncPollingUpdateProcessor:
         assert processor.initialized()
         assert len(store.inits) >= 1
         assert store.inits[0] == SAMPLE_DATA
-
-        await processor.stop()
-
-    @pytest.mark.asyncio
-    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
-    async def test_304_not_modified_does_not_reinitialize_store(self, mock_interval):
-        mock_interval.__get__ = MagicMock(return_value=0)
-
-        store = MockAsyncFeatureStore()
-        ready = asyncio.Event()
-        config = make_config()
-        processor = make_processor(config=config, store=store, ready=ready)
-
-        call_count = 0
-
-        async def get_all_data():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return SAMPLE_DATA
-            return None  # Simulate 304 Not Modified on subsequent calls
-
-        processor._requester.get_all_data = get_all_data
-
-        processor.start()
-        await asyncio.wait_for(ready.wait(), timeout=2.0)
-
-        # Let it run at least a second poll cycle
-        await asyncio.sleep(0.05)
-
-        # Store should only have been initialized once (None return does not trigger re-init)
-        assert len(store.inits) == 1
 
         await processor.stop()
 
@@ -262,8 +251,8 @@ class TestAsyncPollingUpdateProcessor:
 
         processor.start()
 
-        # _ready is set on the first exception (so the client is never stuck),
-        # but the loop continues.  Wait until the store is actually initialized
+        # A generic error must NOT release start_wait; _ready stays unset until a
+        # later poll succeeds. Wait until the store is actually initialized
         # (call_count reaches 3) to verify polling kept running.
         async def wait_for_initialized():
             while not store.initialized:
@@ -275,6 +264,39 @@ class TestAsyncPollingUpdateProcessor:
         assert call_count >= 3
 
         await processor.stop()
+
+    @pytest.mark.asyncio
+    @patch('ldclient.config.Config.poll_interval', new_callable=MagicMock)
+    async def test_general_exception_does_not_set_ready(self, mock_interval):
+        mock_interval.__get__ = MagicMock(return_value=0)
+
+        store = MockAsyncFeatureStore()
+        ready = asyncio.Event()
+        config = make_config()
+        processor = make_processor(config=config, store=store, ready=ready)
+
+        async def get_all_data():
+            raise RuntimeError("transient error")
+
+        processor._requester.get_all_data = get_all_data
+
+        processor.start()
+        # Let several polls run; all raise. A transient error must not release
+        # start_wait (mirrors sync, which leaves _ready unset here).
+        await asyncio.sleep(0.05)
+
+        assert not ready.is_set()
+        assert not processor.initialized()
+
+        await processor.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_closes_requester(self):
+        processor = make_processor()
+
+        await processor.stop()
+
+        processor._requester.close.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stop_cancels_polling_task_cleanly(self):


### PR DESCRIPTION
## Overview

PR 7 of the SDK-60 async epic: the async FDv1 polling data source and feature requester.

- **`async_polling.py`** — async FDv1 polling update processor. Polls the feature requester on an interval and pushes flag/segment data into the data source update sink, updating data source status (VALID / OFF) as appropriate.
- **`async_feature_requester.py`** — async FDv1 feature requester that fetches the full flag/segment payload over HTTP.
- **`test_async_polling.py`** — unit tests for the async polling update processor.

## Stacking

This PR is **stacked on #464** (base branch `jb/sdk-2743/async-fdv1-streaming`), which provides the shared `datasource_common` module these files import. Until #464 merges, this PR will also show #464's commits in its diff; a rebase after #464 merges will drop them, leaving only the three files here.

SDK-2825

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New experimental async flag-ingestion path affects client initialization and data-source status; shutdown and HTTP error handling must stay correct to avoid leaks or stuck waits.
> 
> **Overview**
> Adds **experimental** async FDv1 polling: an `AsyncFeatureRequester` contract plus `AsyncFeatureRequesterImpl` that GETs the poll endpoint with gzip, optional payload filter query param, and **ETag / 304** caching before returning flags and segments.
> 
> **`AsyncPollingUpdateProcessor`** runs polls on `AsyncRepeatingTask`, writes via `sink_or_store`, sets **ready** when the store initializes, and reports **VALID / INTERRUPTED / OFF** on success, recoverable errors, and fatal HTTP failures (matching sync polling semantics, including unblocking init on unrecoverable errors).
> 
> **`AsyncRepeatingTask.wait_stopped()`** lets shutdown wait for the in-flight poll to finish; **`stop()`** on the processor uses that (with **`requester.close()` in `finally`**) so transports are not closed mid-request.
> 
> Broad unit tests cover caching, transport ownership, error recovery, sink status, and shutdown ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305f2b06caebd1403998c50a01909db4c3a733fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->