### PR TITLE
chore: Describe current aclose behavior in async redis store

### DIFF
--- a/ldclient/impl/integrations/redis/async_redis_big_segment_store.py
+++ b/ldclient/impl/integrations/redis/async_redis_big_segment_store.py
@@ -38,7 +38,7 @@ class _AsyncRedisBigSegmentStore(AsyncBigSegmentStore):
         return ret
 
     async def stop(self):
-        # aclose() replaced the async close() in redis-py 5.0.1; the [redis] extra allows >= 4.2
+        # Prefer aclose() (redis-py 5.0.1+); older supported versions (>= 4.2) only have close().
         if hasattr(self._client, "aclose"):
             await self._client.aclose()
         else:


### PR DESCRIPTION
Rewords a comment in the async Redis big segment store to describe current behavior instead of narrating version history.

Before: `# aclose() replaced the async close() in redis-py 5.0.1; the [redis] extra allows >= 4.2`
After:  `# Prefer aclose() (redis-py 5.0.1+); older supported versions (>= 4.2) only have close().`

Comment-only; no behavior change. Part of the async comment-style cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment change with no executable code or dependency changes.
> 
> **Overview**
> **Comment-only** update in `_AsyncRedisBigSegmentStore.stop()`: the note above the `aclose()` / `close()` branch is reworded to describe **current** behavior (prefer `aclose()` on redis-py 5.0.1+, fall back to `close()` on older supported redis-py ≥ 4.2) instead of narrating that `aclose()` replaced `close()` in 5.0.1.
> 
> No logic, dependencies, or runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2abb4952c6b184afea9d307c9230e99a754a6b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->