### PR TITLE
fix: Return empty prerequisites for a flag that fails to evaluate in all_flags_state

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -646,7 +646,6 @@ class LDClient:
                 log.debug(traceback.format_exc())
                 reason = {'kind': 'ERROR', 'errorKind': 'EXCEPTION'}
                 detail = EvaluationDetail(None, None, reason)
-                # A per-flag error degrades only that flag: no value, no prerequisites.
                 prerequisites = []
 
             requires_experiment_data = EventFactory.is_experiment(flag, detail.reason)

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -640,11 +640,14 @@ class LDClient:
             try:
                 result = self._evaluator.evaluate(flag, context, self._event_factory_default)
                 detail = result.detail
+                prerequisites = result.prerequisites
             except Exception as e:
                 log.error("Error evaluating flag \"%s\" in all_flags_state: %s" % (key, repr(e)))
                 log.debug(traceback.format_exc())
                 reason = {'kind': 'ERROR', 'errorKind': 'EXCEPTION'}
                 detail = EvaluationDetail(None, None, reason)
+                # A per-flag error degrades only that flag: no value, no prerequisites.
+                prerequisites = []
 
             requires_experiment_data = EventFactory.is_experiment(flag, detail.reason)
             flag_state = {
@@ -653,7 +656,7 @@ class LDClient:
                 'variation': detail.variation_index,
                 'reason': detail.reason,
                 'version': flag['version'],
-                'prerequisites': result.prerequisites,
+                'prerequisites': prerequisites,
                 'trackEvents': flag.get('trackEvents', False) or requires_experiment_data,
                 'trackReason': requires_experiment_data,
                 'debugEventsUntilDate': flag.get('debugEventsUntilDate', None),

--- a/ldclient/testing/test_ldclient_evaluation.py
+++ b/ldclient/testing/test_ldclient_evaluation.py
@@ -342,3 +342,43 @@ def test_all_flags_returns_empty_state_if_feature_store_throws_error(caplog):
     assert state.valid is False
     errlog = get_log_lines(caplog, 'ERROR')
     assert errlog == ['Unable to read flags for all_flag_state: NotImplementedError()']
+
+
+def test_all_flags_state_degrades_per_flag_on_evaluator_error():
+    # A flag whose evaluation raises degrades only that flag: the loop must not
+    # raise UnboundLocalError when the first flag raises, and a failed flag must
+    # not inherit a previous good flag's prerequisites.
+    from unittest.mock import MagicMock
+
+    store = InMemoryFeatureStore()
+    # Ordering matters: 'bad-first' raises on the first iteration (would
+    # UnboundLocalError if result were read unconditionally); 'bad-last' raises
+    # after a good flag set result (would reuse the good result's prerequisites).
+    store.init({FEATURES: {
+        'bad-first': {'key': 'bad-first', 'version': 1, 'on': True, 'fallthrough': {'variation': 0}, 'variations': ['x']},
+        'good': {'key': 'good', 'version': 1, 'on': True, 'fallthrough': {'variation': 0}, 'variations': ['y']},
+        'bad-last': {'key': 'bad-last', 'version': 1, 'on': True, 'fallthrough': {'variation': 0}, 'variations': ['z']},
+    }})
+    client = make_client(store)
+
+    good_result = MagicMock()
+    good_result.detail = EvaluationDetail('y', 0, {'kind': 'FALLTHROUGH'})
+    good_result.prerequisites = ['prereq-of-good']
+
+    def fake_evaluate(flag, context, event_factory):
+        if flag['key'] == 'good':
+            return good_result
+        raise RuntimeError("boom")
+
+    client._evaluator.evaluate = MagicMock(side_effect=fake_evaluate)
+
+    # This must not raise UnboundLocalError.
+    state = client.all_flags_state(user)
+    assert state.valid
+
+    metadata = state.to_json_dict()['$flagsState']
+    # The good flag carries its own prerequisites; the failed flags carry none
+    # (not a neighbor's).
+    assert metadata['good'].get('prerequisites') == ['prereq-of-good']
+    assert 'prerequisites' not in metadata['bad-first']
+    assert 'prerequisites' not in metadata['bad-last']


### PR DESCRIPTION
## Summary
`all_flags_state` read `result.prerequisites` unconditionally even when a per-flag evaluation raised. The `except` branch set only `detail`, leaving `result` unbound (or holding a previous flag's value), so:
- the **first** flag raising → `UnboundLocalError` that aborts the entire state payload;
- a **later** flag raising → that flag silently inherits the *previous* flag's `prerequisites`.

`Evaluator.evaluate()` only catches its own `EvaluationException`; any other exception from malformed flag data propagates and reaches this path, so the `except` is genuinely reachable (rare, but real).

## Fix
Bind `prerequisites` in **both** eval branches (success → `result.prerequisites`, error → `[]`) so an evaluation error degrades only that flag. Adds a regression test (`bad-first` / `good` / `bad-last`) asserting no `UnboundLocalError` and that a failed flag does not inherit a neighbor's prerequisites.

This mirrors the same fix in the new async client (`AsyncLDClient.all_flags_state`).

Draft — surfaced during the async SDK review; no Jira ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error handling in `all_flags_state` with a targeted regression test; no auth or data-path changes.
> 
> **Overview**
> Fixes per-flag evaluation failures in **`all_flags_state`** so they no longer break the whole payload or leak another flag’s prerequisite metadata.
> 
> **`LDClient.all_flags_state`** now sets `prerequisites` in both the success path (`result.prerequisites`) and the error path (`[]`), instead of always reading `result.prerequisites` after the try/except. That avoids **`UnboundLocalError`** when the first flag raises and stops a later failed flag from inheriting a neighbor’s prerequisites.
> 
> Adds a regression test with `bad-first` / `good` / `bad-last` flag ordering to assert the call completes and failed flags omit prerequisites while a successful flag keeps its own.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f100554e37d28ac02da955160a11a1a9c996981. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->