### PR TITLE
feat: Add environment ID support for hooks.

### DIFF
--- a/contract-tests/hook.py
+++ b/contract-tests/hook.py
@@ -33,6 +33,7 @@ class PostingHook(Hook):
                 'context': series_context.context.to_dict(),
                 'defaultValue': series_context.default_value,
                 'method': series_context.method,
+                'environmentId': series_context.environment_id,
             },
             'evaluationSeriesData': data,
             'stage': stage,

--- a/contract-tests/service.py
+++ b/contract-tests/service.py
@@ -77,6 +77,7 @@ def status():
             'instance-id',
             'anonymous-redaction',
             'evaluation-hooks',
+            'hook-environment-id',
             'omit-anonymous-contexts',
             'client-prereq-events',
             'persistent-data-store-redis',

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -709,7 +709,7 @@ class LDClient:
 
             hooks = self.__hooks.copy()
 
-        series_context = EvaluationSeriesContext(key=key, context=context, default_value=default_value, method=method)
+        series_context = EvaluationSeriesContext(key=key, context=context, default_value=default_value, method=method, environment_id=self._data_system.environment_id)
         hook_data = self.__execute_before_evaluation(hooks, series_context)
         evaluation_result = block()
         self.__execute_after_evaluation(hooks, series_context, hook_data, evaluation_result.evaluation_detail)

--- a/ldclient/hook.py
+++ b/ldclient/hook.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Optional
 
 from ldclient.context import Context
 from ldclient.evaluation import EvaluationDetail
@@ -17,6 +17,7 @@ class EvaluationSeriesContext:
     context: Context  #: The context used during evaluation.
     default_value: Any  #: The default value provided to the evaluation method
     method: str  #: The string version of the method which triggered the evaluation series.
+    environment_id: Optional[str] = None  #: The environment ID the SDK is connected to, if available.
 
 
 @dataclass

--- a/ldclient/impl/datasource/datasource_common.py
+++ b/ldclient/impl/datasource/datasource_common.py
@@ -5,8 +5,9 @@ Pure helpers shared by the FDv1 polling and streaming data sources.
 # currently excluded from documentation - see docs/README.md
 
 from collections import namedtuple
-from typing import Optional
+from typing import Mapping, Optional, Protocol, runtime_checkable
 
+from ldclient.impl.util import _LD_ENVID_HEADER
 from ldclient.interfaces import DataSourceUpdateSink, FeatureStore
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
@@ -32,6 +33,32 @@ def sink_or_store(sink: Optional[DataSourceUpdateSink], store: FeatureStore):
         return store
 
     return sink
+
+
+@runtime_checkable
+class EnvironmentIdSink(Protocol):
+    """
+    Implemented by data source update sinks which can record the environment ID
+    reported by LaunchDarkly. This is separate from
+    :class:`ldclient.interfaces.DataSourceUpdateSink` so that externally
+    implemented sinks remain compatible.
+    """
+
+    def set_environment_id(self, environment_id: str) -> None:
+        ...
+
+
+def record_environment_id(sink, headers: Optional[Mapping[str, str]]):
+    """
+    Records the environment ID from a set of LaunchDarkly response headers, if
+    both the headers and the sink provide one.
+    """
+    if headers is None or not isinstance(sink, EnvironmentIdSink):
+        return
+
+    environment_id = headers.get(_LD_ENVID_HEADER)
+    if isinstance(environment_id, str) and environment_id != '':
+        sink.set_environment_id(environment_id)
 
 
 def parse_path(path: str):

--- a/ldclient/impl/datasource/feature_requester.py
+++ b/ldclient/impl/datasource/feature_requester.py
@@ -4,6 +4,7 @@ Default implementation of feature flag polling requests.
 
 import json
 from collections import namedtuple
+from typing import Mapping, Optional, Tuple
 from urllib import parse
 
 import urllib3
@@ -27,6 +28,10 @@ class FeatureRequesterImpl(FeatureRequester):
             self._poll_uri += '?%s' % parse.urlencode({'filter': config.payload_filter_key})
 
     def get_all_data(self):
+        (data, _) = self.get_all_data_with_headers()
+        return data
+
+    def get_all_data_with_headers(self) -> Tuple[dict, Optional[Mapping[str, str]]]:
         uri = self._poll_uri
         hdrs = _headers(self._config)
         cache_entry = self._cache.get(uri)
@@ -47,4 +52,4 @@ class FeatureRequesterImpl(FeatureRequester):
                 self._cache[uri] = CacheEntry(data=data, etag=etag)
         log.debug("%s response status:[%d] From cache? [%s] ETag:[%s]", uri, r.status, from_cache, etag)
 
-        return {FEATURES: data['flags'], SEGMENTS: data['segments']}
+        return ({FEATURES: data['flags'], SEGMENTS: data['segments']}, r.headers)

--- a/ldclient/impl/datasource/polling.py
+++ b/ldclient/impl/datasource/polling.py
@@ -6,10 +6,13 @@ Default implementation of the polling component.
 
 import time
 from threading import Event
-from typing import Optional
+from typing import Any, Mapping, Optional, Protocol, Tuple, runtime_checkable
 
 from ldclient.config import Config
-from ldclient.impl.datasource.datasource_common import sink_or_store
+from ldclient.impl.datasource.datasource_common import (
+    record_environment_id,
+    sink_or_store
+)
 from ldclient.impl.repeating_task import RepeatingTask
 from ldclient.impl.util import (
     UnsuccessfulResponseException,
@@ -26,6 +29,12 @@ from ldclient.interfaces import (
     FeatureStore,
     UpdateProcessor
 )
+
+
+@runtime_checkable
+class _FeatureRequesterWithHeaders(Protocol):
+    def get_all_data_with_headers(self) -> Tuple[Any, Optional[Mapping[str, str]]]:
+        ...
 
 
 class PollingUpdateProcessor(UpdateProcessor):
@@ -58,7 +67,8 @@ class PollingUpdateProcessor(UpdateProcessor):
 
     def _poll(self):
         try:
-            all_data = self._requester.get_all_data()
+            (all_data, headers) = self._get_all_data_with_headers()
+            record_environment_id(self._data_source_update_sink, headers)
             sink_or_store(self._data_source_update_sink, self._store).init(all_data)
             if not self._ready.is_set() and self._store.initialized:
                 log.info("PollingUpdateProcessor initialized ok")
@@ -84,3 +94,13 @@ class PollingUpdateProcessor(UpdateProcessor):
 
             if self._data_source_update_sink is not None:
                 self._data_source_update_sink.update_status(DataSourceState.INTERRUPTED, DataSourceErrorInfo(DataSourceErrorKind.UNKNOWN, 0, time.time(), str(e)))
+
+    def _get_all_data_with_headers(self) -> Tuple[Any, Optional[Mapping[str, str]]]:
+        """
+        Externally provided feature requesters are not required to surface
+        response headers, so fall back to the data-only method.
+        """
+        if isinstance(self._requester, _FeatureRequesterWithHeaders):
+            return self._requester.get_all_data_with_headers()
+
+        return (self._requester.get_all_data(), None)

--- a/ldclient/impl/datasource/status.py
+++ b/ldclient/impl/datasource/status.py
@@ -26,11 +26,21 @@ class DataSourceUpdateSinkImpl(DataSourceUpdateSink):
 
         self.__lock = ReadWriteLock()
         self.__status = DataSourceStatus(DataSourceState.INITIALIZING, time.time(), None)
+        self.__environment_id: Optional[str] = None
 
     @property
     def status(self) -> DataSourceStatus:
         with self.__lock.read():
             return self.__status
+
+    @property
+    def environment_id(self) -> Optional[str]:
+        with self.__lock.read():
+            return self.__environment_id
+
+    def set_environment_id(self, environment_id: str) -> None:
+        with self.__lock.write():
+            self.__environment_id = environment_id
 
     def init(self, all_data: Mapping[VersionedDataKind, Mapping[str, dict]]):
         old_data = None

--- a/ldclient/impl/datasource/streaming.py
+++ b/ldclient/impl/datasource/streaming.py
@@ -94,8 +94,6 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                         log.info("StreamingUpdateProcessor initialized ok.")
                         self._ready.set()
             elif isinstance(action, Fault):
-                record_environment_id(self._data_source_update_sink, action.headers)
-
                 # If the SSE client detects the stream has closed, then it will emit a fault with no-error. We can
                 # ignore this since we want the connection to continue.
                 if action.error is None:

--- a/ldclient/impl/datasource/streaming.py
+++ b/ldclient/impl/datasource/streaming.py
@@ -5,7 +5,7 @@ from typing import Optional
 from urllib import parse
 
 from ld_eventsource import SSEClient
-from ld_eventsource.actions import Event, Fault
+from ld_eventsource.actions import Event, Fault, Start
 from ld_eventsource.config import (
     ConnectStrategy,
     ErrorStrategy,
@@ -16,6 +16,7 @@ from ld_eventsource.errors import HTTPStatusError
 from ldclient.impl.datasource.datasource_common import (
     STREAM_ALL_PATH,
     parse_path,
+    record_environment_id,
     sink_or_store
 )
 from ldclient.impl.http import HTTPFactory, _http_factory
@@ -62,7 +63,9 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
         self._sse = self._create_sse_client()
         self._connection_attempt_start_time = time.time()
         for action in self._sse.all:
-            if isinstance(action, Event):
+            if isinstance(action, Start):
+                record_environment_id(self._data_source_update_sink, action.headers)
+            elif isinstance(action, Event):
                 message_ok = False
                 try:
                     message_ok = self._process_message(sink_or_store(self._data_source_update_sink, self._store), action)
@@ -91,6 +94,8 @@ class StreamingUpdateProcessor(Thread, UpdateProcessor):
                         log.info("StreamingUpdateProcessor initialized ok.")
                         self._ready.set()
             elif isinstance(action, Fault):
+                record_environment_id(self._data_source_update_sink, action.headers)
+
                 # If the SSE client detects the stream has closed, then it will emit a fault with no-error. We can
                 # ignore this since we want the connection to continue.
                 if action.error is None:

--- a/ldclient/impl/datasystem/__init__.py
+++ b/ldclient/impl/datasystem/__init__.py
@@ -6,7 +6,7 @@ v2), as well as types for v1 and v2 specific protocols.
 from abc import abstractmethod
 from enum import Enum
 from threading import Event
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from ldclient.impl.aio.concurrency import AsyncEvent
@@ -143,6 +143,18 @@ class DataSystem(Protocol):
     def store(self) -> ReadOnlyStore:
         """
         Returns the data store used by the data system.
+        """
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def environment_id(self) -> Optional[str]:
+        """
+        Returns the environment ID reported by LaunchDarkly, if it is known.
+
+        This is only available once a connection to LaunchDarkly has provided
+        it, and it will be None when the SDK is offline, using an unsupported
+        data source, or connected to a service which does not report it.
         """
         raise NotImplementedError
 

--- a/ldclient/impl/datasystem/fdv1.py
+++ b/ldclient/impl/datasystem/fdv1.py
@@ -98,6 +98,10 @@ class FDv1(DataSystem):
     def store(self) -> ReadOnlyStore:
         return self._store_wrapper
 
+    @property
+    def environment_id(self) -> Optional[str]:
+        return self._data_source_update_sink.environment_id
+
     def set_diagnostic_accumulator(self, diagnostic_accumulator: DiagnosticAccumulator):
         """
         Sets the diagnostic accumulator for streaming initialization metrics.

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -21,7 +21,12 @@ from ldclient.impl.flag_tracker import FlagTrackerImpl
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.repeating_task import RepeatingTask
 from ldclient.impl.rwlock import ReadWriteLock
-from ldclient.impl.util import _LD_FD_FALLBACK_HEADER, _Fail, log
+from ldclient.impl.util import (
+    _LD_ENVID_HEADER,
+    _LD_FD_FALLBACK_HEADER,
+    _Fail,
+    log
+)
 from ldclient.interfaces import (
     DataSourceErrorInfo,
     DataSourceErrorKind,
@@ -95,6 +100,7 @@ class FDv2(DataSystem):
         self._lock = ReadWriteLock()
         self._active_synchronizer: Optional[Synchronizer] = None
         self._threads: List[Thread] = []
+        self._environment_id: Optional[str] = None
 
         # Track configuration
         self._configured_with_data_sources = (
@@ -216,6 +222,8 @@ class FDv2(DataSystem):
 
                 if isinstance(basis_result, _Fail):
                     log.warning("Initializer %s failed: %s", initializer.name, basis_result.error)
+                    if basis_result.headers is not None:
+                        self._record_environment_id(basis_result.headers.get(_LD_ENVID_HEADER))
                     # An error response can still carry the FDv1 fallback directive.
                     if basis_result.headers is not None and \
                             basis_result.headers.get(_LD_FD_FALLBACK_HEADER) == 'true':
@@ -239,6 +247,8 @@ class FDv2(DataSystem):
 
                 basis = basis_result.value
                 log.info("Initialized via %s", initializer.name)
+
+                self._record_environment_id(basis.environment_id)
 
                 # Apply the basis to the store
                 self._store.apply(basis.change_set, basis.persist)
@@ -412,6 +422,8 @@ class FDv2(DataSystem):
                 if self._stop_event.is_set():
                     return ConditionDirective.FALLBACK
 
+                self._record_environment_id(update.environment_id)
+
                 # Handle the update
                 if update.change_set is not None:
                     self._store.apply(update.change_set, True)
@@ -495,6 +507,19 @@ class FDv2(DataSystem):
         err = self._store.commit()
         if err is not None:
             log.error("Failed to reinitialize data store", exc_info=err)
+
+    def _record_environment_id(self, environment_id: Optional[str]):
+        if environment_id is None:
+            return
+
+        with self._lock.write():
+            self._environment_id = environment_id
+
+    @property
+    def environment_id(self) -> Optional[str]:
+        """Get the environment ID reported by LaunchDarkly, if known."""
+        with self._lock.read():
+            return self._environment_id
 
     @property
     def store(self) -> ReadOnlyStore:

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -21,12 +21,7 @@ from ldclient.impl.flag_tracker import FlagTrackerImpl
 from ldclient.impl.listeners import Listeners
 from ldclient.impl.repeating_task import RepeatingTask
 from ldclient.impl.rwlock import ReadWriteLock
-from ldclient.impl.util import (
-    _LD_ENVID_HEADER,
-    _LD_FD_FALLBACK_HEADER,
-    _Fail,
-    log
-)
+from ldclient.impl.util import _LD_FD_FALLBACK_HEADER, _Fail, log
 from ldclient.interfaces import (
     DataSourceErrorInfo,
     DataSourceErrorKind,
@@ -222,8 +217,6 @@ class FDv2(DataSystem):
 
                 if isinstance(basis_result, _Fail):
                     log.warning("Initializer %s failed: %s", initializer.name, basis_result.error)
-                    if basis_result.headers is not None:
-                        self._record_environment_id(basis_result.headers.get(_LD_ENVID_HEADER))
                     # An error response can still carry the FDv1 fallback directive.
                     if basis_result.headers is not None and \
                             basis_result.headers.get(_LD_FD_FALLBACK_HEADER) == 'true':
@@ -422,7 +415,8 @@ class FDv2(DataSystem):
                 if self._stop_event.is_set():
                     return ConditionDirective.FALLBACK
 
-                self._record_environment_id(update.environment_id)
+                if update.state == DataSourceState.VALID:
+                    self._record_environment_id(update.environment_id)
 
                 # Handle the update
                 if update.change_set is not None:
@@ -509,7 +503,7 @@ class FDv2(DataSystem):
             log.error("Failed to reinitialize data store", exc_info=err)
 
     def _record_environment_id(self, environment_id: Optional[str]):
-        if environment_id is None:
+        if not isinstance(environment_id, str) or environment_id == '':
             return
 
         with self._lock.write():

--- a/ldclient/interfaces.py
+++ b/ldclient/interfaces.py
@@ -570,6 +570,12 @@ class FeatureRequester(ABC):
         """
         pass
 
+    def get_all_data(self) -> Mapping[VersionedDataKind, Mapping[str, dict]]:
+        """
+        Fetches all feature flag and segment data.
+        """
+        raise NotImplementedError
+
 
 class AsyncFeatureRequester(ABC):
     """

--- a/ldclient/testing/impl/datasource/test_feature_requester.py
+++ b/ldclient/testing/impl/datasource/test_feature_requester.py
@@ -25,6 +25,19 @@ def test_get_all_data_returns_data():
         assert result == expected_data
 
 
+def test_get_all_data_with_headers_returns_response_headers():
+    with start_server() as server:
+        config = Config(sdk_key='sdk-key', base_uri=server.uri)
+        fr = FeatureRequesterImpl(config)
+
+        resp_data = {'flags': {}, 'segments': {}}
+        server.for_path('/sdk/latest-all', JsonResponse(resp_data, {'X-LD-EnvID': 'env-abc-123'}))
+
+        (data, headers) = fr.get_all_data_with_headers()
+        assert data == {FEATURES: {}, SEGMENTS: {}}
+        assert headers.get('X-LD-EnvID') == 'env-abc-123'
+
+
 def test_get_all_data_sends_headers():
     with start_server() as server:
         config = Config(sdk_key='sdk-key', base_uri=server.uri)

--- a/ldclient/testing/impl/datasource/test_polling_processor.py
+++ b/ldclient/testing/impl/datasource/test_polling_processor.py
@@ -165,7 +165,7 @@ def test_records_environment_id_from_polling_headers():
     sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
     config._data_source_update_sink = sink
     setup_processor(config)
-    ready.wait()
+    assert ready.wait(2)
 
     assert sink.environment_id == 'env-abc-123'
 
@@ -177,6 +177,6 @@ def test_environment_id_is_none_when_requester_provides_no_headers():
     sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
     config._data_source_update_sink = sink
     setup_processor(config)
-    ready.wait()
+    assert ready.wait(2)
 
     assert sink.environment_id is None

--- a/ldclient/testing/impl/datasource/test_polling_processor.py
+++ b/ldclient/testing/impl/datasource/test_polling_processor.py
@@ -145,3 +145,38 @@ def verify_recoverable_http_error(http_status_code, ignore_mock):
         assert status.state == DataSourceState.INITIALIZING
         assert status.error.kind == DataSourceErrorKind.ERROR_RESPONSE
         assert status.error.status_code == http_status_code
+
+
+class MockFeatureRequesterWithHeaders(MockFeatureRequester):
+    def __init__(self, headers):
+        super().__init__()
+        self.headers = headers
+
+    def get_all_data_with_headers(self):
+        return (self.get_all_data(), self.headers)
+
+
+def test_records_environment_id_from_polling_headers():
+    global mock_requester
+    mock_requester = MockFeatureRequesterWithHeaders({'X-LD-EnvID': 'env-abc-123'})
+    mock_requester.all_data = {FEATURES: {}, SEGMENTS: {}}
+
+    config = Config("SDK_KEY")
+    sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
+    config._data_source_update_sink = sink
+    setup_processor(config)
+    ready.wait()
+
+    assert sink.environment_id == 'env-abc-123'
+
+
+def test_environment_id_is_none_when_requester_provides_no_headers():
+    mock_requester.all_data = {FEATURES: {}, SEGMENTS: {}}
+
+    config = Config("SDK_KEY")
+    sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
+    config._data_source_update_sink = sink
+    setup_processor(config)
+    ready.wait()
+
+    assert sink.environment_id is None

--- a/ldclient/testing/impl/datasource/test_streaming.py
+++ b/ldclient/testing/impl/datasource/test_streaming.py
@@ -438,6 +438,58 @@ def test_failure_transitions_from_valid():
             assert spy.statuses[1].error.status_code == 401
 
 
+def test_records_environment_id_from_stream_headers():
+    store = InMemoryFeatureStore()
+    ready = Event()
+
+    with start_server() as server:
+        with stream_content(make_put_event(), headers={'X-LD-EnvID': 'env-abc-123'}) as stream:
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
+            sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
+            config._data_source_update_sink = sink
+            server.for_path('/all', stream)
+
+            with StreamingUpdateProcessor(config, store, ready, None) as sp:
+                sp.start()
+                ready.wait(start_wait)
+                assert sink.environment_id == 'env-abc-123'
+
+
+def test_environment_id_is_none_when_not_provided():
+    store = InMemoryFeatureStore()
+    ready = Event()
+
+    with start_server() as server:
+        with stream_content(make_put_event()) as stream:
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri)
+            sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
+            config._data_source_update_sink = sink
+            server.for_path('/all', stream)
+
+            with StreamingUpdateProcessor(config, store, ready, None) as sp:
+                sp.start()
+                ready.wait(start_wait)
+                assert sink.environment_id is None
+
+
+def test_records_environment_id_from_error_response_headers():
+    store = InMemoryFeatureStore()
+    ready = Event()
+
+    with start_server() as server:
+        with stream_content(make_put_event()) as stream:
+            error_then_success = SequentialHandler(BasicResponse(503, None, {'X-LD-EnvID': 'env-from-error'}), stream)
+            config = Config(sdk_key='sdk-key', stream_uri=server.uri, initial_reconnect_delay=brief_delay)
+            sink = DataSourceUpdateSinkImpl(store, Listeners(), Listeners())
+            config._data_source_update_sink = sink
+            server.for_path('/all', error_then_success)
+
+            with StreamingUpdateProcessor(config, store, ready, None) as sp:
+                sp.start()
+                ready.wait(start_wait)
+                assert sink.environment_id == 'env-from-error'
+
+
 def expect_item(store, kind, item):
     assert store.get(kind, item['key'], lambda x: x) == item
 

--- a/ldclient/testing/impl/datasource/test_streaming.py
+++ b/ldclient/testing/impl/datasource/test_streaming.py
@@ -472,7 +472,7 @@ def test_environment_id_is_none_when_not_provided():
                 assert sink.environment_id is None
 
 
-def test_records_environment_id_from_error_response_headers():
+def test_does_not_record_environment_id_from_error_response_headers():
     store = InMemoryFeatureStore()
     ready = Event()
 
@@ -487,7 +487,7 @@ def test_records_environment_id_from_error_response_headers():
             with StreamingUpdateProcessor(config, store, ready, None) as sp:
                 sp.start()
                 ready.wait(start_wait)
-                assert sink.environment_id == 'env-from-error'
+                assert sink.environment_id is None
 
 
 def expect_item(store, kind, item):

--- a/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
@@ -786,7 +786,7 @@ def test_environment_id_from_initializer_basis():
     fdv2.stop()
 
 
-def test_environment_id_from_initializer_error_headers():
+def test_environment_id_is_not_recorded_from_initializer_error_headers():
     init = _StaticInitializer(
         "failing-initializer",
         _Fail(error="boom", exception=None, headers={_LD_ENVID_HEADER: 'env-from-error'}),
@@ -801,7 +801,7 @@ def test_environment_id_from_initializer_error_headers():
     fdv2.start(set_on_ready)
     assert set_on_ready.wait(1), "Data system did not become ready in time"
 
-    assert fdv2.environment_id == 'env-from-error'
+    assert fdv2.environment_id is None
     fdv2.stop()
 
 
@@ -826,13 +826,13 @@ def test_environment_id_from_synchronizer_update():
     fdv2.stop()
 
 
-def test_environment_id_is_retained_when_updates_omit_it():
+def test_environment_id_is_not_recorded_from_non_valid_updates():
     sync_mock: Synchronizer = Mock()
     sync_mock.name = "envid-sync"
     sync_mock.stop = Mock()
     sync_mock.sync.return_value = iter([
         Update(state=DataSourceState.VALID, environment_id="env-from-sync"),
-        Update(state=DataSourceState.INTERRUPTED),
+        Update(state=DataSourceState.INTERRUPTED, environment_id="env-from-interrupted"),
     ])
 
     fdv2 = FDv2(

--- a/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_datasystem.py
@@ -16,7 +16,12 @@ from ldclient.config import (
 from ldclient.datasystem import file_ds_builder
 from ldclient.impl.datasystem import DataAvailability
 from ldclient.impl.datasystem.fdv2 import FDv2
-from ldclient.impl.util import _LD_FD_FALLBACK_HEADER, _Fail, _Success
+from ldclient.impl.util import (
+    _LD_ENVID_HEADER,
+    _LD_FD_FALLBACK_HEADER,
+    _Fail,
+    _Success
+)
 from ldclient.integrations.test_datav2 import TestDataV2
 from ldclient.interfaces import (
     Basis,
@@ -755,3 +760,89 @@ def test_fdv2_synchronizer_fallback_on_success_with_payload():
     # The Valid update's payload must be applied before the handoff.
     assert payload_flag_seen.wait(1), "FDv2 payload was not applied before fallback"
     assert fdv1_flag_seen.wait(1), "FDv1 fallback synchronizer did not run after directive"
+
+
+def test_environment_id_from_initializer_basis():
+    builder = ChangeSetBuilder()
+    builder.start(IntentCode.TRANSFER_FULL)
+    change_set = builder.finish(Selector(state="initializer-state", version=1))
+    init = _StaticInitializer(
+        "envid-initializer",
+        _Success(value=Basis(change_set=change_set, persist=True, environment_id="env-from-initializer")),
+    )
+
+    fdv2 = FDv2(
+        Config(sdk_key="dummy"),
+        DataSystemConfig(initializers=[_InitializerBuilder(init)], synchronizers=None),
+    )
+
+    assert fdv2.environment_id is None
+
+    set_on_ready = Event()
+    fdv2.start(set_on_ready)
+    assert set_on_ready.wait(1), "Data system did not become ready in time"
+
+    assert fdv2.environment_id == "env-from-initializer"
+    fdv2.stop()
+
+
+def test_environment_id_from_initializer_error_headers():
+    init = _StaticInitializer(
+        "failing-initializer",
+        _Fail(error="boom", exception=None, headers={_LD_ENVID_HEADER: 'env-from-error'}),
+    )
+
+    fdv2 = FDv2(
+        Config(sdk_key="dummy"),
+        DataSystemConfig(initializers=[_InitializerBuilder(init)], synchronizers=None),
+    )
+
+    set_on_ready = Event()
+    fdv2.start(set_on_ready)
+    assert set_on_ready.wait(1), "Data system did not become ready in time"
+
+    assert fdv2.environment_id == 'env-from-error'
+    fdv2.stop()
+
+
+def test_environment_id_from_synchronizer_update():
+    sync_mock: Synchronizer = Mock()
+    sync_mock.name = "envid-sync"
+    sync_mock.stop = Mock()
+    sync_mock.sync.return_value = iter([
+        Update(state=DataSourceState.VALID, environment_id="env-from-sync"),
+    ])
+
+    fdv2 = FDv2(
+        Config(sdk_key="dummy"),
+        DataSystemConfig(initializers=None, synchronizers=[MockDataSourceBuilder(sync_mock)]),
+    )
+
+    set_on_ready = Event()
+    fdv2.start(set_on_ready)
+    assert set_on_ready.wait(1), "Data system did not become ready in time"
+
+    assert fdv2.environment_id == "env-from-sync"
+    fdv2.stop()
+
+
+def test_environment_id_is_retained_when_updates_omit_it():
+    sync_mock: Synchronizer = Mock()
+    sync_mock.name = "envid-sync"
+    sync_mock.stop = Mock()
+    sync_mock.sync.return_value = iter([
+        Update(state=DataSourceState.VALID, environment_id="env-from-sync"),
+        Update(state=DataSourceState.INTERRUPTED),
+    ])
+
+    fdv2 = FDv2(
+        Config(sdk_key="dummy"),
+        DataSystemConfig(initializers=None, synchronizers=[MockDataSourceBuilder(sync_mock)]),
+    )
+
+    set_on_ready = Event()
+    fdv2.start(set_on_ready)
+    assert set_on_ready.wait(1), "Data system did not become ready in time"
+
+    assert fdv2.environment_id == "env-from-sync"
+    fdv2.stop()

--- a/ldclient/testing/stub_util.py
+++ b/ldclient/testing/stub_util.py
@@ -43,16 +43,18 @@ def make_delete_event(kind, key, version):
     return 'event:delete\ndata: %s\n\n' % json.dumps(data)
 
 
-def stream_content(event=None):
-    stream = ChunkedResponse({'Content-Type': 'text/event-stream'})
+def stream_content(event=None, headers=None):
+    stream_headers = {'Content-Type': 'text/event-stream'}
+    stream_headers.update(headers or {})
+    stream = ChunkedResponse(stream_headers)
     if event:
         stream.push(event)
     return stream
 
 
-def poll_content(flags=[], segments=[]):
+def poll_content(flags=[], segments=[], headers=None):
     data = {"flags": make_items_map(flags), "segments": make_items_map(segments)}
-    return JsonResponse(data)
+    return JsonResponse(data, headers)
 
 
 class MockEventProcessor(EventProcessor):

--- a/ldclient/testing/test_ldclient_end_to_end.py
+++ b/ldclient/testing/test_ldclient_end_to_end.py
@@ -5,6 +5,7 @@ import pytest
 
 from ldclient.client import Context, LDClient
 from ldclient.config import Config, HTTPConfig
+from ldclient.hook import EvaluationSeriesContext, Hook, Metadata
 from ldclient.testing.http_util import (
     BasicResponse,
     SequentialHandler,
@@ -165,3 +166,31 @@ def test_can_connect_with_selfsigned_cert_by_setting_ca_certs():
         config = Config(sdk_key='sdk_key', base_uri=server.uri, stream=False, send_events=False, http=HTTPConfig(ca_certs='./ldclient/testing/selfsigned.pem'))
         with LDClient(config=config) as client:
             assert client.is_initialized()
+
+
+def test_hooks_receive_environment_id_in_streaming_mode():
+    contexts = []
+
+    class CapturingHook(Hook):
+        @property
+        def metadata(self) -> Metadata:
+            return Metadata(name='capturing-hook')
+
+        def before_evaluation(self, series_context: EvaluationSeriesContext, data: dict) -> dict:
+            contexts.append(series_context)
+            return data
+
+        def after_evaluation(self, series_context: EvaluationSeriesContext, data: dict, detail) -> dict:
+            return data
+
+    with start_server() as stream_server:
+        with stream_content(make_put_event([always_true_flag]), headers={'X-LD-EnvID': 'env-abc-123'}) as stream_handler:
+            stream_server.for_path('/all', stream_handler)
+            config = Config(sdk_key=sdk_key, stream_uri=stream_server.uri, send_events=False, hooks=[CapturingHook()])
+
+            with LDClient(config=config) as client:
+                assert client.is_initialized()
+                client.variation(always_true_flag['key'], user, False)
+
+                assert len(contexts) == 1
+                assert contexts[0].environment_id == 'env-abc-123'

--- a/ldclient/testing/test_ldclient_hooks.py
+++ b/ldclient/testing/test_ldclient_hooks.py
@@ -176,3 +176,18 @@ def test_migration_evaluation_detail_default_converts_to_off_if_invalid():
     assert len(details) == 1
     assert details[0].value == Stage.OFF.value
     assert details[0].variation_index is None
+
+
+def test_series_context_environment_id_is_none_without_environment_id():
+    contexts = []
+    hook = MockHook(before_evaluation=lambda series_context, data: contexts.append(series_context), after_evaluation=record('after', []))
+
+    td = TestData.data_source()
+    td.update(td.flag('flag-key').variation_for_all(True))
+
+    config = Config('SDK_KEY', update_processor_class=td, send_events=False, hooks=[hook])
+    client = LDClient(config=config)
+    client.variation('flag-key', user, False)
+
+    assert len(contexts) == 1
+    assert contexts[0].environment_id is None


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Implements the `environmentId` field of `EvaluationSeriesContext` from the [hooks spec](https://github.com/launchdarkly/sdk-specs/blob/main/specs/HOOK-hooks/README.md), which the OTel tracing hook uses for `feature_flag.set.id`. Mirrors launchdarkly/dotnet-core#81.

**Describe the solution you've provided**

`EvaluationSeriesContext` gains an optional `environment_id`, populated from the `X-LD-EnvID` response header sent by LaunchDarkly. Both data systems are supported, and each exposes it through a new `DataSystem.environment_id` property that the client reads when building the series context. Per the spec, it is only recorded from successful responses, so hooks never see an environment ID scraped off an error page.

- FDv2 already parsed the header into `Basis.environment_id` / `Update.environment_id` but discarded it; `FDv2` now latches the last value seen on a success path (a `_Success` basis, or an update whose state is `VALID`).
- FDv1 had no access to the header. Streaming reads it from the `Start` action of the SSE client, polling reads it from the response headers, and both record it on `DataSourceUpdateSinkImpl`.

Sketch of the FDv1 path:

```python
# streaming
if isinstance(action, Start):
    record_environment_id(self._data_source_update_sink, action.headers)

# polling
(all_data, headers) = self._get_all_data_with_headers()
record_environment_id(self._data_source_update_sink, headers)
```

**Describe alternatives you've considered**

Following the .NET implementation more literally, where the environment ID is stored as init metadata on the data store, would require optional extension interfaces on the public `FeatureStore`/`DataSourceUpdateSink` types. Instead, header handling stays inside the data sources and is surfaced by the data system, so externally implemented stores, sinks, feature requesters, and update processors continue to work unchanged (they simply report no environment ID).

**Additional context**

- No change is needed in `launchdarkly-eventsource`: it already exposes response headers on `Start` and `Fault` (unlike the .NET event source, which needed launchdarkly/dotnet-eventsource#104).
- The async (experimental) client does not run hooks yet, so the async data source path is untouched.
- The `environmentId` support in the OTel tracing hook lives in `python-server-sdk-otel` and is a follow-up.


Link to Devin session: https://app.devin.ai/sessions/bfe54128e2804a96bb100e6120e9a3ef
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds optional **`environment_id`** on **`EvaluationSeriesContext`** so evaluation hooks (e.g. OTel **`feature_flag.set.id`**) can see which LaunchDarkly environment the SDK is connected to, matching the hooks spec.
> 
> The ID comes from the **`X-LD-EnvID`** header on **successful** data-source responses only—not from error responses. **FDv1** records it via streaming **`Start`** headers and polling response headers into **`DataSourceUpdateSinkImpl`**; **FDv2** latches values already present on successful **`Basis`** / **`VALID`** **`Update`** objects. **`DataSystem.environment_id`** exposes the value and **`LDClient`** passes it when building hook series context.
> 
> Custom **`FeatureRequester`** implementations without **`get_all_data_with_headers`** still work (no env ID). Contract tests add the **`hook-environment-id`** capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce7b6a8efffb8c24d657d16bb2114f26ac11c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->