### PR TITLE
chore: Decode async HTTP transport responses strictly

### DIFF
--- a/ldclient/impl/aio/transport.py
+++ b/ldclient/impl/aio/transport.py
@@ -91,7 +91,7 @@ class AsyncHTTPTransport:
             timeout=timeout,
             proxy=self._proxy or _get_proxy_url(uri),
         ) as response:
-            text = await response.text(encoding='UTF-8', errors='replace')
+            text = await response.text(encoding='UTF-8')
             return TransportResponse(response.status, response.headers, text)
 
     async def close(self) -> None:


### PR DESCRIPTION
## Overview

`AsyncHTTPTransport.request` decoded response bodies with `errors='replace'`, which silently substitutes invalid bytes with the U+FFFD replacement character. That can mask a corrupt or misconfigured response instead of surfacing it.

This decodes strictly (`await response.text(encoding='UTF-8')`), matching the sync SDK's `data.decode('UTF-8')`. A malformed body now raises rather than being silently corrupted. Because `AsyncHTTPTransport` is the centralized async HTTP path, this covers both polling and event delivery.

The two other findings from the transport review — the missing `allow_redirects=False` and the absence of a response body-size cap — were triaged as non-divergences from the sync SDK (the SDK deliberately follows redirects on streaming and polling, and the sync SDK reads bodies unbounded), so they were intentionally left unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Async HTTP transport** now decodes response bodies with strict UTF-8 instead of `errors='replace'`, so invalid bytes raise rather than being silently replaced with U+FFFD.
> 
> This aligns `AsyncHTTPTransport.request` with the sync SDK’s `data.decode('UTF-8')` behavior and affects all async HTTP callers that use this centralized path (polling and event delivery).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b76d172b81b3a2b78f89d23b7c9132ebdf95c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->