### PR TITLE
chore: Track the latest v3 contract test release instead of a pinned alpha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           test_service_port: 9000
           token: ${{ secrets.GITHUB_TOKEN }}
-          version: v3.0.0-alpha.6
+          version: v3
           enable_persistence_tests: "true"
 
   windows:


### PR DESCRIPTION
## What

Change the FDv2 contract test job from `version: v3.0.0-alpha.6` to `version: v3`.

## Why

The pin means every `sdk-test-harness` release needs a manual bump in this repo. It went stale: `v3.0.0-alpha.6` shipped 2026-04-29, so this job has been skipping every v3.1.x and v3.2.x test since.

The harness downloader already handles this. `downloader/run.sh` resolves a partial version by querying the Releases API, filtering `tag_name` on the prefix, and taking the newest match. That endpoint includes prereleases, so partials land on alphas:

| `VERSION` | resolves to (checked 2026-08-14) |
| --- | --- |
| `v2` | `v2.39.0` |
| `v3` | `v3.2.0-alpha.7` |

This is not new ground. The FDv1 job in this repo already floats on the action default of `version: v2` and has never pinned a patch. `js-core` floats `v3` for `server-node`, `browser`, `vue`, and `node-client` today, through the same `launchdarkly/gh-actions/actions/contract-tests@contract-tests-v1` action and the same downloader path.

## Notes

The `branch` input is deliberately left alone. `origin/v2:downloader/run.sh` and `origin/v3:downloader/run.sh` are the same blob (`df4fe4b`), so setting `branch: v3` would change nothing.

This jumps from an April harness build to current, so CI on this PR is the real verification. If new test cases fail, the follow-up is a `--skip-from` suppression file rather than restoring the pin.

SDK-2922

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Updates the Linux CI **Run contract tests v3** step so `launchdarkly/gh-actions/actions/contract-tests` uses **`version: v3`** instead of the pinned **`v3.0.0-alpha.6`**.
> 
> That aligns the FDv2 job with the existing v2 contract-test job (unpinned major) and lets the harness downloader pick the newest matching v3 release, avoiding manual bumps when `sdk-test-harness` ships new v3.x builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569a68782af0be5e8bbad14a4cbebc24624d84ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->