### PR TITLE
test: Add failing tests for LDClient.close() releasing all components

### DIFF
--- a/ldclient/testing/test_ldclient_shutdown.py
+++ b/ldclient/testing/test_ldclient_shutdown.py
@@ -1,0 +1,142 @@
+"""
+Tests for the shutdown contract of LDClient.close().
+
+close() is documented as "Releases all threads and network connections used by the LaunchDarkly
+client". These tests pin that contract. They are currently marked xfail because the SDK does not
+yet honour it; each one describes a specific way the contract is broken.
+"""
+
+import time
+
+import pytest
+
+from ldclient.client import Config, LDClient
+from ldclient.config import BigSegmentsConfig
+from ldclient.interfaces import (
+    BigSegmentStore,
+    BigSegmentStoreMetadata,
+    EventProcessor,
+    UpdateProcessor
+)
+
+unreachable_uri = "http://fake"
+
+
+class RecordingBigSegmentStore(BigSegmentStore):
+    """A user-supplied big segment store, of the kind an application would provide."""
+
+    def __init__(self, log: list):
+        self._log = log
+
+    def get_metadata(self) -> BigSegmentStoreMetadata:
+        return BigSegmentStoreMetadata(int(time.time() * 1000))
+
+    def get_membership(self, user_hash: str):
+        return None
+
+    def stop(self):
+        self._log.append('big_segment_store')
+
+
+class RecordingUpdateProcessor(UpdateProcessor):
+    def __init__(self, log: list):
+        self._log = log
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self._log.append('update_processor')
+
+    def initialized(self):
+        return True
+
+
+class FailingEventProcessor(EventProcessor):
+    """
+    Stands in for any component whose stop() raises. This is not far-fetched: close() reaches
+    third-party code in two places - the eventsource client, and the application's own
+    BigSegmentStore implementation.
+    """
+
+    def start(self):
+        pass
+
+    def stop(self):
+        raise Exception("deliberate error from a component's stop()")
+
+    def send_event(self, event):
+        pass
+
+    def flush(self):
+        pass
+
+
+def make_client(stop_log: list, event_processor_class=None) -> LDClient:
+    config = Config(
+        sdk_key='SDK_KEY',
+        base_uri=unreachable_uri,
+        events_uri=unreachable_uri,
+        stream_uri=unreachable_uri,
+        event_processor_class=event_processor_class or (lambda config: FailingEventProcessor()),
+        update_processor_class=lambda config, store, ready: RecordingUpdateProcessor(stop_log),
+        big_segments=BigSegmentsConfig(store=RecordingBigSegmentStore(stop_log)),
+    )
+    return LDClient(config=config, start_wait=0)
+
+
+@pytest.mark.xfail(strict=True, reason="close() has no error handling, so a failure in one component orphans the rest")
+def test_close_releases_every_component_even_if_one_raises():
+    """
+    INVARIANT: close() releases all of the client's resources. A component that fails to shut
+    down cleanly must not prevent the remaining components from being released.
+
+    close() calls the event processor, the data system and the big segment store manager in
+    sequence with no error handling, so an exception from the first abandons the other two.
+    Two of the three reach code the SDK does not control - the eventsource client and the
+    application's own BigSegmentStore - so a raise here is a realistic scenario, not a contrived
+    one. The result is leaked threads and connections from a client the caller believes is closed.
+    """
+    stop_log: list = []
+    client = make_client(stop_log)
+
+    try:
+        client.close()
+    except Exception:
+        pass  # whether close() propagates is a separate question; the leak is the bug
+
+    assert 'update_processor' in stop_log, "the data system was never stopped"
+    assert 'big_segment_store' in stop_log, "the big segment store was never stopped"
+
+
+@pytest.mark.xfail(strict=True, reason="close() has no closed-flag, so it re-runs shutdown on every call")
+def test_close_is_idempotent():
+    """
+    INVARIANT: closing an already-closed client has no further effect.
+
+    LDClient has no closed-flag, so a second close() runs the whole sequence again. That calls
+    stop() a second time on the application's own BigSegmentStore, and on FDv2 calls
+    store.close() twice. Double-close is easy to reach by accident - an explicit close() inside
+    a `with` block does it, as does any cleanup path that runs more than once.
+    """
+    stop_log: list = []
+
+    class NoopEventProcessor(EventProcessor):
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def send_event(self, event):
+            pass
+
+        def flush(self):
+            pass
+
+    client = make_client(stop_log, event_processor_class=lambda config: NoopEventProcessor())
+
+    client.close()
+    client.close()
+
+    assert stop_log.count('big_segment_store') == 1, "the big segment store was stopped more than once"


### PR DESCRIPTION
Failing tests for #495. **Tests only — no fix.**

Found while investigating #493, a production incident where `LDClient.close()` hung and left worker pods alive for hours to days, each holding a concurrency slot. Auditing the shutdown path afterwards turned up two further defects in `close()` itself. I have not observed these two in our own production, but both reproduce reliably.

## What the tests pin

`close()` is documented as "Releases all threads and network connections used by the LaunchDarkly client". Two ways it does not:

**`test_close_releases_every_component_even_if_one_raises`** — `client.py:355-358` calls the event processor, data system and big segment store manager in sequence with no error handling. If the first raises, the other two are never stopped. Two of the three reach code the SDK does not control: the eventsource client, and the application's own `BigSegmentStore` implementation. The caller is left with leaked threads and connections from a client it believes is closed.

**`test_close_is_idempotent`** — there is no closed-flag, so a second `close()` re-runs the whole sequence. The recorded shutdown log is `['update_processor', 'big_segment_store', 'update_processor', 'big_segment_store']` — the application's own store is stopped twice, and under FDv2 `store.close()` is called twice.

## Why xfail

Both are marked `@pytest.mark.xfail(strict=True)` so CI stays green while the defect is documented in the suite. Because it is `strict`, the moment the behaviour is fixed these turn into failures telling you to drop the marker.

To see the actual failures:

```
uv run pytest ldclient/testing/test_ldclient_shutdown.py --runxfail
```

## Why no fix

Whether `close()` should still raise after releasing everything is a semantics decision for the SDK team, so the tests pin the leak rather than the exception behaviour. Happy to add the fix if you tell me which way you want it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`ldclient/testing/test_ldclient_shutdown.py`** — contract tests for sync **`LDClient.close()`** with **no production code changes**. Both cases are **`@pytest.mark.xfail(strict=True)`** so CI stays green until a fix lands.
> 
> **`test_close_releases_every_component_even_if_one_raises`** documents that **`client.py`** stops the event processor, data system, and big-segment manager in sequence with no error handling; if **`stop()`** on the first raises (e.g. eventsource or user **`BigSegmentStore`**), the others never run.
> 
> **`test_close_is_idempotent`** documents that without a closed flag, a second **`close()`** runs shutdown again (e.g. double **`stop()`** on the app’s big-segment store).
> 
> Uses injectable **`Recording*`** / **`FailingEventProcessor`** helpers and unreachable URIs so tests don’t need network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10751c1d65bfb0978f66f7b14ab190887d5ce03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->