### PR TITLE
test: Add failing test for set_config() blocking concurrent get()

### DIFF
--- a/ldclient/testing/test_ldclient_singleton.py
+++ b/ldclient/testing/test_ldclient_singleton.py
@@ -1,7 +1,12 @@
 import json
+import threading
+import time
+
+import pytest
 
 import ldclient
 from ldclient import _reset_client
+from ldclient.client import LDClient
 from ldclient.config import Config
 from ldclient.testing.http_util import BasicResponse, start_server
 from ldclient.testing.stub_util import make_put_event, stream_content
@@ -73,3 +78,53 @@ def test_set_config():
                 assert r.headers['Authorization'] == sdk_key
             finally:
                 _reset_client()
+
+
+@pytest.mark.xfail(strict=True, reason="set_config() holds the global write lock across the old client's close()")
+def test_set_config_does_not_block_concurrent_get():
+    """
+    INVARIANT: reconfiguring the shared client does not stall unrelated threads that are only
+    reading it. ldclient.get() is on the hot path of every flag evaluation in an application.
+
+    set_config() holds the global write lock (ldclient/__init__.py) across both the construction
+    of the replacement client and old_client.close(). ReadWriteLock.lock() holds the underlying
+    mutex for its whole duration, so every concurrent ldclient.get() - which takes a read lock -
+    blocks until both of those finish.
+
+    That couples a network-dependent shutdown to a lock every evaluating thread needs. A close()
+    that stalls stalls the entire application, not just the thread that called set_config().
+    """
+    _reset_client()
+    close_duration = 3.0
+    real_close = LDClient.close
+
+    def slow_close(self):
+        time.sleep(close_duration)
+        real_close(self)
+
+    try:
+        ldclient.set_config(Config(sdk_key, offline=True))
+        ldclient.get()
+
+        LDClient.close = slow_close  # type: ignore[method-assign]
+
+        reconfiguring = threading.Event()
+
+        def reconfigure():
+            reconfiguring.set()
+            ldclient.set_config(Config(sdk_key, offline=True))
+
+        threading.Thread(target=reconfigure, name='reconfigure', daemon=True).start()
+        assert reconfiguring.wait(5)
+        time.sleep(0.2)  # let set_config get inside the write lock
+
+        started = time.time()
+        ldclient.get()
+        blocked_for = time.time() - started
+
+        assert blocked_for < close_duration / 2, (
+            "ldclient.get() blocked for %.1fs while set_config() was closing the previous client" % blocked_for
+        )
+    finally:
+        LDClient.close = real_close  # type: ignore[method-assign]
+        _reset_client()


### PR DESCRIPTION
Failing test for #496. **Test only — no fix.**

Found while investigating #493, a production incident where `LDClient.close()` hung and left worker pods alive for hours to days. This issue is what makes that class of hang so damaging under the singleton API. I have not observed this specific path in our own production — we do not call `set_config()` after startup — but the coupling is real and reproduces reliably.

## What the test pins

`set_config()` holds the global write lock across both the construction of the replacement client and `old_client.close()` (`ldclient/__init__.py:38-47`). `ReadWriteLock.lock()` holds the underlying mutex for the whole write section and `rlock()` needs that same mutex, so every concurrent `ldclient.get()` blocks — and `get()` is on the hot path of every flag evaluation in an application using the singleton API.

`test_set_config_does_not_block_concurrent_get` drives a 3 second `close()` and measures a concurrent `get()`:

```
AssertionError: ldclient.get() blocked for 2.8s while set_config() was closing the previous client
```

Before a shutdown timeout existed, an unbounded `close()` here would block every `get()` in the process indefinitely. Even bounded, the window is `start_wait` (default 5s) plus the shutdown timeout, so a reconfigure can stall all evaluating threads for roughly ten seconds.

## Why xfail

Marked `@pytest.mark.xfail(strict=True)` so CI stays green while the defect is documented; being strict, it fails loudly once fixed so the marker gets removed. To see the real failure:

```
uv run pytest ldclient/testing/test_ldclient_singleton.py -k set_config_does_not_block --runxfail
```

## Why no fix

Moving construction and `close()` outside the lock is the obvious direction, but doing it without introducing a lost-update race between concurrent `set_config()` callers is a design decision I would rather leave with you.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Test-only change** for issue #496: documents a singleton API defect where **`set_config()` keeps the global write lock** while it builds the replacement client and runs **`old_client.close()`**, so concurrent **`ldclient.get()`** (read lock) stalls on the same mutex.
> 
> Adds **`test_set_config_does_not_block_concurrent_get`**, which patches **`LDClient.close`** to sleep 3s during reconfigure and asserts a concurrent **`get()`** finishes in under half that time. The test **fails today** (~2.8s block) and is marked **`@pytest.mark.xfail(strict=True)`** so CI stays green until a fix lands.
> 
> No library changes; the PR pins the invariant that reconfigure should not couple slow shutdown to the flag-evaluation hot path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3e2722eedbc552712def2a7429f10dd03c17f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->