### PR TITLE
feat: Add Config.with_wrapper_information

### DIFF
--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -4,6 +4,7 @@ This submodule contains the :class:`Config` class for custom configuration of th
 Note that the same class can also be imported from the ``ldclient.client`` submodule.
 """
 
+import copy
 import warnings
 from dataclasses import dataclass
 from threading import Event
@@ -471,6 +472,21 @@ class Config(DataSourceBuilderConfig, PrivateAttributesConfig):
             http=self.__http,
             big_segments=self.__big_segments,
         )
+
+    def with_wrapper_information(self, wrapper_name: Optional[str], wrapper_version: Optional[str] = None) -> 'Config':
+        """Returns a new ``Config`` instance that is the same as this one, except for having different wrapper information.
+
+        This is intended for use by wrapper libraries, such as the LaunchDarkly OpenFeature providers, which need to
+        identify themselves rather than the application that configured the client.
+
+        :param wrapper_name: an identifying name for the wrapper being used; see :py:attr:`~wrapper_name`
+        :param wrapper_version: the version of the wrapper being used; see :py:attr:`~wrapper_version`
+        """
+        updated = copy.copy(self)
+        updated.__wrapper_name = wrapper_name
+        updated.__wrapper_version = wrapper_version
+
+        return updated
 
     # for internal use only - probably should be part of the client logic
     def get_default(self, key, default):

--- a/ldclient/config.py
+++ b/ldclient/config.py
@@ -479,6 +479,10 @@ class Config(DataSourceBuilderConfig, PrivateAttributesConfig):
         This is intended for use by wrapper libraries, such as the LaunchDarkly OpenFeature providers, which need to
         identify themselves rather than the application that configured the client.
 
+        The new instance is a shallow copy: it shares the objects the original configuration references, such as the
+        feature store, the logger, and the HTTP configuration. Mutating one of those objects affects both
+        configurations.
+
         :param wrapper_name: an identifying name for the wrapper being used; see :py:attr:`~wrapper_name`
         :param wrapper_version: the version of the wrapper being used; see :py:attr:`~wrapper_version`
         """

--- a/ldclient/testing/test_config.py
+++ b/ldclient/testing/test_config.py
@@ -17,6 +17,27 @@ def test_copy_config():
     assert new_config.stream is False
 
 
+def test_with_wrapper_information():
+    config = Config(sdk_key="SDK_KEY", stream=False, wrapper_name="original", wrapper_version="1.0.0")
+
+    wrapped = config.with_wrapper_information("wrapper", "2.0.0")
+    assert wrapped.wrapper_name == "wrapper"
+    assert wrapped.wrapper_version == "2.0.0"
+    assert wrapped.sdk_key == "SDK_KEY"
+    assert wrapped.stream is False
+
+    assert config.wrapper_name == "original"
+    assert config.wrapper_version == "1.0.0"
+
+
+def test_with_wrapper_information_defaults_the_version():
+    config = Config(sdk_key="SDK_KEY", wrapper_name="original", wrapper_version="1.0.0")
+
+    wrapped = config.with_wrapper_information("wrapper")
+    assert wrapped.wrapper_name == "wrapper"
+    assert wrapped.wrapper_version is None
+
+
 def test_can_set_valid_poll_interval():
     config = Config(sdk_key="SDK_KEY", poll_interval=31)
     assert config.poll_interval == 31


### PR DESCRIPTION
Adds `Config.with_wrapper_information`, so wrapper libraries can derive a config that identifies themselves without reaching into `Config` internals.

- New public method returning a copy of the config with `wrapper_name`/`wrapper_version` replaced
- The original config is left unmodified
- Mirrors `Configuration.Builder(config).WrapperInfo(...)` in .NET and `LDConfig.Builder.fromConfig(config).wrapper(...)` in Java

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

<details>
<summary>Implementation details</summary>

**Related issues**

Needed by [openfeature-python-server#51](https://github.com/launchdarkly/openfeature-python-server/pull/51), where the OpenFeature provider must report itself as the wrapper. Wrapper information can only be supplied to the `Config` constructor today, so a provider that accepts an application-supplied `Config` has no supported way to add it. The .NET and Java providers do this through their SDK's builder-from-config API; Python has no equivalent.

`copy_with_new_sdk_key` is the closest existing method, but it is deprecated and rebuilds the config by hand, so it silently drops anything added since it was written (`application`, `hooks`, `plugins`, `datasystem_config`, and others).

**Describe the solution you've provided**

```python
def with_wrapper_information(self, wrapper_name, wrapper_version=None) -> 'Config':
    updated = copy.copy(self)
    updated.__wrapper_name = wrapper_name
    updated.__wrapper_version = wrapper_version

    return updated
```

Shallow-copying avoids the maintenance hazard of re-listing every constructor parameter: fields added later are carried over automatically. Component references (feature store, hooks, plugins) are shared with the original config, which matches how a config is used — the derived config is what gets handed to `LDClient`, and the original is not used to build a second client.

**Describe alternatives you've considered**

- A general `copy_with(**kwargs)`: broader surface area than needed, and re-exposes the constructor's parameter list to the same drift problem.
- A `Config.Builder`-style API matching .NET/Java: a much larger change to a long-standing public API, and not required to unblock the providers.
- Letting wrappers keep assigning the name-mangled private fields: works, but depends on implementation details of the SDK.

**Testing**

`test_with_wrapper_information` covers replacing both fields while leaving unrelated settings and the original config intact; `test_with_wrapper_information_defaults_the_version` covers omitting the version.

</details>


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds `Config.with_wrapper_information` so wrapper libraries (e.g. OpenFeature providers) can stamp `wrapper_name` / `wrapper_version` onto an application-supplied config without reconstructing it or touching private fields.
> 
> The method shallow-copies the existing `Config`, replaces those two fields, and leaves the original instance unchanged. Shared objects such as the feature store and HTTP config are not cloned. Tests cover replacement of both fields and omitting the version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db02bf317f4aa1ffd633a928f5386e04f5e2322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->