### PR TITLE
fix: Allow tombstones without a key property

### DIFF
--- a/ldclient/impl/integrations/consul/consul_feature_store.py
+++ b/ldclient/impl/integrations/consul/consul_feature_store.py
@@ -86,10 +86,16 @@ class _ConsulFeatureStoreCore(DiagnosticDescription, FeatureStoreCore):
 
     def get_all_internal(self, kind):
         items_out = {}
+        # Use the key that each item is stored under, not the key inside the item. A deleted
+        # item (a "tombstone") is not guaranteed to have a key of its own.
+        item_key_prefix = self._kind_key(kind) + '/'
         index, results = self._client.kv.get(self._kind_key(kind), recurse=True)
         for result in results:
+            db_key = result['Key']
+            if not db_key.startswith(item_key_prefix):
+                continue
             item = json.loads(result['Value'].decode('utf-8'))
-            items_out[item['key']] = item
+            items_out[db_key[len(item_key_prefix):]] = item
         return items_out
 
     def upsert_internal(self, kind, new_item):

--- a/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
+++ b/ldclient/impl/integrations/dynamodb/dynamodb_feature_store.py
@@ -99,7 +99,9 @@ class _DynamoDBFeatureStoreCore(FeatureStoreCore):
         for resp in paginator.paginate(**self._make_query_for_kind(kind)):
             for item in resp['Items']:
                 item_out = self._unmarshal_item(item)
-                items_out[item_out['key']] = item_out
+                # Use the sort key that each item is stored under, not the key inside the item.
+                # A deleted item (a "tombstone") is not guaranteed to have a key of its own.
+                items_out[item[self.SORT_KEY]['S']] = item_out
         return items_out
 
     def upsert_internal(self, kind, item):

--- a/ldclient/impl/model/feature_flag.py
+++ b/ldclient/impl/model/feature_flag.py
@@ -104,11 +104,13 @@ class FeatureFlag(ModelEntity):
         # be absent even if they are really required in the schema. That's for backward compatibility
         # with test logic that constructed incomplete JSON, and also with the file data source which
         # previously allowed users to get away with leaving out a lot of properties in the JSON.
-        self._key = req_str(data, 'key')
         self._version = req_int(data, 'version')
         self._deleted = opt_bool(data, 'deleted')
         if self._deleted:
+            # Tombstones are not guaranteed to have a key.
+            self._key = opt_str(data, 'key') or ''
             return
+        self._key = req_str(data, 'key')
         self._variations = opt_list(data, 'variations')
         self._on = opt_bool(data, 'on')
         self._off_variation = opt_int(data, 'offVariation')

--- a/ldclient/impl/model/segment.py
+++ b/ldclient/impl/model/segment.py
@@ -73,11 +73,13 @@ class Segment(ModelEntity):
         # be absent even if they are really required in the schema. That's for backward compatibility
         # with test logic that constructed incomplete JSON, and also with the file data source which
         # previously allowed users to get away with leaving out a lot of properties in the JSON.
-        self._key = req_str(data, 'key')
         self._version = req_int(data, 'version')
         self._deleted = opt_bool(data, 'deleted')
         if self._deleted:
+            # Tombstones are not guaranteed to have a key.
+            self._key = opt_str(data, 'key') or ''
             return
+        self._key = req_str(data, 'key')
         self._included = set(opt_str_list(data, 'included'))
         self._excluded = set(opt_str_list(data, 'excluded'))
         self._included_contexts = list(SegmentTarget(item) for item in opt_dict_list(data, 'includedContexts'))

--- a/ldclient/testing/impl/test_model_decode.py
+++ b/ldclient/testing/impl/test_model_decode.py
@@ -5,6 +5,7 @@ from semver import VersionInfo
 
 from ldclient.impl.model import *
 from ldclient.testing.builders import *
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 
 def test_flag_targets_are_stored_as_sets():
@@ -41,3 +42,38 @@ def test_clause_values_preprocessed_with_time_operator(op):
     flag = make_boolean_flag_with_clauses(make_clause(None, "attr", op, 1000, "1970-01-01T00:00:02Z", True))
     assert flag.rules[0].clauses[0]._values == [1000, "1970-01-01T00:00:02Z", True]
     assert list(x.as_time for x in flag.rules[0].clauses[0]._values_preprocessed) == [1000, 2000, None]
+
+
+@pytest.mark.parametrize('kind', [FEATURES, SEGMENTS])
+def test_tombstone_without_key_can_be_decoded(kind):
+    # Other LaunchDarkly SDKs write deleted items to a persistent store with only the version,
+    # so we must be able to read them back.
+    item = kind.decode({"version": 5, "deleted": True})
+    assert item.version == 5
+    assert item.deleted is True
+    assert item.key == ''
+    # The original data must round-trip unchanged, because the store re-serializes it.
+    assert item.to_json_dict() == {"version": 5, "deleted": True}
+
+
+@pytest.mark.parametrize('kind', [FEATURES, SEGMENTS])
+def test_tombstone_with_placeholder_key_can_be_decoded(kind):
+    # The Go SDK and the Relay Proxy write deleted items with a placeholder key.
+    item = kind.decode({"key": "$deleted", "version": 5, "deleted": True})
+    assert item.version == 5
+    assert item.deleted is True
+    assert item.key == '$deleted'
+
+
+@pytest.mark.parametrize('kind', [FEATURES, SEGMENTS])
+def test_tombstone_still_requires_version(kind):
+    with pytest.raises(ValueError):
+        kind.decode({"deleted": True})
+
+
+@pytest.mark.parametrize('kind', [FEATURES, SEGMENTS])
+def test_item_that_is_not_deleted_still_requires_key(kind):
+    with pytest.raises(ValueError):
+        kind.decode({"version": 5})
+    with pytest.raises(ValueError):
+        kind.decode({"version": 5, "deleted": False})

--- a/ldclient/testing/integrations/persistent_feature_store_test_base.py
+++ b/ldclient/testing/integrations/persistent_feature_store_test_base.py
@@ -40,6 +40,18 @@ class PersistentFeatureStoreTester(FeatureStoreTester):
         """
         pass
 
+    @abstractmethod
+    def write_raw_item(self, prefix: str, kind, key: str, item: dict):
+        """
+        Override this method to write an item straight to the database, with no help from the
+        store. This lets a test set up data in a shape that the store itself does not write.
+        :param prefix: the prefix parameter for the store constructor - may be None or empty to use the default
+        :param kind: the kind of data, such as FEATURES
+        :param key: the key to store the item under
+        :param item: the item, to be stored as JSON
+        """
+        pass
+
     def create_feature_store(self) -> FeatureStore:
         return self.create_persistent_feature_store(self.prefix, self.caching)
 
@@ -62,6 +74,16 @@ class PersistentFeatureStoreTestBase(FeatureStoreTestBase):
     @pytest.fixture(autouse=True)
     def clear_data_before_each(self, tester):
         tester.clear_data(tester.prefix)
+
+    def test_all_reads_tombstone_with_no_key(self, tester):
+        # Other LaunchDarkly SDKs write a deleted item with only a version, and no key of its
+        # own. The store must read these back with the key that the item is stored under.
+        with self.inited_store(tester) as store:
+            tester.write_raw_item(tester.prefix, FEATURES, 'deleted-flag', {'version': 5, 'deleted': True})
+
+            items = store.all(FEATURES, lambda x: x)
+            assert items == {'foo': self.make_feature('foo', 10), 'bar': self.make_feature('bar', 10)}
+            assert store.get(FEATURES, 'deleted-flag', lambda x: x) is None
 
     def test_stores_with_different_prefixes_are_independent(self):
         # This verifies that init(), get(), all(), and upsert() are all correctly using the specified key prefix.

--- a/ldclient/testing/integrations/test_consul.py
+++ b/ldclient/testing/integrations/test_consul.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from ldclient.integrations import Consul
@@ -38,6 +40,11 @@ class ConsulFeatureStoreTester(PersistentFeatureStoreTester):
         index, keys = client.kv.get((prefix or Consul.DEFAULT_PREFIX) + "/", recurse=True, keys=True)
         for key in keys or []:
             client.kv.delete(key)
+
+    def write_raw_item(self, prefix, kind, key, item):
+        client = consul.Consul()
+        db_key = "%s/%s/%s" % (prefix or Consul.DEFAULT_PREFIX, kind.namespace, key)
+        client.kv.put(db_key, json.dumps(item))
 
 
 class TestConsulFeatureStore(PersistentFeatureStoreTestBase):

--- a/ldclient/testing/integrations/test_dynamodb.py
+++ b/ldclient/testing/integrations/test_dynamodb.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 from ldclient.impl.integrations.dynamodb.dynamodb_big_segment_store import (
@@ -105,6 +106,19 @@ class DynamoDBFeatureStoreTester(PersistentFeatureStoreTester):
 
     def clear_data(self, prefix):
         DynamoDBTestHelper.clear_data_for_prefix(prefix)
+
+    def write_raw_item(self, prefix, kind, key, item):
+        client = DynamoDBTestHelper.make_client()
+        namespace = (prefix + ":" if prefix else "") + kind.namespace
+        client.put_item(
+            TableName=DynamoDBTestHelper.table_name,
+            Item={
+                _DynamoDBFeatureStoreCore.PARTITION_KEY: {'S': namespace},
+                _DynamoDBFeatureStoreCore.SORT_KEY: {'S': key},
+                _DynamoDBFeatureStoreCore.VERSION_ATTRIBUTE: {'N': str(item['version'])},
+                _DynamoDBFeatureStoreCore.ITEM_JSON_ATTRIBUTE: {'S': json.dumps(item)},
+            },
+        )
 
 
 class DynamoDBBigSegmentTester(BigSegmentStoreTester):

--- a/ldclient/testing/integrations/test_redis.py
+++ b/ldclient/testing/integrations/test_redis.py
@@ -54,6 +54,11 @@ class RedisFeatureStoreTester(PersistentFeatureStoreTester):
     def clear_data(self, prefix):
         RedisTestHelper.clear_data_for_prefix(prefix or Redis.DEFAULT_PREFIX)
 
+    def write_raw_item(self, prefix, kind, key, item):
+        r = RedisTestHelper.make_client()
+        items_key = "%s:%s" % (prefix or Redis.DEFAULT_PREFIX, kind.namespace)
+        r.hset(items_key, key, json.dumps(item))
+
 
 class RedisBigSegmentStoreTester(BigSegmentStoreTester):
     def create_big_segment_store(self, prefix) -> BigSegmentStore:

--- a/ldclient/testing/test_async_feature_store_helpers.py
+++ b/ldclient/testing/test_async_feature_store_helpers.py
@@ -4,7 +4,7 @@ import pytest
 
 from ldclient.async_feature_store_helpers import AsyncCachingStoreWrapper
 from ldclient.feature_store import CacheConfig
-from ldclient.versioned_data_kind import VersionedDataKind
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS, VersionedDataKind
 
 # These tests exercise the caching-wrapper logic only, using an in-memory mock core, so they run
 # without a Redis instance. They mirror ldclient.testing.test_feature_store_helpers for the sync
@@ -204,6 +204,21 @@ class TestAsyncCachingStoreWrapper:
         core.force_set(THINGS, item1)
         core.force_set(THINGS, item2)
         assert await wrapper.all(THINGS) == {item1["key"]: item1}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", [FEATURES, SEGMENTS])
+    @pytest.mark.parametrize("cached", [False, True])
+    async def test_get_all_tolerates_tombstone_with_no_key(self, cached, kind):
+        # Other LaunchDarkly SDKs write deleted items to a persistent store with only the
+        # version. The store knows the key, because it is the key the item is stored under.
+        core = MockAsyncCore()
+        wrapper = make_wrapper(core, cached)
+        live_item = {"key": "item1", "version": 1}
+        tombstone = {"version": 2, "deleted": True}
+        core.data[kind] = {"item1": live_item, "item2": tombstone}
+
+        assert await wrapper.all(kind) == {"item1": kind.decode(live_item)}
+        assert await wrapper.get(kind, "item2") is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cached", [False, True])

--- a/ldclient/testing/test_feature_store_helpers.py
+++ b/ldclient/testing/test_feature_store_helpers.py
@@ -5,7 +5,7 @@ import pytest
 
 from ldclient.feature_store import CacheConfig
 from ldclient.feature_store_helpers import CachingStoreWrapper
-from ldclient.versioned_data_kind import VersionedDataKind
+from ldclient.versioned_data_kind import FEATURES, SEGMENTS, VersionedDataKind
 
 THINGS = VersionedDataKind(namespace="things", request_api_path="", stream_api_path="")
 WRONG_THINGS = VersionedDataKind(namespace="wrong", request_api_path="", stream_api_path="")
@@ -188,6 +188,20 @@ class TestCachingStoreWrapper:
         core.force_set(THINGS, item1)
         core.force_set(THINGS, item2)
         assert wrapper.all(THINGS) == {item1["key"]: item1}
+
+    @pytest.mark.parametrize("kind", [FEATURES, SEGMENTS])
+    @pytest.mark.parametrize("cached", [False, True])
+    def test_get_all_tolerates_tombstone_with_no_key(self, cached, kind):
+        # Other LaunchDarkly SDKs write deleted items to a persistent store with only the
+        # version. The store knows the key, because it is the key the item is stored under.
+        core = MockCore()
+        wrapper = make_wrapper(core, cached)
+        live_item = {"key": "item1", "version": 1}
+        tombstone = {"version": 2, "deleted": True}
+        core.data[kind] = {"item1": live_item, "item2": tombstone}
+
+        assert wrapper.all(kind) == {"item1": kind.decode(live_item)}
+        assert wrapper.get(kind, "item2") is None
 
     @pytest.mark.parametrize("cached", [False, True])
     def test_get_all_changes_None_to_empty_dict(self, cached):


### PR DESCRIPTION
## Symptom

A customer running the Python SDK and the Node server SDK against one shared Redis store saw `all_flags_state()` start returning `FeatureFlagsState(valid=False)` with zero flags — the first time any flag was deleted, and for every subsequent read. Individual `variation()` calls kept working; only the all-flags read broke.

## Root cause

`FeatureFlag.__init__` (`ldclient/impl/model/feature_flag.py:107`) and `Segment.__init__` (`ldclient/impl/model/segment.py:76`) validated the required `key` property *before* the deleted-item early-out:

```python
self._key = req_str(data, 'key')      # runs first
self._version = req_int(data, 'version')
self._deleted = opt_bool(data, 'deleted')
if self._deleted:
    return                             # tombstone exemption started here
```

A persisted tombstone with no inner `key` therefore raised `ValueError: error in flag/segment data: required property "key" is missing`.

`CachingStoreWrapper._cache_put_all` (`ldclient/feature_store_helpers.py:130-138`) decodes every item in the set with no per-item error handling, so **one** such record fails the entire all-flags read, and `all_flags_state()` returns an invalid state with no flags (`ldclient/client.py:629-635`).

## Cross-SDK context

Keyless tombstones are the norm, not a corruption:

- The Node server SDK's Redis store writes deleted items as `{"version":N,"deleted":true}` with no key (`js-core`, `packages/store/node-server-sdk-redis/src/RedisCore.ts:163-168`). .NET and Java do the same.
- Haskell and C++ short-circuit on `deleted` before validating the key. .NET's guard is literally `if (key is null && !deleted)`.
- Go and the Relay Proxy write a placeholder key (`$deleted`), which already decoded fine here.

Python was the only SDK that required the inner key on a tombstone. The key is redundant in a persistent store anyway: the store already knows it, because it *is* the Redis hash field the item is stored under.

## Fix

The `key` requirement now applies only to items that are not deleted. A tombstone:

- still requires `version`;
- still validates `key`'s *type* if one is present, so the Go/Relay shape keeps working;
- sets `.key` to an empty string when no key is present, so callers reading `.key` never hit an `AttributeError` (`__slots__` is declared on these classes).

The `version` check moves above the deleted branch so it stays a single check. One knock-on: a live record missing *both* `key` and `version` now reports `version` as the missing property instead of `key`. Both are still required, only the property named in the error changes, and no test asserted the old wording.

No key is synthesized into the stored dict. `ModelEntity.to_json_dict()` returns `self._data` and the FDv2 `Store.commit()` path depends on that, so the original data still round-trips verbatim — a test asserts this.

## Tests

- `ldclient/testing/impl/test_model_decode.py` — for both `FEATURES` and `SEGMENTS`: a keyless tombstone decodes and round-trips unchanged; the Go/Relay `$deleted` shape decodes (regression guard); a tombstone still requires `version`; a live record with no key still raises `ValueError`, including the explicit `"deleted": False` case.
- `ldclient/testing/test_feature_store_helpers.py` and `test_async_feature_store_helpers.py` — a wrapper whose core holds a valid flag plus a keyless tombstone returns the valid flag from `all()` without raising, the tombstone is filtered out, and `get()` on it returns `None`.

No existing test asserted the old strictness for tombstones, so nothing had to be updated. `make test` (1434 passed, 276 skipped) and `make lint` both pass.

## Out of scope

Deliberately kept small and single-purpose. These are tracked separately and are **not** in this PR:

- per-item error isolation in `_cache_put_all`, so one bad record cannot fail a whole set;
- validate-before-write reordering;
- `json.loads` guards in the store cores;
- the store-outage misclassification fix.

## Related

- [SDK-2941](https://launchdarkly.atlassian.net/browse/SDK-2941)
- Customer escalation FROPS-511

[SDK-2941]: https://launchdarkly.atlassian.net/browse/SDK-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes shared persistent-store setups (e.g. Python + Node on Redis) where **keyless deletion tombstones** (`{"version":N,"deleted":true}`) caused `all_flags_state()` to return invalid empty state because decoding required an inner `key`.
> 
> **Model:** `FeatureFlag` and `Segment` now validate `version` first; deleted items no longer require `key` (optional placeholder like `$deleted` still works). `.key` is `''` when absent, and `to_json_dict()` still round-trips the original payload without synthesizing a key.
> 
> **Stores:** Consul and DynamoDB `get_all_internal` index results by the **database/storage key** (hash field / KV path / sort key), not `item['key']`, matching Redis and other SDKs.
> 
> **Tests:** Decode/round-trip cases for FEATURES and SEGMENTS; caching wrapper tolerance; integration `write_raw_item` + `test_all_reads_tombstone_with_no_key` for Consul, DynamoDB, and Redis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37bddbbea3352079225b164d9a557cfb0f5f24c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


