### PR TITLE
fix: Escape attribute names reported in redactedAttributes

### DIFF
--- a/ldclient/impl/events/event_context_formatter.py
+++ b/ldclient/impl/events/event_context_formatter.py
@@ -76,11 +76,11 @@ class EventContextFormatter:
 
     def _check_whole_attr_private(self, attr: str, all_private: List[AttributeRef], redacted: List[str], redact_all: bool) -> bool:
         if self._all_attributes_private or redact_all:
-            redacted.append(attr)
+            redacted.append(AttributeRef.from_literal(attr).path)
             return True
         for p in all_private:
             if p.depth == 1 and p[0] == attr:
-                redacted.append(attr)
+                redacted.append(AttributeRef.from_literal(attr).path)
                 return True
         return False
 

--- a/ldclient/impl/model/attribute_ref.py
+++ b/ldclient/impl/model/attribute_ref.py
@@ -77,7 +77,13 @@ class AttributeRef:
     def from_literal(name: str) -> AttributeRef:
         if name == '':
             return AttributeRef._from_error(AttributeRef._ERR_EMPTY)
-        return AttributeRef(AttributeRef._escape(name), name, None, None)
+        if name[0] != '/':
+            # A name that does not start with a slash is already a valid
+            # reference to a top-level attribute. It needs no escaping.
+            return AttributeRef(name, name, None, None)
+        # A name that starts with a slash must be escaped. If it is not, a
+        # consumer reads it as a path to a nested property.
+        return AttributeRef('/' + AttributeRef._escape(name), name, None, None)
 
     @staticmethod
     def _from_error(error: str) -> AttributeRef:

--- a/ldclient/testing/impl/events/test_event_context_formatter.py
+++ b/ldclient/testing/impl/events/test_event_context_formatter.py
@@ -61,3 +61,21 @@ def test_private_property_in_object():
     f = EventContextFormatter(False, ['/b/prop1', '/c/prop2/sub1'])
     c = Context.builder('a').set('b', {'prop1': True, 'prop2': 3}).set('c', {'prop1': {'sub1': True}, 'prop2': {'sub1': 4, 'sub2': 5}}).build()
     assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'b': {'prop2': 3}, 'c': {'prop1': {'sub1': True}, 'prop2': {'sub2': 5}}, '_meta': {'redactedAttributes': ['/b/prop1', '/c/prop2/sub1']}}
+
+
+def test_all_private_reports_escaped_references():
+    f = EventContextFormatter(True, [])
+    c = Context.builder('a').set('/ssn', '123-45-6789').set('/a~b', 'secret').set('c/d~e', 'plain').build()
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', '_meta': {'redactedAttributes': ['/~1ssn', '/~1a~0b', 'c/d~e']}}
+
+
+def test_redact_anonymous_reports_escaped_references():
+    f = EventContextFormatter(False, [])
+    c = Context.builder('a').name('b').anonymous(True).set('/ssn', '123-45-6789').build()
+    assert f.format_context_redact_anonymous(c) == {'kind': 'user', 'key': 'a', 'anonymous': True, '_meta': {'redactedAttributes': ['name', '/~1ssn']}}
+
+
+def test_private_slash_prefixed_attribute_reports_escaped_reference():
+    f = EventContextFormatter(False, ['/~1ssn'])
+    c = Context.builder('a').name('b').set('/ssn', '123-45-6789').build()
+    assert f.format_context(c) == {'kind': 'user', 'key': 'a', 'name': 'b', '_meta': {'redactedAttributes': ['/~1ssn']}}

--- a/ldclient/testing/impl/test_attribute_ref.py
+++ b/ldclient/testing/impl/test_attribute_ref.py
@@ -42,6 +42,25 @@ class TestAttributeRef:
         assert a.depth == 1
         assert a[0] == input
 
+    @pytest.mark.parametrize(
+        "input,expected_path",
+        [
+            ("name", "name"),
+            ("name/with/slashes", "name/with/slashes"),
+            ("a/b~c", "a/b~c"),
+            ("/ssn", "/~1ssn"),
+            ("/a~b", "/~1a~0b"),
+        ],
+    )
+    def test_literal_path_escapes_a_leading_slash(self, input: str, expected_path: str):
+        # A name that starts with a slash must be escaped, so that a consumer
+        # does not read it as a path to a nested property. Any other name is
+        # already a valid reference and stays unchanged.
+        a = AttributeRef.from_literal(input)
+        assert a.path == expected_path
+        assert AttributeRef.from_path(a.path).path == expected_path
+        assert AttributeRef.from_path(a.path)[0] == input
+
     def test_get_component(self):
         a = AttributeRef.from_path("/first/sec~1ond/third")
         assert a.depth == 3


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Surfaced by contract test harness v3.2.0-alpha.9 (the pin bump in #492). These 6 subtests fail against the newer harness:

- `events/context properties/single-kind, allAttributesPrivate, slash-prefixed attribute name` (debug, identify, index-from-evaluation, index-from-custom-event)
- `events/feature events/single-kind anonymous context redacts all attributes/type: any`
- `events/feature events/multi-kind with anonymous context redacts attributes appropriately/type: any`

The same fix has already landed in Ruby (launchdarkly/ruby-server-sdk#415) and Rust (launchdarkly/rust-server-sdk-evaluation#56). `java-core` and `dotnet-core` fail identically and still need it.

**Describe the solution you've provided**

`_meta.redactedAttributes` in event payloads is a list of attribute *references*, not raw attribute names. When a context has an attribute whose name begins with `/` (e.g. `/ssn`), the SDK emitted the raw name, which a consumer parses as a path expression pointing at a nested property rather than the top-level attribute:

```
expected: "/~1ssn"
actual:   "/ssn"
```

Two changes:

- `EventContextFormatter._check_whole_attr_private` now converts the attribute name to a reference with `AttributeRef.from_literal` before adding it to the redacted list. This covers both the `allAttributesPrivate`/configured-private paths and the anonymous-context redaction path, which is why one change fixes all 6 subtests.
- `AttributeRef.from_literal` built an invalid path: it escaped unconditionally and never prepended `/`, so `/ssn` became `~1ssn` (which re-parses as a literal attribute named `~1ssn`) and `a~b` became `a~0b`. It now matches Go's `NewLiteralRef` and Rust's `Reference::from_literal_name` — escape only when the name starts with `/`, converting `~` to `~0` and `/` to `~1` and prepending `/`. Every other name is already a valid reference and is left unchanged (`name` stays `name`, `a/b~c` stays `a/b~c`).

`EventContextFormatter` is shared by the sync and async event processors through `event_processor_common`, so this covers `LDClient` and `AsyncLDClient` alike.

**Verification**

Contract test service against released harness **v3.2.0-alpha.9**: 4771 total, 15 skipped, all ran passed (6 failures before). Against **v2.41.0**: 4766 total, 17 skipped, all ran passed — no regression on the FDv1 job. Unit suite: 1427 passed. `make lint` clean.

**Describe alternatives you've considered**

Escaping only in the `all_attributes_private` branch — rejected, the same escaping is required wherever a whole attribute is redacted.

Escaping at the call site instead of fixing `from_literal` — rejected, `from_literal` produced a path that could not round-trip through `from_path`, which is a latent bug regardless of this caller.

**Additional context**

Nested redactions in `_redact_json_value` already reported `AttributeRef.path`, so they were unaffected. `AttributeRef.path` has exactly one consumer in the SDK (the redaction list), so the corrected raw path does not change evaluation behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Event payloads now list **proper attribute references** in `_meta.redactedAttributes` instead of raw context attribute names. Whole-attribute redaction (all-private, configured private, and anonymous redaction) goes through `AttributeRef.from_literal(...).path`, so slash-prefixed names like `/ssn` are reported as `/~1ssn` rather than `/ssn`, which consumers would otherwise treat as a nested path.
> 
> **`AttributeRef.from_literal`** is aligned with other LaunchDarkly SDKs: names without a leading `/` are left unchanged; names that start with `/` get `/` plus escape sequences (`~` → `~0`, `/` → `~1`) so the reference round-trips through `from_path`. Nested redaction in `_redact_json_value` was already using `.path` and is unchanged.
> 
> New unit tests cover escaped entries for all-private, anonymous redaction, and explicitly private slash-prefixed attributes, plus `from_literal` path expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c0b4d97ed7b2d3d08d70dac59e2f4e706a7448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->