### PR TITLE
fix: Prevent a persistent-store outage from throwing in the sync FDv2 evaluation

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -402,29 +402,13 @@ class LDClient:
         hook_result = self.__evaluate_with_hooks(key=key, context=context, default_value=default_stage.value, method="migration_variation", block=evaluate)
         return hook_result.results['default_stage'], hook_result.results['tracker']
 
-    def _data_availability(self) -> DataAvailability:
-        """Reads the current data availability, degrading to ``DEFAULTS`` on error.
-
-        During the warm-start window (before a data source initializes) the
-        availability gate may query a persistent store, such as Redis. A store
-        I/O error must not propagate out of an evaluation, so treat it as "no
-        data available"; the caller then returns the default value with
-        ``CLIENT_NOT_READY`` instead of raising.
-        """
-        try:
-            return self._data_system.data_availability
-        except Exception as e:
-            log.error("Error checking data availability; treating data as unavailable: %s" % repr(e))
-            log.debug(traceback.format_exc())
-            return DataAvailability.DEFAULTS
-
     def _evaluate_internal(self, key: str, context: Context, default: Any, event_factory) -> Tuple[EvaluationDetail, Optional[FeatureFlag]]:
         default = self._config.get_default(key, default)
 
         if self._config.offline:
             return EvaluationDetail(default, None, error_reason('CLIENT_NOT_READY')), None
 
-        availability = self._data_availability()
+        availability = self._data_system.data_availability
         if availability != DataAvailability.REFRESHED:
             if availability == DataAvailability.CACHED:
                 log.warning("Feature Flag evaluation attempted before client has initialized - using last known values from feature store for feature key: " + key)
@@ -496,7 +480,7 @@ class LDClient:
             log.warning("all_flags_state() called, but client is in offline mode. Returning empty state")
             return FeatureFlagsState(False)
 
-        availability = self._data_availability()
+        availability = self._data_system.data_availability
         if availability != DataAvailability.REFRESHED:
             if availability == DataAvailability.CACHED:
                 log.warning("all_flags_state() called before client has finished initializing! Using last known values from feature store")

--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -402,14 +402,31 @@ class LDClient:
         hook_result = self.__evaluate_with_hooks(key=key, context=context, default_value=default_stage.value, method="migration_variation", block=evaluate)
         return hook_result.results['default_stage'], hook_result.results['tracker']
 
+    def _data_availability(self) -> DataAvailability:
+        """Reads the current data availability, degrading to ``DEFAULTS`` on error.
+
+        During the warm-start window (before a data source initializes) the
+        availability gate may query a persistent store, such as Redis. A store
+        I/O error must not propagate out of an evaluation, so treat it as "no
+        data available"; the caller then returns the default value with
+        ``CLIENT_NOT_READY`` instead of raising.
+        """
+        try:
+            return self._data_system.data_availability
+        except Exception as e:
+            log.error("Error checking data availability; treating data as unavailable: %s" % repr(e))
+            log.debug(traceback.format_exc())
+            return DataAvailability.DEFAULTS
+
     def _evaluate_internal(self, key: str, context: Context, default: Any, event_factory) -> Tuple[EvaluationDetail, Optional[FeatureFlag]]:
         default = self._config.get_default(key, default)
 
         if self._config.offline:
             return EvaluationDetail(default, None, error_reason('CLIENT_NOT_READY')), None
 
-        if self._data_system.data_availability != DataAvailability.REFRESHED:
-            if self._data_system.data_availability == DataAvailability.CACHED:
+        availability = self._data_availability()
+        if availability != DataAvailability.REFRESHED:
+            if availability == DataAvailability.CACHED:
                 log.warning("Feature Flag evaluation attempted before client has initialized - using last known values from feature store for feature key: " + key)
             else:
                 log.warning("Feature Flag evaluation attempted before client has initialized! Feature store unavailable - returning default: " + str(default) + " for feature key: " + key)
@@ -479,8 +496,9 @@ class LDClient:
             log.warning("all_flags_state() called, but client is in offline mode. Returning empty state")
             return FeatureFlagsState(False)
 
-        if self._data_system.data_availability != DataAvailability.REFRESHED:
-            if self._data_system.data_availability == DataAvailability.CACHED:
+        availability = self._data_availability()
+        if availability != DataAvailability.REFRESHED:
+            if availability == DataAvailability.CACHED:
                 log.warning("all_flags_state() called before client has finished initializing! Using last known values from feature store")
             else:
                 log.warning("all_flags_state() called before client has finished initializing! Feature store unavailable - returning empty state")

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -392,7 +392,7 @@ class FDv2(DataSystem):
         """
         Consume results from a synchronizer until a condition is met or it fails.
 
-        :return: Tuple of (should_remove_sync, fallback_to_fdv1, directive)
+        :return: the ConditionDirective describing how to proceed
         """
         action_queue: Queue = Queue()
         timer = RepeatingTask(

--- a/ldclient/impl/datasystem/fdv2.py
+++ b/ldclient/impl/datasystem/fdv2.py
@@ -565,7 +565,16 @@ class FDv2(DataSystem):
         if self._store.selector().is_defined():
             return DataAvailability.REFRESHED
 
-        if not self._configured_with_data_sources or self._store.is_initialized():
+        if not self._configured_with_data_sources:
+            return DataAvailability.CACHED
+
+        try:
+            store_initialized = self._store.is_initialized()
+        except Exception as e:
+            log.error("Error checking persistent store readiness; treating data as unavailable: %s", e)
+            return DataAvailability.DEFAULTS
+
+        if store_initialized:
             return DataAvailability.CACHED
 
         return DataAvailability.DEFAULTS

--- a/ldclient/impl/datasystem/store.py
+++ b/ldclient/impl/datasystem/store.py
@@ -521,7 +521,7 @@ class Store(_StoreBase):
                     return e
         return None
 
-    def close(self) -> Optional[Exception]:
+    def close(self) -> None:
         """Close the store and any persistent store if configured."""
         with self._lock:
             if self._persistent_store is not None:
@@ -532,8 +532,7 @@ class Store(_StoreBase):
                     if callable(close):
                         close()
                 except Exception as e:
-                    return e
-        return None
+                    log.warning("Error closing the persistent store: %s", e)
 
     def get_data_store_status_provider(self) -> Optional[DataStoreStatusProvider]:
         """Get the data store status provider for the persistent store, if configured."""

--- a/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
@@ -3,11 +3,15 @@
 from threading import Event
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
+import pytest
+
+from ldclient.client import Context
 from ldclient.config import Config, DataSystemConfig
 from ldclient.impl.datasystem import DataAvailability
 from ldclient.impl.datasystem.fdv2 import FDv2
 from ldclient.integrations.test_datav2 import TestDataV2
 from ldclient.interfaces import DataStoreMode, FeatureStore, FlagChange
+from ldclient.testing.test_ldclient import make_client
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS, VersionedDataKind
 
 
@@ -782,3 +786,65 @@ def test_persistent_store_commit_handles_errors():
     assert err is not None, "Commit should return error from persistent store"
     assert isinstance(err, RuntimeError)
     assert str(err) == "Simulated persistent store failure"
+
+
+class ThrowingInitializedStore(StubFeatureStore):
+    """A persistent store whose ``initialized`` check raises, to simulate a
+    store I/O error (for example a Redis connection failure) during the
+    warm-start availability gate."""
+
+    @property
+    def initialized(self) -> bool:
+        raise RuntimeError("persistent store I/O error")
+
+
+def test_variation_does_not_throw_when_persistent_store_errors_during_warm_start(caplog):
+    """A persistent-store error at the warm-start availability gate must not
+    propagate out of the client.
+
+    While a synchronizer is configured but has not yet supplied a basis, the
+    availability gate consults the persistent store's initialized state. If that
+    query raises, evaluation must degrade to the default value with
+    ``CLIENT_NOT_READY`` and ``all_flags_state()`` must return an invalid state,
+    rather than raising. This is the sync counterpart to the async fix in #486.
+    """
+    persistent_store = ThrowingInitializedStore()
+
+    # A synchronizer is configured but the data system is never started, so no
+    # basis arrives. This is the warm-start window in which the gate reads the
+    # persistent store's initialized state.
+    data_system_config = DataSystemConfig(
+        data_store_mode=DataStoreMode.READ_ONLY,
+        data_store=persistent_store,
+        initializers=None,
+        synchronizers=[TestDataV2.data_source().builder],
+    )
+    fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
+
+    # The gate itself raises: this is the unguarded root the fix addresses.
+    with pytest.raises(RuntimeError):
+        _ = fdv2.data_availability
+
+    # Drive the same failing gate through the client and confirm it degrades
+    # instead of propagating the error.
+    client = make_client()
+    try:
+        client._data_system = fdv2
+        context = Context.from_dict({"key": "user", "kind": "user"})
+
+        assert client.variation("flag-key", context, default="default-value") == "default-value"
+
+        detail = client.variation_detail("flag-key", context, default="default-value")
+        assert detail.value == "default-value"
+        assert detail.reason == {"kind": "ERROR", "errorKind": "CLIENT_NOT_READY"}
+        assert detail.is_default_value() is True
+
+        assert client.all_flags_state(context).valid is False
+    finally:
+        client.close()
+
+    assert any(
+        "Error checking data availability" in record.message
+        for record in caplog.records
+        if record.levelname == "ERROR"
+    )

--- a/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
@@ -3,8 +3,6 @@
 from threading import Event
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
-import pytest
-
 from ldclient.client import Context
 from ldclient.config import Config, DataSystemConfig
 from ldclient.impl.datasystem import DataAvailability
@@ -821,11 +819,10 @@ def test_variation_does_not_throw_when_persistent_store_errors_during_warm_start
     )
     fdv2 = FDv2(Config(sdk_key="dummy"), data_system_config)
 
-    # The gate itself raises: this is the unguarded root the fix addresses.
-    with pytest.raises(RuntimeError):
-        _ = fdv2.data_availability
+    # The gate itself must not raise: it degrades to DEFAULTS instead.
+    assert fdv2.data_availability == DataAvailability.DEFAULTS
 
-    # Drive the same failing gate through the client and confirm it degrades
+    # Drive the same gate through the client and confirm it degrades
     # instead of propagating the error.
     client = make_client()
     try:
@@ -844,7 +841,7 @@ def test_variation_does_not_throw_when_persistent_store_errors_during_warm_start
         client.close()
 
     assert any(
-        "Error checking data availability" in record.message
+        "Error checking persistent store readiness" in record.message
         for record in caplog.records
         if record.levelname == "ERROR"
     )

--- a/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
+++ b/ldclient/testing/impl/datasystem/test_fdv2_persistence.py
@@ -845,3 +845,25 @@ def test_variation_does_not_throw_when_persistent_store_errors_during_warm_start
         for record in caplog.records
         if record.levelname == "ERROR"
     )
+
+
+def test_persistent_store_close_logs_and_swallows_error(caplog):
+    """A persistent-store close error is logged as a warning, not raised."""
+    from ldclient.impl.datasystem.store import Store
+    from ldclient.impl.listeners import Listeners
+
+    class ClosingFailsStore(StubFeatureStore):
+        def close(self):
+            raise RuntimeError("close boom")
+
+    store = Store(Listeners(), Listeners())
+    store.with_persistence(ClosingFailsStore(), True, None)
+
+    # close() must log the error rather than raise it.
+    store.close()
+
+    assert any(
+        "Error closing the persistent store" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )


### PR DESCRIPTION
## The bug

Sync FDv2, when configured with a persistent store (e.g. Redis), could **throw a store I/O error out of `variation()` / `variation_detail()` / `all_flags_state()`** during the warm-start window (before a data source initializes), instead of degrading to `CLIENT_NOT_READY` / the default. A `variation()` must never throw.

The path: `LDClient._evaluate_internal` / `all_flags_state` read `self._data_system.data_availability` **before** their own try/except. For FDv2, `data_availability` calls `self._store.is_initialized()` while no basis has arrived, which reaches the persistent store's `initialized_internal()` — a blocking query (e.g. redis `exists()`) that **raises on a store error and was not caught**. `__evaluate_with_hooks` does not catch exceptions from `block()`, so the error propagated out of `variation()`. (The store's `is_available()` is wrapped safe, but `initialized_internal()` was not — that asymmetry is the root.)

## The fix

Make the availability gate **total**: `FDv2.data_availability` now wraps the persistent-store read in a `try/except` and degrades to `DataAvailability.DEFAULTS` on error, logging it. A store I/O error therefore never leaves the gate — `variation()` returns the default with `CLIENT_NOT_READY` and `all_flags_state()` returns an invalid state.

The catch lives **in the gate rather than at the client call sites** so it covers every caller. In particular, `is_initialized()` reads `data_availability` directly, so a client-side-only guard would have left `is_initialized()` able to throw. This mirrors the async gate in #486, keeping the two implementations symmetric.

The catch is scoped to the store read only; the `REFRESHED` and `CACHED` checks around it are untouched, so a real logic error there is not masked.

## Also: log persistent-store close errors

`Store.close()` previously returned the close error as `Optional[Exception]`, which its only caller (`FDv2.stop`) discarded — so a failed close was silently lost. It now logs a warning and returns `None`. Closing happens at shutdown, where there is no caller left to react to the error. (Pre-existing since 9.16.0, not introduced by recent refactors; the async counterpart is in #486.)

Also corrects a stale docstring on `FDv2._consume_synchronizer_results` (described a tuple return; returns a single `ConditionDirective`).

## Validation

- `test_variation_does_not_throw_when_persistent_store_errors_during_warm_start`: a persistent store whose `initialized` raises, with a synchronizer configured but no basis yet. Asserts the gate now **returns `DEFAULTS`** (rather than raising), and that through the client `variation()` / `variation_detail()` return the default with `CLIENT_NOT_READY` and `all_flags_state()` is invalid — no exception.
- `test_persistent_store_close_logs_and_swallows_error`: a persistent store whose `close()` raises; `Store.close()` logs a warning and does not raise.
- Full unit suite (minus DB integrations) green; `mypy`, `isort`, `pycodestyle` clean.

## Scope

Sync FDv2 only. Sync FDv1 reads `data_availability` the same way; out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Prevents **sync FDv2** from raising when a persistent store (e.g. Redis) fails during the warm-start window—before a data source has supplied a basis—while `data_availability` consults the store’s initialized state.
> 
> **`FDv2.data_availability`** now wraps the persistent-store readiness check in `try/except`, logs the failure, and returns **`DataAvailability.DEFAULTS`** instead of propagating I/O errors. Callers such as **`variation()`**, **`variation_detail()`**, and **`all_flags_state()`** therefore return defaults with **`CLIENT_NOT_READY`** or an invalid flags state rather than throwing (aligned with the async fix in #486). **`LDClient`** only caches the availability value in `_evaluate_internal` and `all_flags_state` for clarity.
> 
> **`Store.close()`** logs persistent-store close failures as warnings and no longer returns an exception that callers ignored. A stale docstring on **`_consume_synchronizer_results`** is corrected.
> 
> New tests cover a throwing `initialized` property during warm-start and close-error logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198254bc2ddbadbb3bce00afcd86d8c7f9b79966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->