### PR TITLE
chore: Add an async support section to the README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - [ ] I have added test coverage for new or changed functionality
 - [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
 - [ ] I have validated my changes against all supported platform versions
+- [ ] Sync/async parity: matching changes made to `async_*` siblings (or N/A)
 
 **Related issues**
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### Deployment
+### Event loop
 
 `AsyncLDClient` runs on the caller's event loop. It targets a single event loop and is not thread-safe. Use one client for the whole application.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,43 @@ This version of the LaunchDarkly SDK is compatible with Python 3.10+.
 
 Refer to the [SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/python) for instructions on getting started with using the SDK.
 
+## Async support
+
+> [!CAUTION]
+> The async implementation (`AsyncLDClient` and its associated async API) is experimental and should NOT be considered ready for production use. It may change or be removed without notice and is not subject to backwards compatibility guarantees.
+>
+> Pin to a specific minor version and review the changelog before upgrading.
+
+> [!NOTE]
+> Using Redis with the async client (big segments or a persistent data store) requires `redis>=4.2.0`, the version that introduced `redis.asyncio`. The `redis` extra itself still permits older versions for synchronous use, so install `redis>=4.2.0` when using Redis with the async client.
+
+An async implementation, `AsyncLDClient`, is available for use with `asyncio`-based applications. It uses `aiohttp` for HTTP and requires installing the optional `async` extra:
+
+```
+pip install launchdarkly-server-sdk[async]
+```
+
+```python
+import asyncio
+from ldclient import Config, Context
+from ldclient.async_client import AsyncLDClient
+
+async def main():
+    async with AsyncLDClient(Config("sdk-key")) as client:
+        value = await client.variation("my-flag", Context.create("user-key"), False)
+        print(value)
+
+asyncio.run(main())
+```
+
+### Deployment
+
+`AsyncLDClient` runs on the caller's event loop. It targets a single event loop and is not thread-safe. Use one client for the whole application.
+
+The constructor does not need a running event loop. So you can create the client once, before the application forks or preloads its workers. Then start the client on each worker's event loop with `await client.start()`. You can also use `async with AsyncLDClient(config) as client:`, which starts and closes the client for you.
+
+This model fits ASGI servers. Create the client at application startup, and start it in the ASGI lifespan handler.
+
 ## Learn more
 
 Read our [documentation](http://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](http://docs.launchdarkly.com/docs/python-sdk-reference).


### PR DESCRIPTION
## What

Adds user-facing docs for the experimental async client, plus a small PR-template aid.

**README — new "Async support" section:**
- Experimental caution (matches the `.. caution::` blocks on the async API).
- The `redis>=4.2.0` requirement when using Redis with the async client (big segments or persistent store).
- Install via the `[async]` extra, and a minimal `AsyncLDClient` usage example.
- A **Deployment** note: `AsyncLDClient` is single-event-loop / not thread-safe; construct once (its `__init__` needs no running loop), then `await start()` per worker loop — or use `async with` — which fits ASGI lifespan startup.

**PR template:** adds a "sync/async parity" checkbox so a change to a sync file prompts a matching async update (the drop-codegen sibling-file convention).

## Why

The async implementation is fully merged and importable (`from ldclient import AsyncLDClient`, `[async]` extra), but the README had no async entry point. This is the last user-facing gap before an experimental release.

Both files are Markdown, so the test/contract CI is intentionally skipped (`paths-ignore: **.md`) — there's nothing to test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Documents the experimental **`AsyncLDClient`** in the README so asyncio users have a clear entry point before an experimental release.
> 
> The new **Async support** section adds production warnings, the `launchdarkly-server-sdk[async]` install path, a minimal usage example, Redis `>=4.2.0` guidance for async Redis, and **Event loop** notes (single-loop, not thread-safe, construct without a running loop then `await start()` or `async with`, ASGI lifespan pattern).
> 
> The pull request template gains a **sync/async parity** checkbox so contributors remember matching `async_*` siblings when changing sync APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564868af0886199875c116698d1c2cb90001ce55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->