### PR TITLE
chore: Bump gh-action-pypi-publish to v1.14.2 for metadata 2.5 support

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Publish package distributions to PyPI
         if: ${{ format('{0}', inputs.dry_run) == 'false' }}
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Publish package distributions to PyPI
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           password: ${{env.PYPI_AUTH_TOKEN}}
 


### PR DESCRIPTION
## The problem

The **9.17.0** PyPI publish failed at the pre-upload metadata check:
```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Root cause

The wheel has core `Metadata-Version: 2.5` — emitted by **hatchling 1.32.0** (released 2026-08-11; the previous good publish, 9.16.0, used hatchling 1.30.1 → metadata 2.4). The pinned **`gh-action-pypi-publish@v1.14.1`** bundles **`twine==6.1.0`**, which doesn't recognize metadata 2.5 and rejects the distribution.

## The fix

Bump the action to **v1.14.2**, which bumps its internal Twine to **7.0.0** — and 7.0.0 accepts metadata 2.5 (confirmed in the v1.14.2 release notes and verified locally: `twine 7.0.0` passes a 2.5 wheel, `twine 6.1.0` rejects it). The pin is bumped in **both** publish workflows:
- `.github/workflows/release-please.yml`
- `.github/workflows/manual-publish.yml`

This is the root-appropriate fix — the validator was simply behind the build tool — so hatchling stays current (no cap, metadata stays 2.5).

## Getting 9.17.0 onto PyPI

9.17.0's tag/GitHub release exist but it never reached PyPI. After this merges, run the **Publish Package** workflow (`manual-publish.yml`, `workflow_dispatch`) against `main` with `dry_run=false` — it builds from `main`'s `pyproject.toml` (9.17.0) with the bumped action and publishes. (Re-running the original failed release job won't work — it rebuilds the tagged commit with the old action.)
