### PR TITLE
feat: Warn when the SDK is used in a forked process without postfork

### DIFF
--- a/ldclient/client.py
+++ b/ldclient/client.py
@@ -2,9 +2,10 @@
 This submodule contains the client class that provides most of the SDK functionality.
 """
 
+import os
 import threading
 import traceback
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 from ldclient.config import Config
@@ -50,6 +51,11 @@ from ldclient.versioned_data_kind import FEATURES, SEGMENTS
 
 from .impl import AnyNum
 
+_FORK_WARNING_MESSAGE = (
+    "This process was forked after the LDClient was created. Background threads do not survive a fork, "
+    "so flag updates and analytics events will not work in this process. Call LDClient.postfork() after forking."
+)
+
 
 class LDClient:
     """The LaunchDarkly SDK client object.
@@ -78,6 +84,9 @@ class LDClient:
         self._event_factory_default = EventFactory(False)
         self._event_factory_with_reasons = EventFactory(True)
 
+        self._owner_pid = os.getpid()
+        self._fork_warned_pids: Dict[int, object] = {}
+
         self.__start_up(start_wait)
 
     def postfork(self, start_wait: float = 5):
@@ -100,9 +109,49 @@ class LDClient:
         that any listener or hook integrations be added postfork unless you are
         certain it can survive the forking process.
 
+        If the SDK is used in a forked child process before this method is
+        called, it logs a warning once per process. Calling this method clears
+        that condition for the current process.
+
         :param start_wait: the number of seconds to wait for a successful connection to LaunchDarkly
         """
+        self._owner_pid = os.getpid()
+        self._fork_warned_pids = {}
         self.__start_up(start_wait)
+
+    def _check_forked(self):
+        """
+        Log a warning once per process if this client is used in a process that was forked after
+        the client was created.
+
+        The "already warned" state is keyed by pid, not stored as a boolean. A boolean would be
+        copied into every child on fork, so a grandchild process would never get its own warning.
+
+        The state is a dict written with ``dict.setdefault``, not a ``threading.Lock``. A lock held
+        at the moment of a fork is inherited locked by the child and would hang its first
+        evaluation. ``dict.setdefault`` is atomic in CPython, so many threads log exactly one warning.
+        """
+        pid = os.getpid()
+        if pid == self._owner_pid:
+            return
+        if not self._fork_breaks_client():
+            return
+
+        token = object()
+        if self._fork_warned_pids.setdefault(pid, token) is token:
+            log.warning(_FORK_WARNING_MESSAGE)
+
+    def _fork_breaks_client(self) -> bool:
+        """
+        Return true if this configuration needs background threads. Offline mode has none. LDD mode
+        with events disabled reads flags from the persistent store and sends nothing, so a fork does
+        not break it.
+        """
+        if self._config.offline:
+            return False
+        if self._config.use_ldd and not self._config.send_events:
+            return False
+        return True
 
     def __start_up(self, start_wait: float):
         environment_metadata = get_environment_metadata(self._config, "python-server-sdk")
@@ -220,6 +269,7 @@ class LDClient:
 
         Do not attempt to use the client after calling this method.
         """
+        self._check_forked()
         log.info("Closing LaunchDarkly client..")
         self._event_processor.stop()
         self._data_system.stop()
@@ -247,6 +297,7 @@ class LDClient:
         Customers not using the builder should provide this method with the
         tracker returned from calling :func:`migration_variation`.
         """
+        self._check_forked()
         event = tracker.build()
 
         if isinstance(event, str):
@@ -271,6 +322,7 @@ class LDClient:
         :param metric_value: a numeric value used by the LaunchDarkly experimentation feature in
           numeric custom metrics; can be omitted if this event is used by only non-numeric metrics
         """
+        self._check_forked()
         if not context.valid:
             log.warning("Invalid context for track (%s)" % context.error)
         else:
@@ -289,7 +341,7 @@ class LDClient:
 
         :param context: the context to register
         """
-
+        self._check_forked()
         if not context.valid:
             log.warning("Invalid context for identify (%s)" % context.error)
         else:
@@ -331,6 +383,7 @@ class LDClient:
         schedules the next event delivery to be as soon as possible; however, the delivery still
         happens asynchronously on a worker thread, so this method will return immediately.
         """
+        self._check_forked()
         if self._config.offline:
             return
         return self._event_processor.flush()
@@ -480,6 +533,8 @@ class LDClient:
             log.warning("all_flags_state() called, but client is in offline mode. Returning empty state")
             return FeatureFlagsState(False)
 
+        self._check_forked()
+
         availability = self._data_system.data_availability
         if availability != DataAvailability.REFRESHED:
             if availability == DataAvailability.CACHED:
@@ -572,6 +627,10 @@ class LDClient:
         # :param block:
         # :return:
         """
+        # variation, variation_detail, and migration_variation all pass through here, so this one
+        # check covers every evaluation entry point.
+        self._check_forked()
+
         hooks = []  # type: List[Hook]
         with self.__hooks_lock.read():
             if len(self.__hooks) == 0:

--- a/ldclient/testing/test_ldclient_fork.py
+++ b/ldclient/testing/test_ldclient_fork.py
@@ -1,0 +1,256 @@
+"""
+Tests for the fork warning in LDClient.
+
+Threads do not survive a fork. A child process that inherits a client has no
+background threads, so the client must log a warning once per process until
+``postfork()`` is called.
+"""
+import logging
+import os
+import threading
+import warnings
+from typing import Any, Dict
+
+import pytest
+
+from ldclient.client import Config, Context, LDClient
+from ldclient.migrations import Stage
+from ldclient.testing.stub_util import MockEventProcessor, MockUpdateProcessor
+
+unreachable_uri = "http://fake"
+
+context = Context.builder('xyz').build()
+
+WARNING_TEXT = "forked after the LDClient was created"
+
+
+def make_config(**kwargs) -> Config:
+    params: Dict[str, Any] = dict(
+        sdk_key='SDK_KEY',
+        base_uri=unreachable_uri,
+        events_uri=unreachable_uri,
+        stream_uri=unreachable_uri,
+        event_processor_class=MockEventProcessor,
+        update_processor_class=MockUpdateProcessor,
+    )
+    params.update(kwargs)
+    return Config(**params)
+
+
+def make_client(**kwargs) -> LDClient:
+    return LDClient(config=make_config(**kwargs), start_wait=0)
+
+
+def fork_warnings(caplog) -> list:
+    return [r for r in caplog.records if r.levelno == logging.WARNING and WARNING_TEXT in r.getMessage()]
+
+
+def pretend_forked(monkeypatch, offset: int = 1):
+    """Make os.getpid report a pid other than the one the client recorded.
+
+    The client is created before this patch is applied, so the client sees the
+    real pid as the owner and the patched pid as a child.
+    """
+    fake_pid = os.getpid() + offset
+    monkeypatch.setattr(os, "getpid", lambda: fake_pid)
+
+
+def test_no_warning_when_pid_has_not_changed(caplog):
+    with make_client() as client:
+        client.variation("flag", context, False)
+        client.variation_detail("flag", context, False)
+        client.migration_variation("flag", context, Stage.OFF)
+        client.identify(context)
+        client.track("event", context)
+        client.all_flags_state(context)
+        client.flush()
+    assert fork_warnings(caplog) == []
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda c: c.variation("flag", context, False), id="variation"),
+        pytest.param(lambda c: c.variation_detail("flag", context, False), id="variation_detail"),
+        pytest.param(lambda c: c.migration_variation("flag", context, Stage.OFF), id="migration_variation"),
+        pytest.param(lambda c: c.all_flags_state(context), id="all_flags_state"),
+        pytest.param(lambda c: c.identify(context), id="identify"),
+        pytest.param(lambda c: c.track("event", context), id="track"),
+        pytest.param(lambda c: c.flush(), id="flush"),
+    ],
+)
+def test_warns_on_first_call_after_pid_change(caplog, monkeypatch, call):
+    with make_client() as client:
+        pretend_forked(monkeypatch)
+        call(client)
+        assert len(fork_warnings(caplog)) == 1
+
+
+def test_warns_on_track_migration_op(caplog, monkeypatch):
+    with make_client() as client:
+        _, tracker = client.migration_variation("flag", context, Stage.OFF)
+        pretend_forked(monkeypatch)
+        client.track_migration_op(tracker)
+        assert len(fork_warnings(caplog)) == 1
+
+
+def test_warns_on_close(caplog, monkeypatch):
+    client = make_client()
+    pretend_forked(monkeypatch)
+    client.close()
+    assert len(fork_warnings(caplog)) == 1
+
+
+def test_warning_names_postfork_and_says_what_stops_working(caplog, monkeypatch):
+    with make_client() as client:
+        pretend_forked(monkeypatch)
+        client.variation("flag", context, False)
+    message = fork_warnings(caplog)[0].getMessage()
+    assert "LDClient.postfork()" in message
+    assert "flag updates and analytics events will not work" in message
+
+
+def test_warns_only_once_per_process_across_many_calls(caplog, monkeypatch):
+    with make_client() as client:
+        pretend_forked(monkeypatch)
+        for _ in range(5):
+            client.variation("flag", context, False)
+        client.variation_detail("flag", context, False)
+        client.migration_variation("flag", context, Stage.OFF)
+        client.identify(context)
+        client.track("event", context)
+        client.all_flags_state(context)
+        client.flush()
+    assert len(fork_warnings(caplog)) == 1
+
+
+def test_warns_only_once_when_many_threads_evaluate_at_the_same_time(caplog, monkeypatch):
+    with make_client() as client:
+        pretend_forked(monkeypatch)
+        start = threading.Barrier(16)
+
+        def worker():
+            start.wait()
+            for _ in range(50):
+                client.variation("flag", context, False)
+
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    assert len(fork_warnings(caplog)) == 1
+
+
+def test_postfork_clears_the_warning(caplog, monkeypatch):
+    with make_client() as client:
+        pretend_forked(monkeypatch)
+        client.variation("flag", context, False)
+        assert len(fork_warnings(caplog)) == 1
+
+        client.postfork(0)
+        client.variation("flag", context, False)
+        client.flush()
+    assert len(fork_warnings(caplog)) == 1
+
+
+def test_warns_again_in_a_grandchild_process(caplog, monkeypatch):
+    with make_client() as client:
+        pretend_forked(monkeypatch, offset=1)
+        client.variation("flag", context, False)
+        assert len(fork_warnings(caplog)) == 1
+
+        # The "already warned" state is copied into a grandchild on fork. It must still warn there.
+        pretend_forked(monkeypatch, offset=2)
+        client.variation("flag", context, False)
+        assert len(fork_warnings(caplog)) == 2
+
+
+def test_no_warning_in_offline_mode(caplog, monkeypatch):
+    with make_client(offline=True) as client:
+        pretend_forked(monkeypatch)
+        client.variation("flag", context, False)
+        client.variation_detail("flag", context, False)
+        client.identify(context)
+        client.track("event", context)
+        client.all_flags_state(context)
+        client.flush()
+    assert fork_warnings(caplog) == []
+
+
+def test_no_warning_in_ldd_mode_with_events_disabled(caplog, monkeypatch):
+    with make_client(use_ldd=True, send_events=False) as client:
+        pretend_forked(monkeypatch)
+        client.variation("flag", context, False)
+        client.identify(context)
+        client.flush()
+    assert fork_warnings(caplog) == []
+
+
+def test_warns_in_ldd_mode_with_events_enabled(caplog, monkeypatch):
+    with make_client(use_ldd=True, send_events=True) as client:
+        pretend_forked(monkeypatch)
+        client.variation("flag", context, False)
+    assert len(fork_warnings(caplog)) == 1
+
+
+class _CountingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.WARNING)
+        self.count = 0
+
+    def emit(self, record):
+        if WARNING_TEXT in record.getMessage():
+            self.count += 1
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not supported on this platform")
+def test_real_fork_warns_in_child_and_stops_after_postfork(caplog):
+    client = make_client()
+    try:
+        read_fd, write_fd = os.pipe()
+        with warnings.catch_warnings():
+            # Python 3.12+ warns about fork() in a multi-threaded process. That is the
+            # situation this feature exists for, so the warning is expected here.
+            warnings.simplefilter("ignore", DeprecationWarning)
+            pid = os.fork()
+
+        if pid == 0:
+            # Child. Never return into pytest; always leave through os._exit.
+            try:
+                os.close(read_fd)
+                handler = _CountingHandler()
+                logging.getLogger('ldclient.util').addHandler(handler)
+
+                client.variation("flag", context, False)
+                client.variation("flag", context, False)
+                before_postfork = handler.count
+
+                client.postfork(0)
+                client.variation("flag", context, False)
+                after_postfork = handler.count
+
+                os.write(write_fd, f"{before_postfork},{after_postfork}".encode())
+                os.close(write_fd)
+                os._exit(0)
+            except BaseException:
+                os._exit(1)
+
+        os.close(write_fd)
+        chunks = []
+        while True:
+            chunk = os.read(read_fd, 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        os.close(read_fd)
+        _, status = os.waitpid(pid, 0)
+
+        assert os.waitstatus_to_exitcode(status) == 0
+        assert b"".join(chunks).decode() == "1,1"
+
+        # The parent process was not forked, so it must not warn.
+        client.variation("flag", context, False)
+        assert fork_warnings(caplog) == []
+    finally:
+        client.close()


### PR DESCRIPTION
Jira: https://launchdarkly.atlassian.net/browse/SDK-3047

## Problem

Threads do not survive a fork. When an application creates the `LDClient` and then forks worker processes (gunicorn with `preload_app = True`, uWSGI, Celery prefork, `multiprocessing`), each child inherits a client with no stream thread, no event dispatcher thread, and no timer tasks. In the child, `is_initialized()` stays true, flag values freeze at the boot-time snapshot, no analytics events are sent, and `close()` can block forever. The SDK gives no signal that anything is wrong.

Support ticket #129534 (Ruby SDK) took two weeks to diagnose because of this silence. This PR mirrors the Ruby change merged in launchdarkly/ruby-server-sdk#430 for the Python SDK, which has the same failure mode. `LDClient.postfork()` already exists, but nothing warns when it is missing.

## What this change does

- Records `os.getpid()` when `LDClient` is constructed and again inside `postfork()`.
- On the first use of the client in a process whose pid differs from the recorded one, logs a WARNING once per process:

  > This process was forked after the LDClient was created. Background threads do not survive a fork, so flag updates and analytics events will not work in this process. Call LDClient.postfork() after forking.

- Trigger points: `variation`, `variation_detail`, `migration_variation` (all three funnel through the private hook wrapper, so one check covers them), `all_flags_state`, `identify`, `track`, `track_migration_op`, `flush`, and `close`.
- `postfork()` resets the recorded pid and clears the warned state. Its docstring now mentions the warning.

### Skip conditions

The warning is not logged when a fork breaks nothing:

- `config.offline` is true.
- `config.use_ldd` is true and `config.send_events` is false (flags come from the persistent store, nothing is sent).

### Implementation notes

- The check is one `os.getpid()` call compared with the stored pid. The benchmark below shows no regression above noise, so `os.register_at_fork()` was not needed.
- The "already warned" state is keyed by the pid in which the warning was logged, not a boolean. A boolean would be copied into a grandchild on fork and suppress its warning.
- The state is a dict written with `dict.setdefault` (atomic in CPython, including free-threaded builds) rather than a `threading.Lock`. A lock held at the instant of a fork is inherited locked by the child, and the child's first evaluation would hang forever. That is the class of failure this change exists to expose, not cause.

### Async client

`AsyncLDClient` is unchanged. It has no `postfork()`, `test_sync_async_parity.py` already lists `postfork` as sync-only, and forking a process that owns a running asyncio event loop is not a supported pattern. Fork support for the async client would need its own design.

## Tests

New `ldclient/testing/test_ldclient_fork.py` (19 tests):

- No warning in the owner process.
- Warning on the first call after a pid change for each trigger point (`os.getpid` monkeypatched).
- Exactly one warning across many calls and across 16 threads x 50 evaluations.
- `postfork()` clears the warning.
- A second pid change (grandchild) warns again.
- No warning in offline mode; no warning in LDD mode with events disabled; warning in LDD mode with events enabled.
- One real `os.fork()` test, skipped where `os.fork` is missing: the child logs one warning before `postfork()` and none after, reports over a pipe, and exits with `os._exit`.

Results: `make test` 1540 passed, 355 skipped (database tests). `make lint` clean. Sync contract tests 4749 ran, all passed.

## Benchmark

sdk-stress-tester `--mode benchmark --passes 5`, 1000 flags x 12 contexts, 60,000 evaluations per run. Same venv (Python 3.14.6) and same HTTP server for both sides; baseline is `origin/main` `client.py` checked out into the worktree.

| Run | p50 | p95 | p99 | evals/s (excl. pass 1) |
|---|---|---|---|---|
| before 1 | 140µs | 173µs | 271µs | 6,896 |
| before 2 | 139µs | 173µs | 269µs | 6,959 |
| before 3 | 140µs | 184µs | 277µs | 6,861 |
| after 1 | 141µs | 180µs | 282µs | 6,804 |
| after 2 | 142µs | 197µs | 299µs | 6,589 |
| after 3 | 144µs | 214µs | 316µs | 6,499 |
| after 4 | 140µs | 177µs | 273µs | 6,841 |
| after 5 | 140µs | 175µs | 275µs | 6,899 |
| after 6 | 142µs | 187µs | 290µs | 6,730 |

Median p50 is 140µs before and 141µs after. The p95/p99 spread tracks other load on the machine; after runs 4 and 5 match the baseline exactly. No regression above noise.

## Scope

This is warn-only. The SDK does not re-initialize itself in the child. Automatic re-initialization (for example via `os.register_at_fork(after_in_child=...)`) is a possible follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **fork-aware diagnostics** so apps that create `LDClient` before forking (e.g. gunicorn preload, Celery) get a clear signal instead of silently broken streaming and analytics.
> 
> The client records the creating process id and, on the first use in a different pid, logs a **once-per-process** warning that background threads are gone and **`LDClient.postfork()`** should be called. **`postfork()`** now resets that state and its docs mention the warning. The check runs on flag evaluation (via the shared hook path), **`all_flags_state`**, identify/track/flush/close, and migration helpers. Warnings are **skipped** when **`offline`** is set or **`use_ldd`** with **`send_events`** false.
> 
> Implementation uses a **pid-keyed dict** with **`setdefault`** (not a lock) so grandchild processes still warn and forked children cannot hang on an inherited lock. New **`test_ldclient_fork.py`** covers trigger points, concurrency, config skips, and a real **`os.fork()`** child test where supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d412d2e9416502988151492f8860fd1acadc7737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->