### PR TITLE
fix: Add async modules to the readthedocs API reference

### DIFF
--- a/docs/api-main.rst
+++ b/docs/api-main.rst
@@ -13,10 +13,23 @@ ldclient.client module
 .. automodule:: ldclient.client
     :members: LDClient
 
+ldclient.async_client module
+----------------------------
+
+.. automodule:: ldclient.async_client
+    :members: AsyncLDClient
+
 ldclient.config module
 ----------------------
 
 .. automodule:: ldclient.config
+    :members:
+    :special-members: __init__
+
+ldclient.async_config module
+----------------------------
+
+.. automodule:: ldclient.async_config
     :members:
     :special-members: __init__
 
@@ -31,6 +44,12 @@ ldclient.hook module
 --------------------------
 
 .. automodule:: ldclient.hook
+    :members:
+
+ldclient.plugin module
+----------------------
+
+.. automodule:: ldclient.plugin
     :members:
 
 ldclient.evaluation module


### PR DESCRIPTION
## Overview

The readthedocs API reference (`docs/api-main.rst`) documented no async modules. This adds `automodule` entries so the experimental async surface shows up in the generated docs.

New entries:
- **`ldclient.async_client`** — `AsyncLDClient`
- **`ldclient.async_config`** — `AsyncConfig`
- **`ldclient.plugin`** — `Plugin` and `AsyncPlugin` (this module had no entry at all; a pre-existing gap for the sync `Plugin` too)

`AsyncHook` (`ldclient.hook`) and `AsyncMigrator` (`ldclient.migrations`) were already swept in by the existing `:members:` blocks, so they need no new entry.

These modules import without `aiohttp`, so the docs build needs no `[async]` extra. `make docs` builds cleanly and all three modules render.

Part of the async SDK documentation follow-up (SDK-2879). The async surface shipped experimentally in 9.17.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Extends **`docs/api-main.rst`** so the generated API reference includes the experimental async surface and a previously missing plugin section.
> 
> Adds Sphinx **`automodule`** blocks for **`ldclient.async_client`** (`AsyncLDClient`), **`ldclient.async_config`**, and **`ldclient.plugin`** (sync and async plugin types). No runtime or SDK behavior changes—docs build only, aligned with SDK-2879.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c478e4a849cac082e2a6ca4d22bf1bcc25f11a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->