### PR TITLE
chore: Document the async-dynamodb extra in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Refer to the [SDK reference guide](https://docs.launchdarkly.com/sdk/server-side
 
 > [!NOTE]
 > Using Redis with the async client (big segments or a persistent data store) requires `redis>=4.2.0`, the version that introduced `redis.asyncio`. The `redis` extra itself still permits older versions for synchronous use, so install `redis>=4.2.0` when using Redis with the async client.
+>
+> Using DynamoDB with the async client requires the separate `async-dynamodb` extra (`aioboto3`), distinct from the synchronous `dynamodb` extra: `pip install launchdarkly-server-sdk[async,async-dynamodb]`.
 
 An async implementation, `AsyncLDClient`, is available for use with `asyncio`-based applications. It uses `aiohttp` for HTTP and requires installing the optional `async` extra:
 


### PR DESCRIPTION
## Overview

Async DynamoDB uses a separate `async-dynamodb` extra (`aioboto3`), distinct from the synchronous `dynamodb` extra. The README's async persistent-store note only covered async Redis; this adds the DynamoDB equivalent so users install the right extra:

```
pip install launchdarkly-server-sdk[async,async-dynamodb]
```

Part of the async SDK documentation follow-up (SDK-2879). The async surface shipped experimentally in 9.17.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Extends the **Async support** caution/note block so DynamoDB persistent stores are covered alongside the existing Redis guidance.
> 
> The new note states that async DynamoDB needs the **`async-dynamodb`** optional extra (`aioboto3`), not the synchronous **`dynamodb`** extra, and shows **`pip install launchdarkly-server-sdk[async,async-dynamodb]`** so users avoid installing the wrong dependency when using `AsyncLDClient` with DynamoDB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09e5158e4be58a08fef5148122504cb68248526e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->