### PR TITLE
fix: Report a distinct User-Agent for the async client

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -7,7 +7,7 @@
       "languages": [
         "Python"
       ],
-      "userAgents": ["PythonClient"],
+      "userAgents": ["PythonClient", "PythonAsyncClient"],
       "features": {
         "allFlags": { "introduced": "2.0" },
         "appMetadata": { "introduced": "7.6" },

--- a/ldclient/impl/aio/transport.py
+++ b/ldclient/impl/aio/transport.py
@@ -15,7 +15,7 @@ from ld_eventsource.config.error_strategy import ErrorStrategy
 from ld_eventsource.config.retry_delay_strategy import RetryDelayStrategy
 
 from ldclient.impl.aio.transport_types import TransportResponse
-from ldclient.impl.http import _base_headers, _get_proxy_url
+from ldclient.impl.http import ASYNC_USER_AGENT, _base_headers, _get_proxy_url
 from ldclient.impl.util import log
 
 # Allows up to 5 minutes to elapse without any data sent across the stream.
@@ -123,7 +123,7 @@ class AsyncSSEFactory:
         proxy settings, and the retry/backoff policy come from the SDK config.
         ``query_params`` is an optional zero-argument callable evaluated on
         each (re)connect to produce additional query string parameters."""
-        base_headers = _base_headers(self._config)
+        base_headers = _base_headers(self._config, ASYNC_USER_AGENT)
         aiohttp_request_options: dict = {
             "timeout": aiohttp.ClientTimeout(
                 total=None,

--- a/ldclient/impl/datasource/async_feature_requester.py
+++ b/ldclient/impl/datasource/async_feature_requester.py
@@ -9,6 +9,7 @@ from urllib import parse
 
 from ldclient.impl.aio.transport import AsyncHTTPTransport
 from ldclient.impl.datasource.datasource_common import FDV1_POLLING_ENDPOINT
+from ldclient.impl.http import ASYNC_USER_AGENT
 from ldclient.impl.util import _headers, log, throw_if_unsuccessful_response
 from ldclient.interfaces import AsyncFeatureRequester
 from ldclient.versioned_data_kind import FEATURES, SEGMENTS
@@ -30,7 +31,7 @@ class AsyncFeatureRequesterImpl(AsyncFeatureRequester):
 
     async def get_all_data(self):
         uri = self._poll_uri
-        hdrs = _headers(self._config)
+        hdrs = _headers(self._config, ASYNC_USER_AGENT)
         cache_entry = self._cache.get(uri)
         hdrs['Accept-Encoding'] = 'gzip'
         if cache_entry is not None:

--- a/ldclient/impl/datasourcev2/async_polling.py
+++ b/ldclient/impl/datasourcev2/async_polling.py
@@ -26,6 +26,7 @@ from ldclient.impl.datasourcev2.polling_common import (
     polling_payload_to_changeset,
     polling_result_to_basis
 )
+from ldclient.impl.http import ASYNC_USER_AGENT
 from ldclient.impl.util import (
     UnsuccessfulResponseException,
     _Fail,
@@ -192,7 +193,7 @@ class AiohttpPollingRequester(AsyncRequester):
             filter_query = parse.urlencode(query_params)
             uri += f"?{filter_query}"
 
-        hdrs = _headers(self._config)
+        hdrs = _headers(self._config, ASYNC_USER_AGENT)
         hdrs["Accept-Encoding"] = "gzip"
 
         if self._etag is not None:
@@ -387,7 +388,7 @@ class AiohttpFDv1PollingRequester(AsyncRequester):
             filter_query = parse.urlencode(query_params)
             uri += f"?{filter_query}"
 
-        hdrs = _headers(self._config)
+        hdrs = _headers(self._config, ASYNC_USER_AGENT)
         hdrs["Accept-Encoding"] = "gzip"
 
         if self._etag is not None:

--- a/ldclient/impl/events/async_event_processor.py
+++ b/ldclient/impl/events/async_event_processor.py
@@ -29,6 +29,7 @@ from ldclient.impl.events.event_processor_common import (
     EventOutputFormatter
 )
 from ldclient.impl.events.types import EventInput
+from ldclient.impl.http import ASYNC_USER_AGENT
 from ldclient.impl.lru_cache import SimpleLRUCache
 from ldclient.impl.sampler import Sampler
 from ldclient.impl.util import (
@@ -277,7 +278,7 @@ class DefaultAsyncEventProcessor(AsyncEventProcessor):
 
 
 async def _post_events_with_retry(http_client: AsyncHTTPTransport, config: AsyncConfig, uri: str, payload_id: Optional[str], body: str, events_description: str):
-    hdrs = _headers(config)
+    hdrs = _headers(config, ASYNC_USER_AGENT)
     hdrs['Content-Type'] = 'application/json'
     if config.enable_event_compression:
         hdrs['Content-Encoding'] = 'gzip'

--- a/ldclient/impl/http.py
+++ b/ldclient/impl/http.py
@@ -7,6 +7,12 @@ import urllib3
 
 from ldclient.version import VERSION
 
+#: User-Agent product token for the synchronous client.
+SYNC_USER_AGENT = "PythonClient"
+#: User-Agent product token for the asynchronous client. Sync and async ship in
+#: one package, so the token is how LaunchDarkly tells the two apart.
+ASYNC_USER_AGENT = "PythonAsyncClient"
+
 
 def _application_header_value(application: dict) -> str:
     parts = []
@@ -22,8 +28,8 @@ def _application_header_value(application: dict) -> str:
     return " ".join(parts)
 
 
-def _base_headers(config):
-    headers = {'Authorization': config.sdk_key or '', 'User-Agent': 'PythonClient/' + VERSION}
+def _base_headers(config, user_agent=SYNC_USER_AGENT):
+    headers = {'Authorization': config.sdk_key or '', 'User-Agent': user_agent + '/' + VERSION}
 
     if config._instance_id is not None:
         headers['X-LaunchDarkly-Instance-Id'] = config._instance_id

--- a/ldclient/impl/util.py
+++ b/ldclient/impl/util.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from typing import Any, Dict, Generic, Mapping, Optional, TypeVar, Union
 from urllib.parse import urlparse, urlunparse
 
-from ldclient.impl.http import _base_headers
+from ldclient.impl.http import SYNC_USER_AGENT, _base_headers
 
 
 def current_time_millis() -> int:
@@ -82,8 +82,8 @@ def validate_sdk_key_format(sdk_key: str, logger: logging.Logger) -> str:
     return sdk_key
 
 
-def _headers(config):
-    base_headers = _base_headers(config)
+def _headers(config, user_agent=SYNC_USER_AGENT):
+    base_headers = _base_headers(config, user_agent)
     base_headers.update({'Content-Type': "application/json"})
     return base_headers
 

--- a/ldclient/testing/impl/test_user_agent.py
+++ b/ldclient/testing/impl/test_user_agent.py
@@ -1,0 +1,35 @@
+"""Tests for the sync and async User-Agent tokens.
+
+Sync and async ship in one package, so the User-Agent token is how LaunchDarkly
+tells the two clients apart. These tests lock the exact tokens sent on the wire.
+"""
+
+from ldclient.config import Config
+from ldclient.impl.http import ASYNC_USER_AGENT, SYNC_USER_AGENT, _base_headers
+from ldclient.impl.util import _headers
+from ldclient.version import VERSION
+
+
+def _config():
+    return Config(sdk_key='sdk-key')
+
+
+def test_user_agent_tokens():
+    assert SYNC_USER_AGENT == 'PythonClient'
+    assert ASYNC_USER_AGENT == 'PythonAsyncClient'
+
+
+def test_base_headers_default_user_agent_is_sync():
+    assert _base_headers(_config())['User-Agent'] == 'PythonClient/' + VERSION
+
+
+def test_base_headers_async_user_agent():
+    assert _base_headers(_config(), ASYNC_USER_AGENT)['User-Agent'] == 'PythonAsyncClient/' + VERSION
+
+
+def test_headers_default_user_agent_is_sync():
+    assert _headers(_config())['User-Agent'] == 'PythonClient/' + VERSION
+
+
+def test_headers_async_user_agent():
+    assert _headers(_config(), ASYNC_USER_AGENT)['User-Agent'] == 'PythonAsyncClient/' + VERSION


### PR DESCRIPTION
## Overview

The async client (`AsyncLDClient`) shipped reusing the synchronous `PythonClient/<version>` User-Agent, so LaunchDarkly cannot distinguish async traffic from sync. Because sync and async ship in the **same package**, the User-Agent token is the signal that tells them apart.

This adds a distinct async token **`PythonAsyncClient`** and threads it through every async request path.

## Changes

- `impl/http.py`: add `SYNC_USER_AGENT` / `ASYNC_USER_AGENT` constants; `_base_headers(config, user_agent=SYNC_USER_AGENT)`.
- `impl/util.py`: `_headers(config, user_agent=SYNC_USER_AGENT)` passes the token through.
- Async request sites now pass `ASYNC_USER_AGENT`:
  - `impl/aio/transport.py` — `AsyncSSEFactory` streaming headers
  - `impl/datasource/async_feature_requester.py`
  - `impl/datasourcev2/async_polling.py`
  - `impl/events/async_event_processor.py`
- `.sdk_metadata.json`: register the token on the **existing** `python-server-sdk` entry → `userAgents: ["PythonClient", "PythonAsyncClient"]`.

**Sync behavior is unchanged** (the default token is still `PythonClient`).

## Design note

SDK-2658 originally proposed a separate `python-server-sdk-async` sdk-meta registry entry. We chose to keep a **single entry** and add the async token to its `userAgents` array instead, because async has no independent package and is not a separately-tracked feature.

The analytics/event SDK name `python-server-sdk-async` already ships (`async_client.py`); billing confirmed it does not key off the User-Agent, so this change is safe and additive.

## Tests

New `testing/impl/test_user_agent.py` locks the exact wire tokens for both sync and async via `_base_headers` / `_headers`. `mypy` / `isort` / `pycodestyle` clean; touched-component suites pass.

Implements SDK-2658.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Async `AsyncLDClient` traffic previously used the same **`PythonClient/<version>`** User-Agent as the sync client, so LaunchDarkly could not tell them apart in one package. This PR introduces **`PythonAsyncClient`** and wires it through shared header helpers while keeping sync defaults unchanged.
> 
> **`SYNC_USER_AGENT`** / **`ASYNC_USER_AGENT`** are defined in `impl/http.py`; **`_base_headers`** and **`_headers`** take an optional `user_agent` (default **`PythonClient`**). Async paths pass **`ASYNC_USER_AGENT`**: SSE in `impl/aio/transport.py`, FDv1 polling in `async_feature_requester.py`, FDv2 polling in `async_polling.py`, and event posts in `async_event_processor.py`.
> 
> **`.sdk_metadata.json`** adds **`PythonAsyncClient`** to the existing **`python-server-sdk`** `userAgents` list. **`testing/impl/test_user_agent.py`** asserts the exact wire User-Agent strings for sync and async.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32498ceec2001ab2ed4a75434170f46edae7e8fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->