### PR TITLE
chore: Fix async README example to use AsyncConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ pip install launchdarkly-server-sdk[async]
 
 ```python
 import asyncio
-from ldclient import Config, Context
+from ldclient import Context
 from ldclient.async_client import AsyncLDClient
+from ldclient.async_config import AsyncConfig
 
 async def main():
-    async with AsyncLDClient(Config("sdk-key")) as client:
+    async with AsyncLDClient(AsyncConfig("sdk-key")) as client:
         value = await client.variation("my-flag", Context.create("user-key"), False)
         print(value)
 


### PR DESCRIPTION
## Overview

The async example in the README passed the synchronous `Config` to `AsyncLDClient`, but the constructor requires an `AsyncConfig` (`AsyncLDClient.__init__(self, config: AsyncConfig)`). Passing `Config` is type-incorrect (mypy rejects it) and builds the async client with sync-typed components.

Fix the example to import and use `AsyncConfig`:

```diff
-from ldclient import Config, Context
+from ldclient import Context
 from ldclient.async_client import AsyncLDClient
+from ldclient.async_config import AsyncConfig
 ...
-    async with AsyncLDClient(Config("sdk-key")) as client:
+    async with AsyncLDClient(AsyncConfig("sdk-key")) as client:
```

Docs-only change.